### PR TITLE
fix: move sandbox rollback defer before timeout to prevent resource leak

### DIFF
--- a/pkg/workloadmanager/handlers.go
+++ b/pkg/workloadmanager/handlers.go
@@ -160,16 +160,9 @@ func (s *Server) createSandbox(ctx context.Context, dynamicClient dynamic.Interf
 		}
 	}
 
-	var createdSandbox *sandboxv1alpha1.Sandbox
-	select {
-	case result := <-resultChan:
-		createdSandbox = result.Sandbox
-		klog.V(2).Infof("sandbox %s/%s running", createdSandbox.Namespace, createdSandbox.Name)
-	case <-time.After(2 * time.Minute): // consistent with router settings
-		klog.Warningf("sandbox %s/%s create timed out", sandbox.Namespace, sandbox.Name)
-		return nil, fmt.Errorf("sandbox creation timed out")
-	}
-
+	// Register rollback BEFORE waiting for the sandbox to become ready.
+	// This ensures the K8s resource and store placeholder are cleaned up on
+	// timeout, pod-IP failure, or store-update failure — not just on post-creation errors.
 	needRollbackSandbox := true
 	sandboxRollbackFunc := func() {
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -180,17 +173,21 @@ func (s *Server) createSandbox(ctx context.Context, dynamicClient dynamic.Interf
 			err = deleteSandboxClaim(ctxTimeout, dynamicClient, sandboxClaim.Namespace, sandboxClaim.Name)
 			if err != nil {
 				klog.Infof("sandbox claim %s/%s rollback failed: %v", sandboxClaim.Namespace, sandboxClaim.Name, err)
-				return
+			} else {
+				klog.Infof("sandbox claim %s/%s rollback succeeded", sandboxClaim.Namespace, sandboxClaim.Name)
 			}
-			klog.Infof("sandbox claim %s/%s rollback succeeded", sandboxClaim.Namespace, sandboxClaim.Name)
 		} else {
 			// Rollback Sandbox
 			err = deleteSandbox(ctxTimeout, dynamicClient, sandbox.Namespace, sandbox.Name)
 			if err != nil {
 				klog.Infof("sandbox %s/%s rollback failed: %v", sandbox.Namespace, sandbox.Name, err)
-				return
+			} else {
+				klog.Infof("sandbox %s/%s rollback succeeded", sandbox.Namespace, sandbox.Name)
 			}
-			klog.Infof("sandbox %s/%s rollback succeeded", sandbox.Namespace, sandbox.Name)
+		}
+		// Clean up the store placeholder so it does not pollute GC queries
+		if delErr := s.storeClient.DeleteSandboxBySessionID(ctxTimeout, sandboxEntry.SessionID); delErr != nil {
+			klog.Infof("sandbox %s/%s store placeholder cleanup failed: %v", sandbox.Namespace, sandbox.Name, delErr)
 		}
 	}
 	defer func() {
@@ -199,6 +196,16 @@ func (s *Server) createSandbox(ctx context.Context, dynamicClient dynamic.Interf
 		}
 		sandboxRollbackFunc()
 	}()
+
+	var createdSandbox *sandboxv1alpha1.Sandbox
+	select {
+	case result := <-resultChan:
+		createdSandbox = result.Sandbox
+		klog.V(2).Infof("sandbox %s/%s running", createdSandbox.Namespace, createdSandbox.Name)
+	case <-time.After(2 * time.Minute): // consistent with router settings
+		klog.Warningf("sandbox %s/%s create timed out", sandbox.Namespace, sandbox.Name)
+		return nil, fmt.Errorf("sandbox creation timed out")
+	}
 
 	// agent-sandbox create pod with same name as sandbox if no warmpool is used
 	// so here we try to get pod IP by sandbox name first


### PR DESCRIPTION
## What type of PR is this?
/kind bug                                                                                                                                                             

## What this PR does / why we need it:                                                                                                                                
  
I found a resource leak in sandbox creation that really starts hurting when the cluster gets under pressure. basically when a sandbox takes too long to start and hits the 2 minute timeout, the cleanup code never runs because i had the defer registered after the timeout return statement. so you end up with leftover kubernetes resources and store entries just sitting there consuming cpu and memory.                                                                                
  
I moved the defer earlier in the function so it actually catches the timeout case. I also realized the rollback was never cleaning up the store placeholder which was another gap. And I fixed the rollback logic to not bail out early so both the K8s deletion and store cleanup always try to run even if one of them fails.
                                                                                                                                                                     
### Special notes for your reviewer:

This is a classic Go bug where I had the defer too far down in the function. The timeout case would return before the defer ever got registered. The fix is straightforward, just move the defer up earlier so it wraps the timeout case.
I also made the rollback function a bit more robust by removing the early returns so it always attempts both cleanup steps.  
                                                                                                            
###  Does this PR introduce a user-facing change?:                                                                                                                         
 No, this is an internal fix that prevents resource leaks. Users will see improved cluster stability under burst load scenarios, but no API or behavior changes.       
`NONE`    