### PR TITLE
doc: update sample url for router & workload_manager

### DIFF
--- a/docs/design/AgentRun-CLI-Design.md
+++ b/docs/design/AgentRun-CLI-Design.md
@@ -291,8 +291,8 @@ readiness_probe_path: /health
 readiness_probe_port: 8080
 
 # AgentCube specific configuration
-router_url: http://router.agentcube.svc
-workload_manager_url: http://workload-manager.agentcube.svc
+router_url: http://agentcube-router.agentcube.svc:8080
+workload_manager_url: http://workloadmanager.agentcube.svc:8080
 
 image:
   repository_url: registry.example.com/weather-agent


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

it seems that the example outdated, the latest svc name as following:
<img width="1380" height="192" alt="image" src="https://github.com/user-attachments/assets/302e606c-cbec-40aa-b778-42cb459e83a7" />

btw the original document missing port for `router_url` and `workload_manager_url`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
