### PR TITLE
Implement connection pooling and granular timeouts for SDK

### DIFF
--- a/sdk-python/agentcube/clients/control_plane.py
+++ b/sdk-python/agentcube/clients/control_plane.py
@@ -16,7 +16,7 @@ class ControlPlaneClient:
         workload_manager_url: Optional[str] = None,
         auth_token: Optional[str] = None,
         timeout: int = 120,
-        connect_timeout: float = 10.0,
+        connect_timeout: float = 5.0,
         pool_connections: int = 10,
         pool_maxsize: int = 10,
     ):
@@ -26,7 +26,7 @@ class ControlPlaneClient:
             workload_manager_url: URL of the WorkloadManager service.
             auth_token: Kubernetes Service Account Token for authentication.
             timeout: Default request timeout in seconds (default: 120).
-            connect_timeout: Connection timeout in seconds (default: 10).
+            connect_timeout: Connection timeout in seconds (default: 5).
             pool_connections: Number of connection pools to cache (default: 10).
             pool_maxsize: Maximum connections per pool (default: 10).
         """

--- a/sdk-python/agentcube/clients/data_plane.py
+++ b/sdk-python/agentcube/clients/data_plane.py
@@ -29,7 +29,7 @@ class DataPlaneClient:
         cr_name: Optional[str] = None,
         base_url: Optional[str] = None,
         timeout: int = 120,
-        connect_timeout: float = 10.0,
+        connect_timeout: float = 5.0,
         pool_connections: int = 10,
         pool_maxsize: int = 10,
     ):
@@ -43,7 +43,7 @@ class DataPlaneClient:
             cr_name: Code Interpreter resource name (optional if base_url is provided).
             base_url: Direct base URL for invocations (overrides router logic).
             timeout: Default request timeout in seconds (default: 120).
-            connect_timeout: Connection timeout in seconds (default: 10).
+            connect_timeout: Connection timeout in seconds (default: 5).
             pool_connections: Number of connection pools to cache (default: 10).
             pool_maxsize: Maximum connections per pool (default: 10).
         """

--- a/sdk-python/agentcube/utils/http.py
+++ b/sdk-python/agentcube/utils/http.py
@@ -2,40 +2,26 @@
 
 import requests
 from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 
 
 def create_session(
     pool_connections: int = 10,
     pool_maxsize: int = 10,
-    retry_total: int = 3,
-    retry_backoff_factor: float = 0.5,
-    retry_status_forcelist: tuple = (502, 503, 504),
 ) -> requests.Session:
-    """Create a requests Session with connection pooling and retry strategy.
+    """Create a requests Session with connection pooling.
     
     Args:
         pool_connections: Number of connection pools to cache (default: 10).
         pool_maxsize: Maximum connections per pool (default: 10).
-        retry_total: Maximum number of retries (default: 3).
-        retry_backoff_factor: Backoff factor for retries (default: 0.5).
-        retry_status_forcelist: HTTP status codes to retry on (default: 502, 503, 504).
     
     Returns:
-        A configured requests.Session object with connection pooling and retry strategy.
+        A configured requests.Session object with connection pooling.
     """
     session = requests.Session()
-    
-    retry_strategy = Retry(
-        total=retry_total,
-        backoff_factor=retry_backoff_factor,
-        status_forcelist=retry_status_forcelist,
-    )
     
     adapter = HTTPAdapter(
         pool_connections=pool_connections,
         pool_maxsize=pool_maxsize,
-        max_retries=retry_strategy,
     )
     
     session.mount("http://", adapter)


### PR DESCRIPTION
**Related to #106** 

Introduce significant improvements to the HTTP client implementations by adding connection pooling, configurable timeouts, and retry logic.

**HTTP Connection Management and Reliability Improvements:**

* Switched both `ControlPlaneClient` and `DataPlaneClient` to use persistent `requests.Session` objects with connection pooling and configurable pool sizes, improving performance and resource usage. ~~Added retry strategies for handling transient HTTP errors (502, 503, 504) with exponential backoff.~~
* Made timeouts for requests configurable, including separate connect and read timeouts, and exposed pool connection parameters for both clients.

**API Changes and Code Refactoring:**

* Updated all HTTP requests in both clients to use the new session objects and the new timeout settings, replacing direct calls to `requests` with session methods. 
* Added a `close()` method to `ControlPlaneClient` to allow explicit cleanup of session resources.