### PR TITLE
fix(router): add auth header for workload manager

### DIFF
--- a/docs/devguide/code-interpreter-python-sdk.md
+++ b/docs/devguide/code-interpreter-python-sdk.md
@@ -29,7 +29,7 @@ The `CodeInterpreterClient` is the main entry point. You can initialize it direc
 | `ttl` | `int` | `3600` | Session time-to-live (seconds) |
 | `workload_manager_url` | `str` | `None` | Control Plane URL (falls back to env `WORKLOAD_MANAGER_URL`) |
 | `router_url` | `str` | `None` | Data Plane Router URL (falls back to env `ROUTER_URL`) |
-| `auth_token` | `str` | `None` | Auth token (falls back to env `API_TOKEN`, then K8s SA token) |
+| `auth_token` | `str` | `None` | Auth token (falls back to K8s SA token) |
 | `session_id` | `str` | `None` | Reuse existing session instead of creating new |
 | `verbose` | `bool` | `False` | Enable debug logging |
 
@@ -39,7 +39,6 @@ The `CodeInterpreterClient` is the main entry point. You can initialize it direc
 |----------|-------------|
 | `WORKLOAD_MANAGER_URL` | Control Plane URL (required if not passed as argument) |
 | `ROUTER_URL` | Data Plane Router URL (required if not passed as argument) |
-| `API_TOKEN` | Auth token for Control Plane (optional, falls back to K8s SA token) |
 
 ### Example: Basic Initialization
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -177,7 +177,6 @@ export WORKLOAD_MANAGER_URL="http://localhost:8080"
 export ROUTER_URL="http://localhost:8081"
 
 # Optional: If your instance requires authentication
-# export API_TOKEN="your-token"
 ```
 
 ```python

--- a/pkg/router/session_manager.go
+++ b/pkg/router/session_manager.go
@@ -195,10 +195,6 @@ func (m *manager) createSandbox(ctx context.Context, namespace string, name stri
 }
 
 func loadWorkloadManagerAuthToken() string {
-	if token := strings.TrimSpace(os.Getenv("API_TOKEN")); token != "" {
-		return token
-	}
-
 	b, err := os.ReadFile(serviceAccountTokenPath)
 	if err != nil {
 		if !os.IsNotExist(err) {

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -92,7 +92,6 @@ CodeInterpreterClient(
 
 * `WORKLOAD_MANAGER_URL`: Control Plane URL
 * `ROUTER_URL`: Data Plane URL  
-* `API_TOKEN`: Authentication token
 
 ## Advanced: Session Reuse
 

--- a/sdk-python/agentcube/clients/control_plane.py
+++ b/sdk-python/agentcube/clients/control_plane.py
@@ -52,9 +52,9 @@ class ControlPlaneClient:
                 "or 'WORKLOAD_MANAGER_URL' environment variable."
             )
 
-        # Prioritize argument -> env var -> k8s service account token file
+        # Prioritize argument -> k8s service account token file
         token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-        token = auth_token or os.getenv("API_TOKEN") or read_token_from_file(token_path)
+        token = auth_token or read_token_from_file(token_path)
         self.timeout = timeout
         self.connect_timeout = connect_timeout
 
@@ -149,4 +149,3 @@ class ControlPlaneClient:
     def close(self):
         """Close the underlying session and release connection pool resources."""
         self.session.close()
-

--- a/sdk-python/examples/README.md
+++ b/sdk-python/examples/README.md
@@ -21,7 +21,6 @@ This directory contains examples of how to use the AgentCube Python SDK.
     export ROUTER_URL="http://<your-router-host>:<port>"
     
     # Optional: If your instance requires authentication
-    # export API_TOKEN="your-token"
     ```
 
 ## Running the Examples


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Adds Authorization header for Router->Workload Manager sandbox creation using service account token, so WM auth works when enabled.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Router now reads  /var/run/secrets/kubernetes.io/serviceaccount/token for WM calls.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```