### PR TITLE
Fix pcap analyzer example

### DIFF
--- a/example/code-interpreter/code-interpreter.yaml
+++ b/example/code-interpreter/code-interpreter.yaml
@@ -4,9 +4,22 @@ metadata:
   name: simple-codeinterpreter
   namespace: default
 spec:
+  ports:
+    - pathPrefix: "/"
+      port: 8080
+      protocol: "HTTP"
   template:
-    image: busybox
-    command: ["/bin/sh", "-c", "sleep 36000"]
+    image: picod:latest
+    imagePullPolicy: IfNotPresent
+    args:
+      - --workspace=/workspace
+    resources:
+      limits:
+        cpu: "500m"
+        memory: "512Mi"
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
   sessionTimeout: "15m"
   maxSessionDuration: "8h"
   warmPoolSize: 2

--- a/example/pcap-analyzer/README.md
+++ b/example/pcap-analyzer/README.md
@@ -191,9 +191,11 @@ for attempt in range(max_retries + 1):
 | `OPENAI_API_KEY` | LLM API key | *Required* |
 | `OPENAI_MODEL` | Model name | `Qwen/QwQ-32B` |
 | `OPENAI_API_BASE` | Model API endpoint | `https://api.siliconflow.cn/v1` |
-| `SANDBOX_NAMESPACE` | Sandbox namespace | `default` |
-| `SANDBOX_CPU` / `SANDBOX_MEMORY` | Resource allocation | `200m` / `256Mi` |
-| `SANDBOX_WARMUP_SEC` | Sandbox warm-up time (seconds) | `20` |
+| `WORKLOAD_MANAGER_URL` | AgentCube Control Plane URL | *Required in cluster* |
+| `ROUTER_URL` | AgentCube Data Plane (Router) URL | *Required* |
+| `CODEINTERPRETER_NAME` | Name of CodeInterpreter CRD | `simple-codeinterpreter` |
+| `SANDBOX_NAMESPACE` | Kubernetes namespace for sandbox | `default` |
+| `SANDBOX_WARMUP_SEC` | Sandbox warm-up time (seconds) | `5` |
 | `PLANNER_MAX_RETRIES` | Maximum auto-repair attempts | `2` |
 | `DEBUG_SAVE_DIR` | Debug artifact output directory | `./debug_artifacts` |
 
@@ -238,7 +240,14 @@ kubectl apply -f deployment.yaml
 #### request
 Obtain the pod IP by running the command "kubectl get pod -owide | grep pcap-analyzer". "./samples/pocket.pcap" need change to your file path.
 ```bash
-curl -X POST "http://{pod_ip}:8000/analyze"   -H "Content-Type: application/x-www-form-urlencoded"   -d "pcap_file=@./samples/pocket.pcap"
+curl -X POST "http://{pod_ip}:8000/analyze" \
+  -F "pcap_file=@./samples/pocket.pcap"
+```
+
+Alternatively, you can use `pcap_path` form field for local file path:
+```bash
+curl -X POST "http://{pod_ip}:8000/analyze" \
+  -F "pcap_path=/path/to/your/file.pcap"
 ```
 
 Response:

--- a/example/pcap-analyzer/deployment.yaml
+++ b/example/pcap-analyzer/deployment.yaml
@@ -44,7 +44,15 @@ spec:
               value: "https://api.siliconflow.cn/v1" # Change to your openAI api url
             - name: OPENAI_MODEL
               value: "Qwen/QwQ-32B"
-            - name: API_URL
+            - name: WORKLOAD_MANAGER_URL
               value: "http://workloadmanager.agentcube.svc.cluster.local:8080"
+            - name: ROUTER_URL
+              value: "http://router.agentcube.svc.cluster.local:8080"
+            - name: CODEINTERPRETER_NAME
+              value: "simple-codeinterpreter"  # Name of CodeInterpreter CRD
+            - name: SANDBOX_NAMESPACE
+              value: "default"
+            - name: SANDBOX_WARMUP_SEC
+              value: "5"
           command: ["uv"]
           args: ["run", "pcap_analyzer.py"]


### PR DESCRIPTION
Fix #144

This pull request refactors the pcap analyzer example to modernize and simplify sandbox integration, update configuration, and improve usability. The main changes are a migration from low-level sandbox resource management to using a named CodeInterpreter CRD, updated environment variables, and improved documentation and API usage.

**Sandbox/CodeInterpreter Integration:**

- Refactored `SandboxRunner` and related functions to use a named CodeInterpreter CRD (via `CODEINTERPRETER_NAME` and `SANDBOX_NAMESPACE`), removing direct CPU/memory/public/private key management in favor of higher-level configuration. (`example/pcap-analyzer/pcap_analyzer.py`) [[1]](diffhunk://#diff-e8d798ae1101284ec7cdbdd1b5fc66bdc852400e6c09cd9d441b0a7461ea16c4L83-R86) [[2]](diffhunk://#diff-e8d798ae1101284ec7cdbdd1b5fc66bdc852400e6c09cd9d441b0a7461ea16c4L186-R198) [[3]](diffhunk://#diff-e8d798ae1101284ec7cdbdd1b5fc66bdc852400e6c09cd9d441b0a7461ea16c4L375-R388) [[4]](diffhunk://#diff-e8d798ae1101284ec7cdbdd1b5fc66bdc852400e6c09cd9d441b0a7461ea16c4L394-R409) [[5]](diffhunk://#diff-e8d798ae1101284ec7cdbdd1b5fc66bdc852400e6c09cd9d441b0a7461ea16c4L481-R503) [[6]](diffhunk://#diff-e8d798ae1101284ec7cdbdd1b5fc66bdc852400e6c09cd9d441b0a7461ea16c4L593-R611)
- Updated command execution logic to use the new `CodeInterpreterClient` interface and handle `CommandExecutionError` for better error reporting. (`example/pcap-analyzer/pcap_analyzer.py`)

**Configuration and Deployment:**

- Updated deployment manifest to use new environment variables (`WORKLOAD_MANAGER_URL`, `ROUTER_URL`, `CODEINTERPRETER_NAME`, etc.) and removed resource-specific variables. (`example/pcap-analyzer/deployment.yaml`)
- Updated the example CodeInterpreter CRD manifest to specify ports, image, resource limits, and arguments for the code interpreter. (`example/code-interpreter/code-interpreter.yaml`)

**Documentation Improvements:**

- Revised the README to document the new environment variables, clarify required settings, and update sandbox configuration instructions. (`example/pcap-analyzer/README.md`)
- Improved the API usage example to support both file upload and local path via form fields, and updated the sample curl commands accordingly. (`example/pcap-analyzer/README.md`)