### PR TITLE
Support session_id reuse for SDK

### DIFF
--- a/sdk-python/examples/basic_usage.py
+++ b/sdk-python/examples/basic_usage.py
@@ -12,72 +12,83 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+AgentCube SDK Basic Usage Example
+
+Demonstrates:
+1. Basic command execution and code running
+2. File operations
+3. Session reuse for state persistence (useful for AI workflows)
+"""
+
 from agentcube import CodeInterpreterClient
 
-def main():
-    """
-    This example demonstrates the basic usage of the AgentCube Python SDK.
-    It requires a running AgentCube environment.
-    
-    Ensure the following environment variables are set before running:
-    - WORKLOAD_MANAGER_URL: URL of the WorkloadManager service
-    - ROUTER_URL: URL of the Router service
-    - API_TOKEN: (Optional) Authentication token if required
-    """
-    
-    # specific configuration can be passed directly or via environment variables
-    # workload_manager_url = os.getenv("WORKLOAD_MANAGER_URL", "http://localhost:8080")
-    # router_url = os.getenv("ROUTER_URL", "http://localhost:8080")
 
-    print("Initializing AgentCube Client...")
+def basic_operations():
+    """Demonstrate basic SDK operations."""
+    print("=== Basic Operations ===\n")
+    
+    client = CodeInterpreterClient(verbose=True)
+    print(f"Session created: {client.session_id}")
     
     try:
-        # Using context manager ensures the session is cleaned up (deleted) after use
-        with CodeInterpreterClient(verbose=True) as client:
-            print(f"Session created successfully! Session ID: {client.session_id}")
+        # 1. Shell commands
+        print("\n--- Shell Command: whoami ---")
+        output = client.execute_command("whoami")
+        print(f"Result: {output.strip()}")
 
-            # 1. Execute a simple Shell Command
-            print("\n--- 1. Shell Command: whoami ---")
-            output = client.execute_command("whoami")
-            print(f"Result: {output.strip()}")
+        # 2. Python code execution
+        print("\n--- Python Code ---")
+        code = """
+import math
+print(f"Pi is approximately {math.pi:.6f}")
+"""
+        output = client.run_code("python", code)
+        print(f"Result: {output.strip()}")
 
-            print("\n--- 2. Shell Command: Check OS release ---")
-            output = client.execute_command("cat /etc/os-release")
-            print(f"Result:\n{output.strip()}")
+        # 3. File operations
+        print("\n--- File Operations ---")
+        client.write_file("Hello from AgentCube!", "hello.txt")
+        files = client.list_files(".")
+        print(f"Files: {[f['name'] for f in files]}")
+        
+    finally:
+        client.delete()
+        print("\nSession deleted.")
 
-            # 2. Execute Python Code
-            print("\n--- 3. Python Code: Calculate Pi ---")
-            code = """
-                import math
-                print(f"Pi is approximately {math.pi:.6f}")
-            """
-            output = client.run_code("python", code)
-            print(f"Result: {output.strip()}")
 
-            # 3. File Operations
-            print("\n--- 4. File Operations ---")
-            
-            # Write a file to the remote sandbox
-            remote_filename = "hello_agentcube.txt"
-            content = "Hello from AgentCube SDK Example!"
-            print(f"Writing to '{remote_filename}'...")
-            client.write_file(content, remote_filename)
-            
-            # Verify file creation by listing files
-            print("Listing files in current directory...")
-            files = client.list_files(".")
-            for f in files:
-                print(f" - {f['name']} ({f['size']} bytes)")
-                
-            # Read the file back (using cat for simplicity)
-            print(f"Reading '{remote_filename}' content...")
-            output = client.execute_command(f"cat {remote_filename}")
-            print(f"File content: {output.strip()}")
+def session_reuse_example():
+    """
+    Demonstrate session reuse for AI workflows.
+    
+    This pattern is essential for low-code/no-code platforms (like Dify)
+    where the interpreter is invoked multiple times as a tool within a
+    single workflow, and state needs to persist across invocations.
+    """
+    print("\n=== Session Reuse (State Persistence) ===\n")
+    
+    # Step 1: Create session and set variable
+    print("Step 1: Create session, set x = 42")
+    client1 = CodeInterpreterClient(verbose=True)
+    session_id = client1.session_id
+    client1.run_code("python", "x = 42")
+    client1.close()  # Close connection, session persists
+    print(f"Connection closed. Session ID saved: {session_id}")
+    
+    # Step 2: Reuse session - variable x should still exist
+    print("\nStep 2: Reuse session, access x")
+    client2 = CodeInterpreterClient(session_id=session_id, verbose=True)
+    result = client2.run_code("python", "print(f'x = {x}')")
+    print(f"Result: {result.strip()}")  # Should print "x = 42"
+    client2.close()
+    
+    # Step 3: Cleanup
+    print("\nStep 3: Delete session")
+    client3 = CodeInterpreterClient(session_id=session_id, verbose=True)
+    client3.delete()
+    print("Session deleted.")
 
-    except Exception as e:
-        print(f"\nAn error occurred: {e}")
-        # Note: If an exception occurs within the 'with' block, 
-        # the __exit__ method is still called, ensuring cleanup.
 
 if __name__ == "__main__":
-    main()
+    basic_operations()
+    session_reuse_example()


### PR DESCRIPTION
**Closes #113**

This pull request makes significant improvements to the Python SDK for AgentCube by simplifying the user experience, clarifying documentation, and enhancing session management and lifecycle control. The changes focus on making the SDK easier to use, supporting session reuse for persistent workflows, and cleaning up the code for better maintainability.

**Key improvements include:**

- A complete overhaul of the `README.md` for clarity and quick onboarding.
- Major refactoring of the `CodeInterpreterClient` to support immediate session creation, session reuse, and explicit connection/session lifecycle management.
- Simplified and more robust SDK usage patterns, including context manager support and advanced session reuse.
- Improved example code to demonstrate new patterns and best practices.

---

### Documentation and Usage Experience

* Completely rewrote `sdk-python/README.md` to provide a clearer, step-by-step guide, including quick start, file operations, advanced session reuse, and updated API reference. Removed outdated architecture and feature sections in favor of actionable examples.

### SDK API and Lifecycle Management

* Refactored `CodeInterpreterClient` in `code_interpreter.py` to create or reuse sessions immediately on initialization, support explicit `close()` and `delete()` methods, and clarify session lifecycle in both code and docstrings. Removed lazy initialization and now require all arguments up front. [[1]](diffhunk://#diff-87c222f1a19c4e72e29ceeeff4d5aae9a779dbdb522772b312230ba62821a5eeR23-R49) [[2]](diffhunk://#diff-87c222f1a19c4e72e29ceeeff4d5aae9a779dbdb522772b312230ba62821a5eeL42-R77) [[3]](diffhunk://#diff-87c222f1a19c4e72e29ceeeff4d5aae9a779dbdb522772b312230ba62821a5eeL65-L124)

* Added `session_id` parameter to allow for session reuse across client instances, supporting persistent interpreter state for advanced workflows. [[1]](diffhunk://#diff-87c222f1a19c4e72e29ceeeff4d5aae9a779dbdb522772b312230ba62821a5eeL42-R77) [[2]](diffhunk://#diff-87c222f1a19c4e72e29ceeeff4d5aae9a779dbdb522772b312230ba62821a5eeL65-L124)

* Removed all lazy session start logic and error checks for uninitialized data plane clients, since the session and clients are now always initialized in `__init__`. [[1]](diffhunk://#diff-87c222f1a19c4e72e29ceeeff4d5aae9a779dbdb522772b312230ba62821a5eeL65-L124) [[2]](diffhunk://#diff-87c222f1a19c4e72e29ceeeff4d5aae9a779dbdb522772b312230ba62821a5eeL139-L141) [[3]](diffhunk://#diff-87c222f1a19c4e72e29ceeeff4d5aae9a779dbdb522772b312230ba62821a5eeL160-L162) [[4]](diffhunk://#diff-87c222f1a19c4e72e29ceeeff4d5aae9a779dbdb522772b312230ba62821a5eeL173-L178) [[5]](diffhunk://#diff-87c222f1a19c4e72e29ceeeff4d5aae9a779dbdb522772b312230ba62821a5eeL189-L194) [[6]](diffhunk://#diff-87c222f1a19c4e72e29ceeeff4d5aae9a779dbdb522772b312230ba62821a5eeL205-R223) [[7]](diffhunk://#diff-87c222f1a19c4e72e29ceeeff4d5aae9a779dbdb522772b312230ba62821a5eeL223-L229)

### Example Code

* Updated `examples/basic_usage.py` to demonstrate the new SDK patterns, including basic operations, file operations, and session reuse for state persistence. The example is now more concise and highlights best practices for both basic and advanced users.