### PR TITLE
fix: propagate url.Parse error in buildURL to prevent nil pointer pan…

### DIFF
--- a/pkg/router/handlers.go
+++ b/pkg/router/handlers.go
@@ -17,6 +17,7 @@ limitations under the License.
 package router
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
@@ -103,27 +104,33 @@ func (s *Server) handleGetSandboxError(c *gin.Context, err error) {
 	c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 }
 
+// errNoEntryPoint is returned when a sandbox has no entry points configured.
+var errNoEntryPoint = errors.New("no entry point found for sandbox")
+
 func determineUpstreamURL(sandbox *types.SandboxInfo, path string) (*url.URL, error) {
 	// prefer matched entrypoint by path
 	for _, ep := range sandbox.EntryPoints {
 		if strings.HasPrefix(path, ep.Path) {
-			return buildURL(ep.Protocol, ep.Endpoint), nil
+			return buildURL(ep.Protocol, ep.Endpoint)
 		}
 	}
 	// fallback to first entrypoint
 	if len(sandbox.EntryPoints) == 0 {
-		return nil, fmt.Errorf("no entry point found for sandbox")
+		return nil, errNoEntryPoint
 	}
 	ep := sandbox.EntryPoints[0]
-	return buildURL(ep.Protocol, ep.Endpoint), nil
+	return buildURL(ep.Protocol, ep.Endpoint)
 }
 
-func buildURL(protocol, endpoint string) *url.URL {
+func buildURL(protocol, endpoint string) (*url.URL, error) {
 	if protocol != "" && !strings.Contains(endpoint, "://") {
-		endpoint = (strings.ToLower(protocol) + "://" + endpoint)
+		endpoint = strings.ToLower(protocol) + "://" + endpoint
 	}
-	url, _ := url.Parse(endpoint)
-	return url
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("invalid endpoint URL %q: %w", endpoint, err)
+	}
+	return u, nil
 }
 
 // handleAgentInvoke handles agent invocation requests
@@ -148,9 +155,11 @@ func (s *Server) forwardToSandbox(c *gin.Context, sandbox *types.SandboxInfo, pa
 	targetURL, err := determineUpstreamURL(sandbox, path)
 	if err != nil {
 		klog.Errorf("Failed to get sandbox access address %s: %v", sandbox.SandboxID, err)
-		c.JSON(http.StatusNotFound, gin.H{
-			"error": err.Error(),
-		})
+		if errors.Is(err, errNoEntryPoint) {
+			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid sandbox endpoint configuration"})
+		}
 		return
 	}
 

--- a/pkg/router/handlers.go
+++ b/pkg/router/handlers.go
@@ -180,7 +180,7 @@ func (s *Server) forwardToSandbox(c *gin.Context, sandbox *types.SandboxInfo, pa
 		if errors.Is(err, errNoEntryPoint) {
 			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		} else {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("invalid sandbox endpoint configuration: %v", err)})
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid sandbox endpoint configuration"})
 		}
 		return
 	}

--- a/pkg/router/handlers.go
+++ b/pkg/router/handlers.go
@@ -158,7 +158,7 @@ func (s *Server) forwardToSandbox(c *gin.Context, sandbox *types.SandboxInfo, pa
 		if errors.Is(err, errNoEntryPoint) {
 			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		} else {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid sandbox endpoint configuration"})
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("invalid sandbox endpoint configuration: %v", err)})
 		}
 		return
 	}

--- a/pkg/router/handlers.go
+++ b/pkg/router/handlers.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -122,6 +123,12 @@ func determineUpstreamURL(sandbox *types.SandboxInfo, path string) (*url.URL, er
 	return buildURL(ep.Protocol, ep.Endpoint)
 }
 
+// validProxySchemes are the URL schemes accepted for reverse-proxy targets.
+// ws/wss are included to support WebSocket upgrades.
+var validProxySchemes = map[string]bool{
+	"http": true, "https": true, "ws": true, "wss": true,
+}
+
 func buildURL(protocol, endpoint string) (*url.URL, error) {
 	if protocol != "" && !strings.Contains(endpoint, "://") {
 		endpoint = strings.ToLower(protocol) + "://" + endpoint
@@ -133,8 +140,17 @@ func buildURL(protocol, endpoint string) (*url.URL, error) {
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("invalid endpoint URL %q: missing scheme", endpoint)
 	}
+	if !validProxySchemes[u.Scheme] {
+		return nil, fmt.Errorf("invalid endpoint URL %q: unsupported scheme %q, must be http, https, ws, or wss", endpoint, u.Scheme)
+	}
 	if u.Host == "" {
 		return nil, fmt.Errorf("invalid endpoint URL %q: missing host", endpoint)
+	}
+	if portStr := u.Port(); portStr != "" {
+		port, err := strconv.Atoi(portStr)
+		if err != nil || port < 1 || port > 65535 {
+			return nil, fmt.Errorf("invalid endpoint URL %q: port %q out of range (1-65535)", endpoint, portStr)
+		}
 	}
 	return u, nil
 }

--- a/pkg/router/handlers.go
+++ b/pkg/router/handlers.go
@@ -130,6 +130,12 @@ func buildURL(protocol, endpoint string) (*url.URL, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid endpoint URL %q: %w", endpoint, err)
 	}
+	if u.Scheme == "" {
+		return nil, fmt.Errorf("invalid endpoint URL %q: missing scheme", endpoint)
+	}
+	if u.Host == "" {
+		return nil, fmt.Errorf("invalid endpoint URL %q: missing host", endpoint)
+	}
 	return u, nil
 }
 

