### PR TITLE
Fix sandbox readiness race before proxying

### DIFF
--- a/pkg/router/config.go
+++ b/pkg/router/config.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package router
 
+import "time"
+
 // LastActivityAnnotationKey is the annotation key for tracking last activity
 const LastActivityAnnotationKey = "agentcube.volcano.sh/last-activity"
 
@@ -38,4 +40,11 @@ type Config struct {
 
 	// MaxConcurrentRequests limits the number of concurrent requests (0 = unlimited)
 	MaxConcurrentRequests int
+
+	// InitialConnectRetryCount is the number of preflight retries before proxying
+	// a request to a sandbox that is not yet accepting connections.
+	InitialConnectRetryCount int
+
+	// InitialConnectRetryInterval is the delay between preflight retries.
+	InitialConnectRetryInterval time.Duration
 }

--- a/pkg/router/handlers.go
+++ b/pkg/router/handlers.go
@@ -207,7 +207,7 @@ func upstreamUnavailableResponse(err error) (int, gin.H) {
 	case strings.Contains(errText, "deadline exceeded") || strings.Contains(errText, "timeout"):
 		return http.StatusGatewayTimeout, gin.H{"error": "sandbox timeout"}
 	default:
-		return http.StatusBadGateway, gin.H{"error": "sandbox unreachable"}
+		return http.StatusServiceUnavailable, gin.H{"error": "sandbox unreachable"}
 	}
 }
 

--- a/pkg/router/handlers.go
+++ b/pkg/router/handlers.go
@@ -227,6 +227,19 @@ func (s *Server) forwardToSandbox(c *gin.Context, sandbox *types.SandboxInfo, pa
 		return
 	}
 
+	if err := s.waitForUpstreamReachable(c.Request.Context(), targetURL); err != nil {
+		klog.Errorf("Sandbox preflight failed (session: %s): %v", sandbox.SessionID, err)
+		switch {
+		case connectionRefusedRetryable(err):
+			c.JSON(http.StatusBadGateway, gin.H{"error": "sandbox unreachable"})
+		case strings.Contains(strings.ToLower(err.Error()), "deadline exceeded") || strings.Contains(strings.ToLower(err.Error()), "timeout"):
+			c.JSON(http.StatusGatewayTimeout, gin.H{"error": "sandbox timeout"})
+		default:
+			c.JSON(http.StatusBadGateway, gin.H{"error": "sandbox unreachable"})
+		}
+		return
+	}
+
 	// Create reverse proxy with reusable transport
 	proxy := httputil.NewSingleHostReverseProxy(targetURL)
 
@@ -317,19 +330,6 @@ func (s *Server) forwardToSandbox(c *gin.Context, sandbox *types.SandboxInfo, pa
 		// Always set session ID in response header
 		resp.Header.Set("x-agentcube-session-id", sandbox.SessionID)
 		return nil
-	}
-
-	if err := s.waitForUpstreamReachable(c.Request.Context(), targetURL); err != nil {
-		klog.Errorf("Sandbox preflight failed (session: %s): %v", sandbox.SessionID, err)
-		switch {
-		case connectionRefusedRetryable(err):
-			c.JSON(http.StatusBadGateway, gin.H{"error": "sandbox unreachable"})
-		case strings.Contains(strings.ToLower(err.Error()), "deadline exceeded") || strings.Contains(strings.ToLower(err.Error()), "timeout"):
-			c.JSON(http.StatusGatewayTimeout, gin.H{"error": "sandbox timeout"})
-		default:
-			c.JSON(http.StatusBadGateway, gin.H{"error": "sandbox unreachable"})
-		}
-		return
 	}
 
 	// No timeout for invoke requests to allow long-running operations

--- a/pkg/router/handlers.go
+++ b/pkg/router/handlers.go
@@ -199,6 +199,112 @@ func (s *Server) waitForUpstreamReachable(ctx context.Context, targetURL *url.UR
 	return nil
 }
 
