### PR TITLE
Add E2E test doc and improve image loading compatibility

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,118 @@
+# AgentCube E2E Tests
+
+End-to-end tests for AgentCube backend services, validating the complete request flow from SDK to execution runtime.
+
+## Test Scope
+
+### Components Tested
+
+| Component | Description |
+|-----------|-------------|
+| **Python SDK** (`sdk-python`) | `CodeInterpreterClient` - session management, code execution, file operations |
+| **WorkloadManager** | Control plane - session creation/deletion, pod scheduling |
+| **Router** | Data plane - request signing (JWT) and forwarding |
+| **PicoD** | Code execution runtime with authentication verification |
+| **agent-sandbox** | Kubernetes sandbox lifecycle management |
+
+### Components NOT Tested
+
+| Component | Description |
+|-----------|-------------|
+| **CLI** (`cmd/cli`) | `kubectl agentcube` commands (pack, build, publish, invoke, status) |
+
+## Request Flow
+
+1. **Session Creation**: SDK → WorkloadManager → agent-sandbox (creates Pod with PicoD)
+2. **Code Execution**: SDK → Router (signs request) → PicoD (verifies signature, executes code)
+3. **Session Deletion**: SDK → WorkloadManager → agent-sandbox (deletes Pod)
+
+## What the Script Does
+
+The `run_e2e.sh` script performs the following steps:
+
+1. Creates a Kind cluster
+2. Installs CRDs and agent-sandbox
+3. **Builds Docker images** (`make docker-build`, `make docker-build-router`, `make docker-build-picod`)
+4. Loads images into Kind cluster
+5. Deploys Redis, WorkloadManager, and Router
+6. Creates test resources (AgentRuntime, CodeInterpreter)
+7. Runs Go tests and Python SDK tests
+8. Cleans up resources
+
+## Prerequisites
+
+- **Docker** - Container runtime
+- **Kind** - Kubernetes in Docker
+- **kubectl** - Kubernetes CLI
+- **Python 3.8+** - For SDK tests
+- **Go 1.24+** - For Go tests
+
+## Running Tests
+
+```bash
+# Run all E2E tests (creates Kind cluster, deploys services, runs tests)
+./test/e2e/run_e2e.sh
+
+# Skip cluster recreation (faster for re-runs)
+E2E_CLEAN_CLUSTER=false ./test/e2e/run_e2e.sh
+```
+
+## Test Cases
+
+### Go Tests (`e2e_test.go`)
+
+| Test | Description |
+|------|-------------|
+| `TestAgentRuntimeBasicInvocation` | Basic echo agent invocation (basic, empty, complex input) |
+| `TestAgentRuntimeErrorHandling` | Error handling for non-existent runtimes |
+| `TestAgentRuntimeSessionTTL` | Session timeout and cleanup verification |
+
+### Python SDK Tests (`test_codeinterpreter.py`)
+
+| Test | Description |
+|------|-------------|
+| `test_case1_simple_code_execution_auto_session` | Simple code execution with auto-created session |
+| `test_case2_code_execution_in_session` | Stateless execution verification (variables not preserved) |
+| `test_case3_file_based_workflow_fibonacci_json` | File upload, execution, and download workflow |
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `E2E_CLUSTER_NAME` | `agentcube-e2e` | Kind cluster name |
+| `E2E_CLEAN_CLUSTER` | `true` | Delete and recreate cluster before tests |
+| `AGENTCUBE_NAMESPACE` | `agentcube` | Kubernetes namespace for deployments |
+| `E2E_VENV_DIR` | `/tmp/agentcube-e2e-venv` | Python virtual environment path |
+| `WORKLOAD_MANAGER_LOCAL_PORT` | `8080` | Local port for WorkloadManager |
+| `ROUTER_LOCAL_PORT` | `8081` | Local port for Router |
+
+## Test Resources
+
+| File | Description |
+|------|-------------|
+| `echo_agent.yaml` | AgentRuntime CR for echo agent tests |
+| `e2e_code_interpreter.yaml` | CodeInterpreter CR for SDK tests |
+
+## Adding New Tests
+
+### Go Tests (`e2e_test.go`)
+
+Add test functions to `e2e_test.go` following the existing patterns.
+
+### Python SDK Tests (`test_codeinterpreter.py`)
+
+Add test methods to `TestCodeInterpreterE2E` class in `test_codeinterpreter.py`.
+
+## Cleanup
+
+The test script automatically cleans up:
+
+- Port-forward processes
+- Python virtual environment
+- Temporary files
+
+To manually delete the Kind cluster:
+
+```bash
+kind delete cluster --name agentcube-e2e
+```

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -141,7 +141,12 @@ docker_pull_if_missing() {
 
 kind_load_image() {
     local image="$1"
-    kind load docker-image "${image}" --name "${E2E_CLUSTER_NAME}"
+    # Note: Docker Desktop 29.x with containerd image store can fail to load multi-platform
+    # images. We allow failures here and let Kind nodes pull from registry instead.
+    if ! kind load docker-image "${image}" --name "${E2E_CLUSTER_NAME}"; then
+        echo "Warning: Failed to load image ${image} into Kind. Will attempt to pull from registry." >&2
+        return 0
+    fi
 }
 
 curl_download() {


### PR DESCRIPTION
## What this PR does
<img width="599" height="133" alt="image" src="https://github.com/user-attachments/assets/09c13739-e61a-43a4-aa30-1c4c66840f69" />

1. **Improve image loading compatibility** ([test/e2e/run_e2e.sh](cci:7://file:///Users/soto/Documents/Codes/agentcube/test/e2e/run_e2e.sh:0:0-0:0))
   - Handle `kind load docker-image` failures gracefully for third-party images
   - Allows Kind nodes to pull images from public registries as fallback
   - Fixes compatibility with Docker Desktop 29.x containerd image store
2. **Add E2E test documentation** ([test/e2e/README.md](cci:7://file:///Users/soto/Documents/Codes/agentcube/test/e2e/README.md:0:0-0:0))
   - Documents test scope (what's tested vs not tested)
   - Explains the request flow (SDK → WorkloadManager/Router → PicoD)
   - Lists prerequisites, environment variables, and test cases
   - Provides guidance for adding new tests

## Why it's needed
- Docker Desktop 29.x introduced containerd as default image store, which causes
  `kind load docker-image` to fail for multi-platform images (e.g., `redis:7-alpine`)
- New contributors need documentation to understand E2E test scope and usage

