### PR TITLE
feat(cli): enhance java workspace validation logic

### DIFF
--- a/cmd/cli/agentcube/services/metadata_service.py
+++ b/cmd/cli/agentcube/services/metadata_service.py
@@ -263,7 +263,7 @@ class MetadataService:
             )
 
         # Check for atleast one source file
-        has_java_files = any(f.suffix == '.java' for f in src_dir.rglob('*'))
+        has_java_files = any(src_dir.rglob('*.java'))
 
         if not has_java_files:
             raise ValueError(


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

/kind enhancement

**What this PR does / why we need it**:
This PR addresses the TODO in `_validate_java_workspace` by implementing stricter validation for Java projects. Now we verify existence of `pom.xml`, existence of standard Maven directory `src/main/java`, and that atleast 1 source file (`.java`) exists.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
NONE
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
CLI: Added strict validation for Java agents. The CLI now requires the standard `src/main/java` directory structure and at least one `.java` source file to be present.
```
