### PR TITLE
Removing POST \init from the docs

### DIFF
--- a/docs/design/agentcube-proposal.md
+++ b/docs/design/agentcube-proposal.md
@@ -404,13 +404,6 @@ The CodeInterpreter is a component responsible for executing code snippets or co
 
 ### 5.1 API design
 
-Initialization
-
-- POST /init - Initialize sandbox with session public key (one-time only)
-  - Request: JWT signed by bootstrap private key containing session public key
-  - Response: JSON confirmation message
-  - Access: Workload Manager only
-
 Command Execution
 
 - POST /api/execute - Execute command and return output


### PR DESCRIPTION
**What type of PR is this?**                                                  
                                                                
  kind documentation                                                           
                                                                                
  **What this PR does / why we need it**:

  Removes the `POST /init` endpoint from the design docs (agentcube-proposal and
   picod-proposal) because it was never implemented. The actual code uses the
  `PICOD_AUTH_PUBLIC_KEY` environment variable to inject the public key at
  startup instead of a runtime `/init` endpoint. Updates the auth descriptions,
  security considerations, and core authentication components in the
  picod-proposal to reflect the actual implementation. Sequence diagrams are
  kept as-is since they represent the intended design flow.

  **Which issue(s) this PR fixes**:
  Fixes #199
 