+func upstreamUnavailableResponse(err error) (int, gin.H) {
+	errText := strings.ToLower(err.Error())
+	switch {
+	case connectionRefusedRetryable(err):
+		return http.StatusBadGateway, gin.H{"error": "sandbox unreachable"}
+	case strings.Contains(errText, "deadline exceeded") || strings.Contains(errText, "timeout"):
+		return http.StatusGatewayTimeout, gin.H{"error": "sandbox timeout"}
+	default:
+		return http.StatusBadGateway, gin.H{"error": "sandbox unreachable"}
+	}
+}
+
+func (s *Server) resolveSandboxTarget(c *gin.Context, sandbox *types.SandboxInfo, path string) (*url.URL, bool) {
+	targetURL, err := determineUpstreamURL(sandbox, path)
+	if err != nil {
+		klog.Errorf("Failed to get sandbox access address %s: %v", sandbox.SandboxID, err)
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		return nil, false
+	}
+
+	if err := s.waitForUpstreamReachable(c.Request.Context(), targetURL); err != nil {
+		klog.Errorf("Sandbox preflight failed (session: %s): %v", sandbox.SessionID, err)
+		statusCode, response := upstreamUnavailableResponse(err)
+		c.JSON(statusCode, response)
+		return nil, false
+	}
+
+	return targetURL, true
+}
+
+func (s *Server) generateSandboxJWT(c *gin.Context, sandbox *types.SandboxInfo) (string, bool) {
+	if sandbox.Kind != types.SandboxClaimsKind && sandbox.Kind != types.SandboxKind {
+		return "", true
+	}
+	if s.jwtManager == nil {
+		return "", true
+	}
+
+	claims := map[string]interface{}{
+		"session_id": sandbox.SessionID,
+	}
+	token, err := s.jwtManager.GenerateToken(claims)
+	if err != nil {
+		klog.Errorf("Failed to generate JWT token (session: %s): %v", sandbox.SessionID, err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "failed to sign request",
+			"code":  "JWT_SIGNING_FAILED",
+		})
+		return "", false
+	}
+
+	return token, true
+}
+
+func normalizedProxyPath(path string) string {
+	if path != "" && !strings.HasPrefix(path, "/") {
+		return "/" + path
+	}
+	return path
+}
+
+func forwardedClientIP(req *http.Request, clientIP string) string {
+	if prior, ok := req.Header["X-Forwarded-For"]; ok {
+		return strings.Join(prior, ", ") + ", " + clientIP
+	}
+	return clientIP
+}
+
+func configureProxyDirector(proxy *httputil.ReverseProxy, c *gin.Context, targetURL *url.URL, path, jwtToken, sessionID string) {
+	proxyPath := normalizedProxyPath(path)
+	originalDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		originalDirector(req)
+
+		req.URL.Path = proxyPath
+		req.URL.RawPath = ""
+		req.Host = targetURL.Host
+		req.Header.Set("X-Forwarded-Host", c.Request.Host)
+		req.Header.Set("X-Forwarded-Proto", "http")
+		if c.Request.TLS != nil {
+			req.Header.Set("X-Forwarded-Proto", "https")
+		}
+		req.Header.Set("X-Forwarded-For", forwardedClientIP(req, c.ClientIP()))
+		if jwtToken != "" {
+			req.Header.Set("Authorization", "Bearer "+jwtToken)
+		}
+
+		klog.Infof("Forwarding request to: %s%s (session: %s)", targetURL.String(), proxyPath, sessionID)
+	}
+}
+
+func configureProxyErrorHandler(proxy *httputil.ReverseProxy, c *gin.Context, sessionID string) {
+	proxy.ErrorHandler = func(_ http.ResponseWriter, _ *http.Request, err error) {
+		klog.Errorf("Proxy error (session: %s): %v", sessionID, err)
+		statusCode, response := upstreamUnavailableResponse(err)
+		c.JSON(statusCode, response)
+	}
+}
+
+func configureProxyResponse(proxy *httputil.ReverseProxy, sessionID string) {
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		resp.Header.Set("x-agentcube-session-id", sessionID)
+		return nil
+	}
+}
+
 // handleAgentInvoke handles agent invocation requests
 func (s *Server) handleAgentInvoke(c *gin.Context) {
 	namespace := c.Param("namespace")
@@ -217,26 +323,8 @@ func (s *Server) handleCodeInterpreterInvoke(c *gin.Context) {
 
 // forwardToSandbox forwards the request to the specified sandbox endpoint
 func (s *Server) forwardToSandbox(c *gin.Context, sandbox *types.SandboxInfo, path string) {
-	// Extract url from sandbox - find matching entry point by path
-	targetURL, err := determineUpstreamURL(sandbox, path)
-	if err != nil {
-		klog.Errorf("Failed to get sandbox access address %s: %v", sandbox.SandboxID, err)
-		c.JSON(http.StatusNotFound, gin.H{
-			"error": err.Error(),
-		})
-		return
-	}
-
-	if err := s.waitForUpstreamReachable(c.Request.Context(), targetURL); err != nil {
-		klog.Errorf("Sandbox preflight failed (session: %s): %v", sandbox.SessionID, err)
-		switch {
-		case connectionRefusedRetryable(err):
-			c.JSON(http.StatusBadGateway, gin.H{"error": "sandbox unreachable"})
-		case strings.Contains(strings.ToLower(err.Error()), "deadline exceeded") || strings.Contains(strings.ToLower(err.Error()), "timeout"):
-			c.JSON(http.StatusGatewayTimeout, gin.H{"error": "sandbox timeout"})
-		default:
-			c.JSON(http.StatusBadGateway, gin.H{"error": "sandbox unreachable"})
-		}
+	targetURL, ok := s.resolveSandboxTarget(c, sandbox, path)
+	if !ok {
 		return
 	}
 
@@ -246,96 +334,14 @@ func (s *Server) forwardToSandbox(c *gin.Context, sandbox *types.SandboxInfo, pa
 	// Use the shared HTTP transport for connection pooling
 	proxy.Transport = s.httpTransport
 
-	var jwtToken string
-	if sandbox.Kind == types.SandboxClaimsKind || sandbox.Kind == types.SandboxKind {
-		// Generate JWT token before setting up Director
-		// Include session ID in claims for debugging and request tracking
-		if s.jwtManager != nil {
-			claims := map[string]interface{}{
-				"session_id": sandbox.SessionID,
-			}
-			token, err := s.jwtManager.GenerateToken(claims)
-			if err != nil {
-				klog.Errorf("Failed to generate JWT token (session: %s): %v", sandbox.SessionID, err)
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"error": "failed to sign request",
-					"code":  "JWT_SIGNING_FAILED",
-				})
-				return
-			}
-			jwtToken = token
-		}
+	jwtToken, ok := s.generateSandboxJWT(c, sandbox)
+	if !ok {
+		return
 	}
 
-	// Customize the director to modify the request
-	originalDirector := proxy.Director
-	proxy.Director = func(req *http.Request) {
-		originalDirector(req)
-
-		// Set the target path
-		if path != "" && !strings.HasPrefix(path, "/") {
-			path = "/" + path
-		}
-		req.URL.Path = path
-		req.URL.RawPath = ""
-
-		// Set the host header
-		req.Host = targetURL.Host
-
-		// Add forwarding headers
-		req.Header.Set("X-Forwarded-Host", c.Request.Host)
-		req.Header.Set("X-Forwarded-Proto", "http")
-		if c.Request.TLS != nil {
-			req.Header.Set("X-Forwarded-Proto", "https")
-		}
-
-		// Set X-Forwarded-For to preserve original client IP
-		clientIP := c.ClientIP()
-		if prior, ok := req.Header["X-Forwarded-For"]; ok {
-			clientIP = strings.Join(prior, ", ") + ", " + clientIP
-		}
-		req.Header.Set("X-Forwarded-For", clientIP)
-
-		// Add JWT authorization header using pre-generated token
-		if jwtToken != "" {
-			req.Header.Set("Authorization", "Bearer "+jwtToken)
-		}
-
-		klog.Infof("Forwarding request to: %s%s (session: %s)", targetURL.String(), path, sandbox.SessionID)
-	}
-
-	// Customize error handler
-	proxy.ErrorHandler = func(_ http.ResponseWriter, _ *http.Request, err error) {
-		klog.Errorf("Proxy error (session: %s): %v", sandbox.SessionID, err)
-
-		// Determine error type and return appropriate response
-		switch {
-		case strings.Contains(err.Error(), "connection refused"):
-			c.JSON(http.StatusBadGateway, gin.H{
-				"error": "sandbox unreachable",
-			})
-		case strings.Contains(err.Error(), "timeout"):
-			c.JSON(http.StatusGatewayTimeout, gin.H{
-				"error": "sandbox timeout",
-			})
-		default:
-			c.JSON(http.StatusBadGateway, gin.H{
-				"error": "sandbox unreachable",
-			})
-		}
-	}
-
-	// Modify response
-	proxy.ModifyResponse = func(resp *http.Response) error {
-		// Always set session ID in response header
-		resp.Header.Set("x-agentcube-session-id", sandbox.SessionID)
-		return nil
-	}
-
-	// No timeout for invoke requests to allow long-running operations
-	// ctx, cancel := context.WithTimeout(c.Request.Context(), time.Duration(s.config.RequestTimeout)*time.Second)
-	// defer cancel()
-	// c.Request = c.Request.WithContext(ctx)
+	configureProxyDirector(proxy, c, targetURL, path, jwtToken, sandbox.SessionID)
+	configureProxyErrorHandler(proxy, c, sandbox.SessionID)
+	configureProxyResponse(proxy, sandbox.SessionID)
 
 	// Use the proxy to serve the request
 	proxy.ServeHTTP(c.Writer, c.Request)

--- a/pkg/router/handlers.go
+++ b/pkg/router/handlers.go
@@ -17,7 +17,9 @@ limitations under the License.
 package router
 
 import (
+	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -107,7 +109,7 @@ func determineUpstreamURL(sandbox *types.SandboxInfo, path string) (*url.URL, er
 	// prefer matched entrypoint by path
 	for _, ep := range sandbox.EntryPoints {
 		if strings.HasPrefix(path, ep.Path) {
-			return buildURL(ep.Protocol, ep.Endpoint), nil
+			return buildURL(ep.Protocol, ep.Endpoint)
 		}
 	}
 	// fallback to first entrypoint
@@ -115,15 +117,86 @@ func determineUpstreamURL(sandbox *types.SandboxInfo, path string) (*url.URL, er
 		return nil, fmt.Errorf("no entry point found for sandbox")
 	}
 	ep := sandbox.EntryPoints[0]
-	return buildURL(ep.Protocol, ep.Endpoint), nil
+	return buildURL(ep.Protocol, ep.Endpoint)
 }
 
-func buildURL(protocol, endpoint string) *url.URL {
+func buildURL(protocol, endpoint string) (*url.URL, error) {
 	if protocol != "" && !strings.Contains(endpoint, "://") {
 		endpoint = (strings.ToLower(protocol) + "://" + endpoint)
 	}
-	url, _ := url.Parse(endpoint)
-	return url
+	parsedURL, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("invalid upstream endpoint %q: %w", endpoint, err)
+	}
+	if parsedURL.Host == "" {
+		return nil, fmt.Errorf("invalid upstream endpoint %q: missing host", endpoint)
+	}
+	return parsedURL, nil
+}
+
+func connectionRefusedRetryable(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "connection refused")
+}
+
+func preflightTargetAddress(targetURL *url.URL) string {
+	if targetURL == nil {
+		return ""
+	}
+	if targetURL.Host == "" {
+		return ""
+	}
+	if _, _, err := net.SplitHostPort(targetURL.Host); err == nil {
+		return targetURL.Host
+	}
+	switch strings.ToLower(targetURL.Scheme) {
+	case "https":
+		return net.JoinHostPort(targetURL.Host, "443")
+	default:
+		return net.JoinHostPort(targetURL.Host, "80")
+	}
+}
+
+func (s *Server) waitForUpstreamReachable(ctx context.Context, targetURL *url.URL) error {
+	address := preflightTargetAddress(targetURL)
+	if address == "" {
+		return nil
+	}
+
+	retryCount := 0
+	retryInterval := 200 * time.Millisecond
+	if s != nil && s.config != nil {
+		retryCount = s.config.InitialConnectRetryCount
+		if s.config.InitialConnectRetryInterval > 0 {
+			retryInterval = s.config.InitialConnectRetryInterval
+		}
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= retryCount; attempt++ {
+		dialer := &net.Dialer{Timeout: retryInterval}
+		conn, err := dialer.DialContext(ctx, "tcp", address)
+		if err == nil {
+			if closeErr := conn.Close(); closeErr != nil {
+				klog.V(4).Infof("closing preflight connection to %s failed: %v", address, closeErr)
+			}
+			return nil
+		}
+		lastErr = err
+		if !connectionRefusedRetryable(err) || attempt == retryCount {
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(retryInterval):
+		}
+	}
+
+	if lastErr != nil {
+		return fmt.Errorf("sandbox preflight connect failed: %w", lastErr)
+	}
+	return nil
 }
 
 // handleAgentInvoke handles agent invocation requests
@@ -244,6 +317,19 @@ func (s *Server) forwardToSandbox(c *gin.Context, sandbox *types.SandboxInfo, pa
 		// Always set session ID in response header
 		resp.Header.Set("x-agentcube-session-id", sandbox.SessionID)
 		return nil
+	}
+
+	if err := s.waitForUpstreamReachable(c.Request.Context(), targetURL); err != nil {
+		klog.Errorf("Sandbox preflight failed (session: %s): %v", sandbox.SessionID, err)
+		switch {
+		case connectionRefusedRetryable(err):
+			c.JSON(http.StatusBadGateway, gin.H{"error": "sandbox unreachable"})
+		case strings.Contains(strings.ToLower(err.Error()), "deadline exceeded") || strings.Contains(strings.ToLower(err.Error()), "timeout"):
+			c.JSON(http.StatusGatewayTimeout, gin.H{"error": "sandbox timeout"})
+		default:
+			c.JSON(http.StatusBadGateway, gin.H{"error": "sandbox unreachable"})
+		}
+		return
 	}
 
 	// No timeout for invoke requests to allow long-running operations

--- a/pkg/router/handlers_test.go
+++ b/pkg/router/handlers_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -424,9 +425,59 @@ func TestForwardToSandbox_InvalidEndpoint(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusInternalServerError {
-		t.Errorf("Expected status code %d, got %d", http.StatusInternalServerError, resp.StatusCode)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("Expected status code %d, got %d", http.StatusNotFound, resp.StatusCode)
 	}
+}
+
+func TestWaitForUpstreamReachable_RetriesUntilReady(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to allocate listener: %v", err)
+	}
+	address := listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatalf("failed to close listener: %v", err)
+	}
+
+	startServer := make(chan struct{})
+	serveDone := make(chan struct{})
+	go func() {
+		defer close(serveDone)
+		<-startServer
+		ln, listenErr := net.Listen("tcp", address)
+		if listenErr != nil {
+			return
+		}
+		defer ln.Close()
+
+		conn, acceptErr := ln.Accept()
+		if acceptErr == nil {
+			_ = conn.Close()
+		}
+	}()
+
+	server := &Server{config: &Config{InitialConnectRetryCount: 5, InitialConnectRetryInterval: 100 * time.Millisecond}}
+
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		close(startServer)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	targetURL, err := buildURL("HTTP", address)
+	if err != nil {
+		t.Fatalf("failed to build upstream URL: %v", err)
+	}
+
+	err = server.waitForUpstreamReachable(ctx, targetURL)
+	if err != nil {
+		t.Fatalf("expected upstream to become reachable, got error: %v", err)
+	}
+
+	<-serveDone
 }
 
 func TestConcurrencyLimitMiddleware_Overload(t *testing.T) {

--- a/pkg/router/server.go
+++ b/pkg/router/server.go
@@ -51,6 +51,12 @@ func NewServer(config *Config) (*Server, error) {
 	if config.MaxConcurrentRequests <= 0 {
 		config.MaxConcurrentRequests = 1000 // Default limit
 	}
+	if config.InitialConnectRetryCount < 0 {
+		config.InitialConnectRetryCount = 0
+	}
+	if config.InitialConnectRetryInterval <= 0 {
+		config.InitialConnectRetryInterval = 200 * time.Millisecond
+	}
 
 	// Create session manager with store client
 	sessionManager, err := NewSessionManager(store.Storage())
@@ -153,7 +159,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 	// Create HTTP/2 server for better performance
 	h2s := &http2.Server{}
-	
+
 	// Wrap handler with h2c for HTTP/2 cleartext support
 	h2cHandler := h2c.NewHandler(s.engine, h2s)
 

--- a/pkg/workloadmanager/handlers.go
+++ b/pkg/workloadmanager/handlers.go
@@ -201,7 +201,7 @@ func (s *Server) createSandbox(ctx context.Context, dynamicClient dynamic.Interf
 	select {
 	case result := <-resultChan:
 		createdSandbox = result.Sandbox
-		klog.V(2).Infof("sandbox %s/%s running", createdSandbox.Namespace, createdSandbox.Name)
+		klog.V(2).Infof("sandbox %s/%s reported ready, verifying entrypoints", createdSandbox.Namespace, createdSandbox.Name)
 	case <-time.After(2 * time.Minute): // consistent with router settings
 		klog.Warningf("sandbox %s/%s create timed out", sandbox.Namespace, sandbox.Name)
 		return nil, fmt.Errorf("sandbox creation timed out")
@@ -219,6 +219,9 @@ func (s *Server) createSandbox(ctx context.Context, dynamicClient dynamic.Interf
 	podIP, err := s.k8sClient.GetSandboxPodIP(ctx, sandbox.Namespace, sandbox.Name, sandboxPodName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get sandbox %s/%s pod IP: %v", sandbox.Namespace, sandbox.Name, err)
+	}
+	if err := s.waitForSandboxEntryPointsReady(ctx, podIP, sandboxEntry); err != nil {
+		return nil, fmt.Errorf("failed to verify sandbox %s/%s entrypoints: %w", sandbox.Namespace, sandbox.Name, err)
 	}
 
 	storeCacheInfo := buildSandboxInfo(createdSandbox, podIP, sandboxEntry)

--- a/pkg/workloadmanager/handlers.go
+++ b/pkg/workloadmanager/handlers.go
@@ -164,33 +164,11 @@ func (s *Server) createSandbox(ctx context.Context, dynamicClient dynamic.Interf
 	// This ensures the K8s resource and store placeholder are cleaned up on
 	// timeout, pod-IP failure, or store-update failure — not just on post-creation errors.
 	needRollbackSandbox := true
-	sandboxRollbackFunc := func() {
-		ctxTimeout, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		var err error
-		if sandboxClaim != nil {
-			// Rollback SandboxClaim
-			err = deleteSandboxClaim(ctxTimeout, dynamicClient, sandboxClaim.Namespace, sandboxClaim.Name)
-			if err != nil {
-				klog.Infof("sandbox claim %s/%s rollback failed: %v", sandboxClaim.Namespace, sandboxClaim.Name, err)
-			}
-		} else {
-			// Rollback Sandbox
-			err = deleteSandbox(ctxTimeout, dynamicClient, sandbox.Namespace, sandbox.Name)
-			if err != nil {
-				klog.Infof("sandbox %s/%s rollback failed: %v", sandbox.Namespace, sandbox.Name, err)
-			}
-		}
-		// Clean up the store placeholder so it does not pollute GC queries
-		if delErr := s.storeClient.DeleteSandboxBySessionID(ctxTimeout, sandboxEntry.SessionID); delErr != nil {
-			klog.Infof("sandbox %s/%s store placeholder cleanup failed: %v", sandbox.Namespace, sandbox.Name, delErr)
-		}
-	}
 	defer func() {
 		if !needRollbackSandbox {
 			return
 		}
-		sandboxRollbackFunc()
+		s.sandboxRollback(sandboxClaim, dynamicClient, sandbox, sandboxEntry)
 	}()
 
 	var createdSandbox *sandboxv1alpha1.Sandbox
@@ -237,6 +215,29 @@ func (s *Server) createSandbox(ctx context.Context, dynamicClient dynamic.Interf
 	klog.V(2).Infof("init sandbox %s/%s successfully, kind: %s, sessionID: %s", createdSandbox.Namespace,
 		createdSandbox.Name, createdSandbox.Kind, sandboxEntry.SessionID)
 	return response, nil
+}
+
+func (s *Server) sandboxRollback(sandboxClaim *extensionsv1alpha1.SandboxClaim, dynamicClient dynamic.Interface, sandbox *sandboxv1alpha1.Sandbox, sandboxEntry *sandboxEntry) {
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	var err error
+	if sandboxClaim != nil {
+		// Rollback SandboxClaim
+		err = deleteSandboxClaim(ctxTimeout, dynamicClient, sandboxClaim.Namespace, sandboxClaim.Name)
+		if err != nil {
+			klog.Infof("sandbox claim %s/%s rollback failed: %v", sandboxClaim.Namespace, sandboxClaim.Name, err)
+		}
+	} else {
+		// Rollback Sandbox
+		err = deleteSandbox(ctxTimeout, dynamicClient, sandbox.Namespace, sandbox.Name)
+		if err != nil {
+			klog.Infof("sandbox %s/%s rollback failed: %v", sandbox.Namespace, sandbox.Name, err)
+		}
+	}
+	// Clean up the store placeholder so it does not pollute GC queries
+	if delErr := s.storeClient.DeleteSandboxBySessionID(ctxTimeout, sandboxEntry.SessionID); delErr != nil {
+		klog.Infof("sandbox %s/%s store placeholder cleanup failed: %v", sandbox.Namespace, sandbox.Name, delErr)
+	}
 }
 
 // handleDeleteSandbox handles sandbox deletion requests

--- a/pkg/workloadmanager/handlers.go
+++ b/pkg/workloadmanager/handlers.go
@@ -173,16 +173,12 @@ func (s *Server) createSandbox(ctx context.Context, dynamicClient dynamic.Interf
 			err = deleteSandboxClaim(ctxTimeout, dynamicClient, sandboxClaim.Namespace, sandboxClaim.Name)
 			if err != nil {
 				klog.Infof("sandbox claim %s/%s rollback failed: %v", sandboxClaim.Namespace, sandboxClaim.Name, err)
-			} else {
-				klog.Infof("sandbox claim %s/%s rollback succeeded", sandboxClaim.Namespace, sandboxClaim.Name)
 			}
 		} else {
 			// Rollback Sandbox
 			err = deleteSandbox(ctxTimeout, dynamicClient, sandbox.Namespace, sandbox.Name)
 			if err != nil {
 				klog.Infof("sandbox %s/%s rollback failed: %v", sandbox.Namespace, sandbox.Name, err)
-			} else {
-				klog.Infof("sandbox %s/%s rollback succeeded", sandbox.Namespace, sandbox.Name)
 			}
 		}
 		// Clean up the store placeholder so it does not pollute GC queries

--- a/pkg/workloadmanager/handlers_test.go
+++ b/pkg/workloadmanager/handlers_test.go
@@ -108,6 +108,7 @@ func TestServerCreateSandbox(t *testing.T) {
 		createSandboxErr  error
 		createClaimErr    error
 		podIPErr          error
+		readyErr          error
 		updateErr         error
 		sendResult        bool
 		expectErr         bool
@@ -150,6 +151,14 @@ func TestServerCreateSandbox(t *testing.T) {
 		{
 			name:              "pod ip lookup fails triggers rollback",
 			podIPErr:          errors.New("pod ip missing"),
+			sendResult:        true,
+			expectErr:         true,
+			expectCreateCalls: 1,
+			expectDeleteCalls: 1,
+		},
+		{
+			name:              "entrypoint readiness failure triggers rollback",
+			readyErr:          errors.New("connection refused"),
 			sendResult:        true,
 			expectErr:         true,
 			expectCreateCalls: 1,
@@ -218,6 +227,10 @@ func TestServerCreateSandbox(t *testing.T) {
 				return "10.0.0.9", nil
 			})
 
+			patches.ApplyPrivateMethod(reflect.TypeOf(server), "waitForSandboxEntryPointsReady", func(_ *Server, _ context.Context, _ string, _ *sandboxEntry) error {
+				return tt.readyErr
+			})
+
 			resp, err := server.createSandbox(context.Background(), nil, sb, claim, makeEntry(), resultChan)
 
 			require.Equal(t, tt.expectCreateCalls, createCalls, "createSandbox call count")
@@ -248,7 +261,7 @@ func TestServerCreateSandbox(t *testing.T) {
 
 func newFakeServer() *Server {
 	return &Server{
-		config:            &Config{},
+		config:            &Config{SandboxReadyProbeTimeout: 5 * time.Millisecond, SandboxReadyProbeInterval: time.Millisecond},
 		k8sClient:         &K8sClient{},
 		sandboxController: &SandboxReconciler{},
 		storeClient:       &fakeStore{},

--- a/pkg/workloadmanager/k8s_client.go
+++ b/pkg/workloadmanager/k8s_client.go
@@ -25,6 +25,7 @@ import (
 
 	runtimev1alpha1 "github.com/volcano-sh/agentcube/pkg/apis/runtime/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -251,9 +252,10 @@ func deleteSandbox(ctx context.Context, client dynamic.Interface, namespace, san
 		sandboxName,
 		metav1.DeleteOptions{},
 	)
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete sandbox: %w", err)
 	}
+
 	return nil
 }
 
@@ -264,9 +266,10 @@ func deleteSandboxClaim(ctx context.Context, client dynamic.Interface, namespace
 		sandboxClaimName,
 		metav1.DeleteOptions{},
 	)
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete sandbox claim: %w", err)
 	}
+
 	return nil
 }
 

--- a/pkg/workloadmanager/sandbox_helper.go
+++ b/pkg/workloadmanager/sandbox_helper.go
@@ -17,14 +17,32 @@ limitations under the License.
 package workloadmanager
 
 import (
+	"context"
+	"fmt"
 	"net"
 	"strconv"
 	"time"
 
+	runtimev1alpha1 "github.com/volcano-sh/agentcube/pkg/apis/runtime/v1alpha1"
 	"github.com/volcano-sh/agentcube/pkg/common/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
 )
+
+const (
+	defaultSandboxReadyProbeTimeout  = 15 * time.Second
+	defaultSandboxReadyProbeInterval = 1 * time.Second
+	defaultSandboxReadyDialTimeout   = 1 * time.Second
+)
+
+var sandboxEntrypointDial = func(ctx context.Context, endpoint string, timeout time.Duration) error {
+	dialer := &net.Dialer{Timeout: timeout}
+	conn, err := dialer.DialContext(ctx, "tcp", endpoint)
+	if err != nil {
+		return err
+	}
+	return conn.Close()
+}
 
 func buildSandboxPlaceHolder(sandboxCR *sandboxv1alpha1.Sandbox, entry *sandboxEntry) *types.SandboxInfo {
 	return &types.SandboxInfo{
@@ -73,4 +91,54 @@ func getSandboxStatus(sandbox *sandboxv1alpha1.Sandbox) string {
 		}
 	}
 	return "unknown"
+}
+
+func (s *Server) waitForSandboxEntryPointsReady(ctx context.Context, podIP string, entry *sandboxEntry) error {
+	if entry == nil || len(entry.Ports) == 0 {
+		return nil
+	}
+
+	probeTimeout := defaultSandboxReadyProbeTimeout
+	probeInterval := defaultSandboxReadyProbeInterval
+	if s != nil && s.config != nil {
+		if s.config.SandboxReadyProbeTimeout > 0 {
+			probeTimeout = s.config.SandboxReadyProbeTimeout
+		}
+		if s.config.SandboxReadyProbeInterval > 0 {
+			probeInterval = s.config.SandboxReadyProbeInterval
+		}
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+
+	var lastErr error
+	for {
+		lastErr = probeSandboxEntryPoints(probeCtx, podIP, entry.Ports, probeInterval)
+		if lastErr == nil {
+			return nil
+		}
+
+		select {
+		case <-probeCtx.Done():
+			return fmt.Errorf("sandbox entrypoints not ready before timeout: %w", lastErr)
+		case <-time.After(probeInterval):
+		}
+	}
+}
+
+func probeSandboxEntryPoints(ctx context.Context, podIP string, ports []runtimev1alpha1.TargetPort, probeInterval time.Duration) error {
+	dialTimeout := probeInterval
+	if dialTimeout <= 0 || dialTimeout > defaultSandboxReadyDialTimeout {
+		dialTimeout = defaultSandboxReadyDialTimeout
+	}
+
+	for _, port := range ports {
+		endpoint := net.JoinHostPort(podIP, strconv.Itoa(int(port.Port)))
+		if err := sandboxEntrypointDial(ctx, endpoint, dialTimeout); err != nil {
+			return fmt.Errorf("entrypoint %s not reachable: %w", endpoint, err)
+		}
+	}
+
+	return nil
 }

--- a/pkg/workloadmanager/server.go
+++ b/pkg/workloadmanager/server.go
@@ -57,12 +57,23 @@ type Config struct {
 	TLSKey string
 	// EnableAuth enable auth by service account
 	EnableAuth bool
+	// SandboxReadyProbeTimeout is the maximum time to wait for sandbox entrypoints
+	// to start accepting connections after the sandbox is reported ready.
+	SandboxReadyProbeTimeout time.Duration
+	// SandboxReadyProbeInterval is the retry interval for sandbox entrypoint probes.
+	SandboxReadyProbeInterval time.Duration
 }
 
 // NewServer creates a new API server instance
 func NewServer(config *Config, sandboxController *SandboxReconciler) (*Server, error) {
 	if config == nil {
 		return nil, fmt.Errorf("config cannot be nil")
+	}
+	if config.SandboxReadyProbeTimeout <= 0 {
+		config.SandboxReadyProbeTimeout = defaultSandboxReadyProbeTimeout
+	}
+	if config.SandboxReadyProbeInterval <= 0 {
+		config.SandboxReadyProbeInterval = defaultSandboxReadyProbeInterval
 	}
 
 	// Create Kubernetes client


### PR DESCRIPTION
## Summary
- wait for sandbox entrypoints to accept TCP connections before publishing sandbox info from Workload Manager
- add a Router preflight reachability retry before proxy setup to reduce residual connection-refused races
- reject invalid upstream endpoints cleanly and cover the new behavior with focused tests

## Testing
- go test ./pkg/workloadmanager/... -count=1
- go test ./pkg/router -run '^TestWaitForUpstreamReachable_RetriesUntilReady$|^TestHandleAgentInvoke$|^TestForwardToSandbox_InvalidEndpoint$' -count=1