### PR TITLE
Add Python CLI publish workflow

### DIFF
--- a/.github/workflows/python-cli-publish.yml
+++ b/.github/workflows/python-cli-publish.yml
@@ -1,0 +1,63 @@
+name: Python CLI Publish
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "cmd/cli/**"
+      - ".github/workflows/python-cli-publish.yml"
+  workflow_dispatch:
+
+jobs:
+  publish-python-cli:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependency
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: make build-python-cli
+
+      - name: Read package version
+        id: package
+        working-directory: cmd/cli
+        run: |
+          version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether version already exists on PyPI
+        id: pypi
+        env:
+          PACKAGE_NAME: agentcube-cli
+          PACKAGE_VERSION: ${{ steps.package.outputs.version }}
+        run: |
+          status="$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/${PACKAGE_NAME}/${PACKAGE_VERSION}/json")"
+          if [ "$status" = "200" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Version ${PACKAGE_VERSION} already exists on PyPI, skipping publish."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Version ${PACKAGE_VERSION} is not published yet."
+          fi
+
+      - name: Publish package to PyPI
+        if: steps.pypi.outputs.exists != 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: cmd/cli/dist/

--- a/Makefile
+++ b/Makefile
@@ -324,3 +324,12 @@ build-python-sdk: ## Build Python SDK
 	cp LICENSE "$$tmp_file"; \
 	cd sdk-python && python3 -m build
 	@echo "Build complete. Artifacts are in sdk-python/dist/"
+
+.PHONY: build-python-cli
+build-python-cli: ## Build Python CLI
+	@echo "Building Python CLI..."
+	@tmp_file="$(PROJECT_DIR)/cmd/cli/LICENSE"; \
+	trap 'rm -f "$$tmp_file"' EXIT; \
+	cp LICENSE "$$tmp_file"; \
+	cd cmd/cli && python3 -m build
+	@echo "Build complete. Artifacts are in cmd/cli/dist/"

--- a/cmd/cli/MANIFEST.in
+++ b/cmd/cli/MANIFEST.in
@@ -1,0 +1,4 @@
+include LICENSE
+include README.md
+recursive-include examples *
+global-exclude __pycache__ *.py[cod]

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -6,7 +6,7 @@ AgentCube CLI is a developer tool that streamlines the development, packaging, b
 
 ### Prerequisites
 
-- Python 3.8+
+- Python 3.10+
 - Git
 - Docker (optional, for container builds)
 
@@ -69,7 +69,7 @@ pip install -e .
 ### From PyPI (Recommended)
 
 ```bash
-pip install agentcube
+pip install agentcube-cli
 ```
 
 ### From Source

--- a/cmd/cli/pyproject.toml
+++ b/cmd/cli/pyproject.toml
@@ -7,12 +7,11 @@ name = "agentcube-cli"
 version = "0.1.0"
 description = "AgentCube CLI - A developer tool for packaging, building, and deploying AI agents to AgentCube"
 readme = "README.md"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 keywords = ["ai", "agent", "kubernetes", "volcano", "agentcube", "cli"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

This PR adds automated PyPI publishing for the Python CLI package under `cmd/cli`.

The new workflow builds the `agentcube-cli` package, reads the version from `cmd/cli/pyproject.toml`, checks whether that version already exists on PyPI, and only publishes when the version is not already present.

It also tightens the CLI packaging flow by:
- reusing a dedicated `make build-python-cli` entrypoint for both local and CI builds
- keeping the repository root `LICENSE` as the single source of truth while still including it in built artifacts
- adding a `MANIFEST.in` for the CLI package and excluding Python cache artifacts from the source distribution
- updating the CLI package metadata to the modern SPDX string form
- fixing the README so the documented PyPI install command matches the actual package name and Python version requirement

This workflow uses PyPI Trusted Publishing via GitHub Actions OIDC and `pypa/gh-action-pypi-publish`, so it does not require a stored PyPI API token. It assumes the trusted publisher has been configured for the `agentcube-cli` project as well.

<img width="702" height="178" alt="image" src="https://github.com/user-attachments/assets/6e4cf838-aa5d-4807-91d4-bf30e5f3f034" />


References:
- https://docs.pypi.org/trusted-publishers/adding-a-publisher/
- https://docs.pypi.org/trusted-publishers/using-a-publisher/
- https://github.com/pypa/gh-action-pypi-publish

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

This PR is intentionally scoped to the CLI package only. The existing Python SDK publish workflow is not modified here.

**Does this PR introduce a user-facing change?**:
```release-note
Added automated PyPI publishing for the `agentcube-cli` package when `cmd/cli` changes are merged to `main`.
```