--- a/pkg/router/handlers_test.go
+++ b/pkg/router/handlers_test.go
@@ -429,6 +429,40 @@ func TestForwardToSandbox_InvalidEndpoint(t *testing.T) {
 	}
 }
 
+func TestForwardToSandbox_NoEntryPoints(t *testing.T) {
+	setupEnv()
+	defer teardownEnv()
+
+	config := &Config{Port: "8080"}
+	server, err := NewServer(config)
+	if err != nil {
+		t.Fatalf("Failed to create server: %v", err)
+	}
+
+	server.sessionManager = &mockSessionManager{
+		sandbox: &types.SandboxInfo{
+			SandboxID:   "test-sandbox",
+			SessionID:   "test-session",
+			Name:        "test-sandbox",
+			EntryPoints: []types.SandboxEntryPoint{},
+		},
+	}
+
+	routerServer := httptest.NewServer(server.engine)
+	defer routerServer.Close()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Post(routerServer.URL+"/v1/namespaces/default/agent-runtimes/test-agent/invocations/test", "application/json", nil)
+	if err != nil {
+		t.Fatalf("Failed to make request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("Expected status code %d, got %d", http.StatusNotFound, resp.StatusCode)
+	}
+}
+
 func TestConcurrencyLimitMiddleware_Overload(t *testing.T) {
 	// Set required environment variables
 	setupEnv()

--- a/pkg/router/handlers_test.go
+++ b/pkg/router/handlers_test.go
@@ -393,39 +393,52 @@ func TestHandleCodeInterpreterInvoke(t *testing.T) {
 }
 
 func TestForwardToSandbox_InvalidEndpoint(t *testing.T) {
-	setupEnv()
-	defer teardownEnv()
-
-	config := &Config{Port: "8080"}
-	server, err := NewServer(config)
-	if err != nil {
-		t.Fatalf("Failed to create server: %v", err)
+	cases := []struct {
+		name     string
+		endpoint string
+	}{
+		{"malformed scheme", "://invalid-url"},
+		{"empty endpoint", ""},
+		{"scheme only", "http://"},
+		{"no scheme", "localhost:8080"},
 	}
 
-	server.sessionManager = &mockSessionManager{
-		sandbox: &types.SandboxInfo{
-			SandboxID: "test-sandbox",
-			SessionID: "test-session",
-			Name:      "test-sandbox",
-			EntryPoints: []types.SandboxEntryPoint{
-				{Endpoint: "://invalid-url", Path: "/test"},
-			},
-		},
-	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setupEnv()
+			defer teardownEnv()
 
-	// run via real server to avoid CloseNotifier panic
-	routerServer := httptest.NewServer(server.engine)
-	defer routerServer.Close()
+			config := &Config{Port: "8080"}
+			server, err := NewServer(config)
+			if err != nil {
+				t.Fatalf("Failed to create server: %v", err)
+			}
 
-	client := &http.Client{Timeout: 5 * time.Second}
-	resp, err := client.Post(routerServer.URL+"/v1/namespaces/default/agent-runtimes/test-agent/invocations/test", "application/json", nil)
-	if err != nil {
-		t.Fatalf("Failed to make request: %v", err)
-	}
-	defer resp.Body.Close()
+			server.sessionManager = &mockSessionManager{
+				sandbox: &types.SandboxInfo{
+					SandboxID: "test-sandbox",
+					SessionID: "test-session",
+					Name:      "test-sandbox",
+					EntryPoints: []types.SandboxEntryPoint{
+						{Endpoint: tc.endpoint, Path: "/test"},
+					},
+				},
+			}
 
-	if resp.StatusCode != http.StatusInternalServerError {
-		t.Errorf("Expected status code %d, got %d", http.StatusInternalServerError, resp.StatusCode)
+			routerServer := httptest.NewServer(server.engine)
+			defer routerServer.Close()
+
+			client := &http.Client{Timeout: 5 * time.Second}
+			resp, err := client.Post(routerServer.URL+"/v1/namespaces/default/agent-runtimes/test-agent/invocations/test", "application/json", nil)
+			if err != nil {
+				t.Fatalf("Failed to make request: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusInternalServerError {
+				t.Errorf("[%s] expected %d, got %d", tc.name, http.StatusInternalServerError, resp.StatusCode)
+			}
+		})
 	}
 }
 

--- a/pkg/router/handlers_test.go
+++ b/pkg/router/handlers_test.go
@@ -408,8 +408,9 @@ func TestForwardToSandbox_InvalidEndpoint(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			setupEnv()
-			defer teardownEnv()
+			t.Setenv("REDIS_ADDR", "localhost:6379")
+			t.Setenv("REDIS_PASSWORD", "test-password")
+			t.Setenv("WORKLOAD_MANAGER_URL", "http://localhost:8080")
 
 			config := &Config{Port: "8080"}
 			server, err := NewServer(config)
@@ -446,8 +447,9 @@ func TestForwardToSandbox_InvalidEndpoint(t *testing.T) {
 }
 
 func TestForwardToSandbox_NoEntryPoints(t *testing.T) {
-	setupEnv()
-	defer teardownEnv()
+	t.Setenv("REDIS_ADDR", "localhost:6379")
+	t.Setenv("REDIS_PASSWORD", "test-password")
+	t.Setenv("WORKLOAD_MANAGER_URL", "http://localhost:8080")
 
 	config := &Config{Port: "8080"}
 	server, err := NewServer(config)

--- a/pkg/router/handlers_test.go
+++ b/pkg/router/handlers_test.go
@@ -399,8 +399,11 @@ func TestForwardToSandbox_InvalidEndpoint(t *testing.T) {
 	}{
 		{"malformed scheme", "://invalid-url"},
 		{"empty endpoint", ""},
-		{"scheme only", "http://"},
+		{"scheme only no host", "http://"},
 		{"no scheme", "localhost:8080"},
+		{"unsupported scheme ftp", "ftp://host:21"},
+		{"unsupported scheme file", "file:///etc/passwd"},
+		{"port out of range", "http://host:99999"},
 	}
 
 	for _, tc := range cases {

--- a/pkg/router/jwt_test.go
+++ b/pkg/router/jwt_test.go
@@ -186,7 +186,7 @@ func TestGetPrivateKeyPEM(t *testing.T) {
 
 	// Compare key components instead of whole struct — ParsePKCS1PrivateKey may
 	// not precompute Dp/Dq/Qinv identically to the original key.
-	assert.Equal(t, manager.privateKey.PublicKey.N, privateKey.PublicKey.N, "Public key N should match")
+	assert.Equal(t, 0, manager.privateKey.PublicKey.N.Cmp(privateKey.PublicKey.N), "Public key N should match")
 	assert.Equal(t, manager.privateKey.PublicKey.E, privateKey.PublicKey.E, "Public key E should match")
 	assert.Equal(t, 0, manager.privateKey.D.Cmp(privateKey.D), "Private exponent D should match")
 	assert.Equal(t, len(manager.privateKey.Primes), len(privateKey.Primes), "Number of primes should match")

--- a/pkg/router/jwt_test.go
+++ b/pkg/router/jwt_test.go
@@ -183,7 +183,16 @@ func TestGetPrivateKeyPEM(t *testing.T) {
 	privateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	assert.NoError(t, err)
 	assert.NotNil(t, privateKey)
-	assert.Equal(t, manager.privateKey, privateKey)
+
+	// Compare key components instead of whole struct — ParsePKCS1PrivateKey may
+	// not precompute Dp/Dq/Qinv identically to the original key.
+	assert.Equal(t, manager.privateKey.PublicKey.N, privateKey.PublicKey.N, "Public key N should match")
+	assert.Equal(t, manager.privateKey.PublicKey.E, privateKey.PublicKey.E, "Public key E should match")
+	assert.Equal(t, 0, manager.privateKey.D.Cmp(privateKey.D), "Private exponent D should match")
+	assert.Equal(t, len(manager.privateKey.Primes), len(privateKey.Primes), "Number of primes should match")
+	for i := range manager.privateKey.Primes {
+		assert.Equal(t, 0, manager.privateKey.Primes[i].Cmp(privateKey.Primes[i]), "Prime %d should match", i)
+	}
 }
 
 func TestLoadPrivateKeyPEM(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`buildURL` in the router was silently discarding the error returned by `url.Parse` using a blank identifier (`_`). This meant that when a sandbox entry point contained a malformed or empty endpoint string, `url.Parse` would return a `nil` `*url.URL` which was then passed directly to `httputil.NewSingleHostReverseProxy`. Passing a `nil` URL to the reverse proxy causes a panic at request time, which was only masked by gin's built-in recovery middleware returning a 500 — not proper error handling.

This PR fixes the issue by:
- Changing `buildURL` to return `(*url.URL, error)` and propagating the parse error to the caller
- Adding an `errNoEntryPoint` sentinel to distinguish between "no entry points configured" (404) and "malformed endpoint URL" (500) in `forwardToSandbox`
- Returning a proper `500 Internal Server Error` with a descriptive message instead of relying on panic recovery

**Which issue(s) this PR fixes**:
Fixes #269

**Special notes for your reviewer**:

The existing test `TestForwardToSandbox_InvalidEndpoint` was already covering this scenario but was passing for the wrong reason — it expected 500 because gin's panic recovery was catching the nil pointer dereference. The test still passes after this fix, but now tests legitimate error handling instead of panic recovery behaviour.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed a router panic caused by malformed sandbox endpoint URLs. Invalid endpoints now return a 500 Internal Server Error instead of crashing the router process.
```

