### PR TITLE
fix(auth): use strings.Fields for better Authorization header parsing

### DIFF
--- a/pkg/workloadmanager/auth.go
+++ b/pkg/workloadmanager/auth.go
@@ -91,7 +91,7 @@ func (s *Server) authMiddleware(c *gin.Context) {
 	}
 
 	// Check if it's a Bearer token
-	parts := strings.SplitN(authHeader, " ", 2)
+	parts := strings.Fields(authHeader)
 	if len(parts) != 2 || parts[0] != "Bearer" {
 		respondError(c, http.StatusUnauthorized, "Invalid authorization header format")
 		c.Abort()


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

/kind enhancement

**What this PR does / why we need it**:

Currently, the code uses `strings.SplitN(authHeader, " ", 2)` to separate the Bearer prefix from the token. This is fragile because it strictly expects exactly 1 space separator. If a client sends a header with multiple spaces (example: using curl or in testing), the parsed token will incorrectly capture the leading whitespace causing failure.


**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
