### PR TITLE
Optimize environment variable slice allocation in ExecuteHandler

### DIFF
--- a/pkg/picod/execute.go
+++ b/pkg/picod/execute.go
@@ -107,7 +107,9 @@ func (s *Server) ExecuteHandler(c *gin.Context) {
 
 	// Set environment variables
 	if len(req.Env) > 0 {
-		currentEnv := os.Environ()
+		environ := os.Environ()
+		currentEnv := make([]string, len(environ), len(environ)+len(req.Env))
+		copy(currentEnv, environ)
 		for k, v := range req.Env {
 			currentEnv = append(currentEnv, fmt.Sprintf("%s=%s", k, v))
 		}


### PR DESCRIPTION
Pre-allocate the slice capacity when merging environment variables in `ExecuteHandler`.

Previously, `append` was used on the result of `os.Environ()`, which could trigger multiple allocations as the slice grew. Since we know the final size (`len(os.Environ()) + len(req.Env)`), pre-allocating the capacity avoids these unnecessary allocations and copy operations.