### PR TITLE
fix: stop codeinterpreter controller from spamming status updates

### DIFF
--- a/cmd/workload-manager/main.go
+++ b/cmd/workload-manager/main.go
@@ -32,10 +32,8 @@ import (
 	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
 	extensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	runtimev1alpha1 "github.com/volcano-sh/agentcube/pkg/apis/runtime/v1alpha1"
 	"github.com/volcano-sh/agentcube/pkg/workloadmanager"
@@ -177,12 +175,7 @@ func setupControllers(mgr ctrl.Manager, sandboxReconciler *workloadmanager.Sandb
 	}
 
 	// Setup CodeInterpreter controller.
-	// GenerationChangedPredicate filters out status-only update events so that
-	// the controller is not re-enqueued by its own status writes, preventing
-	// an infinite reconciliation loop.
-	if err := ctrl.NewControllerManagedBy(mgr).
-		For(&runtimev1alpha1.CodeInterpreter{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Complete(codeInterpreterReconciler); err != nil {
+	if err := codeInterpreterReconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create codeinterpreter controller: %w", err)
 	}
 

--- a/cmd/workload-manager/main.go
+++ b/cmd/workload-manager/main.go
@@ -32,8 +32,10 @@ import (
 	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
 	extensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	runtimev1alpha1 "github.com/volcano-sh/agentcube/pkg/apis/runtime/v1alpha1"
 	"github.com/volcano-sh/agentcube/pkg/workloadmanager"
@@ -174,9 +176,12 @@ func setupControllers(mgr ctrl.Manager, sandboxReconciler *workloadmanager.Sandb
 		return fmt.Errorf("unable to create sandbox controller: %w", err)
 	}
 
-	// Setup CodeInterpreter controller
+	// Setup CodeInterpreter controller.
+	// GenerationChangedPredicate filters out status-only update events so that
+	// the controller is not re-enqueued by its own status writes, preventing
+	// an infinite reconciliation loop.
 	if err := ctrl.NewControllerManagedBy(mgr).
-		For(&runtimev1alpha1.CodeInterpreter{}).
+		For(&runtimev1alpha1.CodeInterpreter{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(codeInterpreterReconciler); err != nil {
 		return fmt.Errorf("unable to create codeinterpreter controller: %w", err)
 	}

--- a/pkg/workloadmanager/codeinterpreter_controller.go
+++ b/pkg/workloadmanager/codeinterpreter_controller.go
@@ -24,6 +24,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -97,33 +98,18 @@ func (r *CodeInterpreterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 // updateStatus updates the CodeInterpreter status
 func (r *CodeInterpreterReconciler) updateStatus(ctx context.Context, ci *runtimev1alpha1.CodeInterpreter) error {
-	// Update status
 	ci.Status.Ready = true
 
-	// Update conditions
-	readyCondition := metav1.Condition{
+	// SetStatusCondition only updates LastTransitionTime when the condition
+	// Status actually changes, preventing spurious status writes that would
+	// trigger an infinite reconciliation loop.
+	apimeta.SetStatusCondition(&ci.Status.Conditions, metav1.Condition{
 		Type:               "Ready",
 		Status:             metav1.ConditionTrue,
 		Reason:             "Reconciled",
 		Message:            "CodeInterpreter is ready",
-		LastTransitionTime: metav1.Now(),
 		ObservedGeneration: ci.Generation,
-	}
-
-	// Update or add condition
-	conditionIndex := -1
-	for i, cond := range ci.Status.Conditions {
-		if cond.Type == "Ready" {
-			conditionIndex = i
-			break
-		}
-	}
-
-	if conditionIndex >= 0 {
-		ci.Status.Conditions[conditionIndex] = readyCondition
-	} else {
-		ci.Status.Conditions = append(ci.Status.Conditions, readyCondition)
-	}
+	})
 
 	return r.Status().Update(ctx, ci)
 }

--- a/pkg/workloadmanager/codeinterpreter_controller.go
+++ b/pkg/workloadmanager/codeinterpreter_controller.go
@@ -29,9 +29,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	runtimev1alpha1 "github.com/volcano-sh/agentcube/pkg/apis/runtime/v1alpha1"
 	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
@@ -96,10 +98,19 @@ func (r *CodeInterpreterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	return ctrl.Result{}, nil
 }
 
-// updateStatus updates the CodeInterpreter status
+// updateStatus updates the CodeInterpreter status. It skips the API write
+// when the status is already up-to-date to avoid triggering a new watch event
+// that would re-enqueue the object unnecessarily.
 func (r *CodeInterpreterReconciler) updateStatus(ctx context.Context, ci *runtimev1alpha1.CodeInterpreter) error {
-	ci.Status.Ready = true
+	existing := apimeta.FindStatusCondition(ci.Status.Conditions, "Ready")
+	if ci.Status.Ready &&
+		existing != nil &&
+		existing.Status == metav1.ConditionTrue &&
+		existing.ObservedGeneration == ci.Generation {
+		return nil
+	}
 
+	ci.Status.Ready = true
 	// SetStatusCondition only updates LastTransitionTime when the condition
 	// Status actually changes, preventing spurious status writes that would
 	// trigger an infinite reconciliation loop.
@@ -347,10 +358,12 @@ func (r *CodeInterpreterReconciler) GetCodeInterpreter(name, namespace string) *
 }
 
 // SetupWithManager sets up the controller with the Manager.
+// GenerationChangedPredicate filters out status-only update events so that
+// the controller is not re-enqueued by its own status writes.
 func (r *CodeInterpreterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.mgr = mgr
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&runtimev1alpha1.CodeInterpreter{}).
+		For(&runtimev1alpha1.CodeInterpreter{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }


### PR DESCRIPTION
## What type of PR is this?

  /kind bug
                                                                                                                                                                                           
##  What this PR does / why we need it:                                                                                                                                                    
so the codeinterpreter controller had a pretty nasty reconcile loop going on. every reconcile was calling updateStatus which was stamping a fresh metav1.Now() on the condition every single time, no matter what. kubernetes sees a different timestamp, treats it as a real change, writes it to etcd, bumps resourceversion, informer catches it, re-enqueues the object, reconcile fires again. rinse and repeat, forever, for every codeinterpreter object on the cluster.
no errors surfaced anywhere. controller looked perfectly healthy. it was just silently hammering the api server and etcd with pointless writes the entire time it was running. scales linearly with how many codeinterpreter objects you have so it gets worse over time.
fixed it two ways , swapped metav1.Now() out for apimeta.SetStatusCondition which only touches LastTransitionTime when the condition actually transitions, so when it's already ready nothing gets dirtied. also added GenerationChangedPredicate on the controller builder so status-only watch events get dropped before they even reach the reconcile queue.
                                                                                                                                                                                 
###  Special notes for your reviewer:                                                                                                                                                       

the two changes together are belt-and-suspenders. SetStatusCondition is the real fix , it stops the status object from being dirty on no-op reconciles. the predicate is a second layer so even if something else causes a status diff it won't re-trigger reconciliation. both changes are tiny and self-contained, no behavior changes outside the reconcile loop.             
                                                                                                                                                                                                                                                                                                                