### PR TITLE
Add Python SDK publish workflow

### DIFF
--- a/.github/workflows/python-sdk-publish.yml
+++ b/.github/workflows/python-sdk-publish.yml
@@ -1,0 +1,63 @@
+name: Python SDK Publish
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "sdk-python/**"
+      - ".github/workflows/python-sdk-publish.yml"
+  workflow_dispatch:
+
+jobs:
+  publish-python-sdk:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependency
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: make build-python-sdk
+
+      - name: Read package version
+        id: package
+        working-directory: sdk-python
+        run: |
+          version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether version already exists on PyPI
+        id: pypi
+        env:
+          PACKAGE_NAME: agentcube-sdk
+          PACKAGE_VERSION: ${{ steps.package.outputs.version }}
+        run: |
+          status="$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/${PACKAGE_NAME}/${PACKAGE_VERSION}/json")"
+          if [ "$status" = "200" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Version ${PACKAGE_VERSION} already exists on PyPI, skipping publish."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Version ${PACKAGE_VERSION} is not published yet."
+          fi
+
+      - name: Publish package to PyPI
+        if: steps.pypi.outputs.exists != 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: sdk-python/dist/

--- a/Makefile
+++ b/Makefile
@@ -319,6 +319,8 @@ e2e-clean:
 .PHONY: build-python-sdk
 build-python-sdk: ## Build Python SDK
 	@echo "Building Python SDK..."
-	cp LICENSE sdk-python/LICENSE
-	cd sdk-python && python3 -m build; cd ..; rm -f sdk-python/LICENSE
+	@tmp_file="$(PROJECT_DIR)/sdk-python/LICENSE"; \
+	trap 'rm -f "$$tmp_file"' EXIT; \
+	cp LICENSE "$$tmp_file"; \
+	cd sdk-python && python3 -m build
 	@echo "Build complete. Artifacts are in sdk-python/dist/"

--- a/sdk-python/MANIFEST.in
+++ b/sdk-python/MANIFEST.in
@@ -2,3 +2,4 @@ include LICENSE
 include README.md
 include requirements.txt
 recursive-include examples *
+global-exclude __pycache__ *.py[cod]

--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -7,7 +7,7 @@ name = "agentcube-sdk"
 version = "0.1.0"
 description = "Python SDK for AgentCube Code Interpreter"
 readme = "README.md"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 requires-python = ">=3.10"
 
 dependencies = [


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

This PR adds an automated publishing workflow for the Python SDK.

The new workflow builds the package from `sdk-python`, reads the package version from `sdk-python/pyproject.toml`, checks whether that version already exists on PyPI, and only publishes when the version is not already present.

It also tightens the SDK packaging flow by:
- excluding Python cache artifacts from the source distribution
- updating the Python package license metadata to the modern string form
- reusing the existing `make build-python-sdk` path so the root `LICENSE` remains the single source of truth while still being included in built artifacts

Trusted publishing for PyPI has already been configured for this repository, so this workflow does not require a stored PyPI API token. It uses PyPI's trusted publisher flow via GitHub Actions OIDC and `pypa/gh-action-pypi-publish`.

<img width="688" height="184" alt="Screenshot 2026-03-28 at 21 38 52" src="https://github.com/user-attachments/assets/1d4c20e5-62fc-4b9c-bf8e-56cd7568f0e4" />


References:
- https://docs.pypi.org/trusted-publishers/adding-a-publisher/
- https://docs.pypi.org/trusted-publishers/using-a-publisher/
- https://github.com/pypa/gh-action-pypi-publish

**Which issue(s) this PR fixes**:
Fixes #246

**Special notes for your reviewer**:

The publish job is intentionally limited to `push` on `main` and manual dispatch. Existing Python test workflows remain responsible for test coverage; this workflow focuses on build-and-publish behavior.

**Does this PR introduce a user-facing change?**:
```release-note
Added automated PyPI publishing for the Python SDK when `sdk-python` changes are merged to `main`.
```
