### PR TITLE
Optimize slice allocation in ListFilesHandler

### DIFF
--- a/pkg/picod/files.go
+++ b/pkg/picod/files.go
@@ -348,7 +348,7 @@ func (s *Server) ListFilesHandler(c *gin.Context) {
 		return
 	}
 
-	var files []FileEntry
+	files := make([]FileEntry, 0, len(entries))
 	for _, entry := range entries {
 		info, err := entry.Info()
 		if err != nil {


### PR DESCRIPTION
Pre-allocate the `files` slice capacity based on the number of directory entries in `ListFilesHandler`.

Previously, `append` was used on a nil slice, causing repeated allocations as the slice grew. Pre-allocating the known size (`len(entries)`) prevents this overhead.