### PR TITLE
doc: Add proposal for PicoD Plain Authentication Design

### DIFF
--- a/docs/design/PicoD-Plain-Authentication-Design.md
+++ b/docs/design/PicoD-Plain-Authentication-Design.md
@@ -11,6 +11,7 @@ However, emerging use cases require a more flexible architecture where the clien
 *   Managing the security of connections between clients (agents) and the service.
 
 The existing self-signed key-pair model is incompatible with this centralized management flow, as it bypasses the Router's ability to mediate access. To address this, we propose a new **Plain Authentication** mechanism for `picod`. This design enables the Router/Gateway to manage credentials and connection security, simplifying the client-side workflow while maintaining robust access control.
+
 ## Use Cases
 
 ### Gateway-Managed Sandbox Access
@@ -25,13 +26,12 @@ To ensure **High Availability (HA)** across multiple Router replicas and enfor
 
 1. **Shared Authority (Router)**:
     
-    - All Router replicas share a single cryptographic identity to function as a unified Certificate Authority (CA).
-    - **Private Key Storage**: Stored in a Kubernetes Secret (picod-router-identity). This is restricted to the Router namespace/service account.
+    - All Router replicas share a single cryptographic identity to function as a unified Token Issuer.
+    - **Private Key Storage**: Stored in a Kubernetes Secret (picod-router-identity). The Private Key is accessible only by the Router component.
     - **Public Key Distribution**: Published to a Kubernetes ConfigMap (picod-router-public-key). This is accessible by the WorkloadManager and PicoD instances.
         
 2. **Decoupled Provisioning (WorkloadManager)**:
     
-    - The WorkloadManager is relieved of cryptographic payload management.
     - It provisions sandboxes by injecting the Public Key into the picod container as an Environment Variable (PICOD_AUTH_PUBLIC_KEY).
         
 3. **Local Verification (PicoD)**:


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
/kind feature

**What this PR does / why we need it:**
Currently, AgentCube’s `picod` daemon enforces authentication using a client self-signed key-pair mechanism, which binds a specific client directly to a `picod` instance. While secure, this 1:1 model is incompatible with centralized gateway architectures where an upstream Router is responsible for authentication and session management.

This PR introduces a design proposal for **PicoD Plain Authentication**.

**Key highlights of the proposal:**
1.  **Shared Identity Model**: Introduces a Router-managed identity where Router replicas share a Private Key (Secret) to sign tokens, and `picod` instances share a Public Key (ConfigMap) to verify them.
2.  **Decoupled Provisioning**: The WorkloadManager injects the Public Key into `picod` via Environment Variables (`PICOD_AUTH_PUBLIC_KEY`), removing the need for complex volume mounts or key payloads in the API.
3.  **Simplified Auth Flow**: Supports standard JWT-based authentication, allowing the Python SDK to connect seamlessly to sandbox instances allocated by the Router.
4.  **High Availability**: Includes a leader-elected bootstrap mechanism for Routers to automatically generate and synchronize keys across replicas.

This design enables "Gateway-Managed Sandbox Access" scenarios, simplifying client workflows while maintaining robust security boundaries.