### PR TITLE
Stop publishing Python packages from main branch pushes

### DIFF
--- a/.github/workflows/python-cli-publish.yml
+++ b/.github/workflows/python-cli-publish.yml
@@ -2,11 +2,8 @@ name: Python CLI Publish
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - "cmd/cli/**"
-      - ".github/workflows/python-cli-publish.yml"
+    tags:
+      - "v*.*.*"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/python-sdk-publish.yml
+++ b/.github/workflows/python-sdk-publish.yml
@@ -2,11 +2,8 @@ name: Python SDK Publish
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - "sdk-python/**"
-      - ".github/workflows/python-sdk-publish.yml"
+    tags:
+      - "v*.*.*"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

<img width="1123" height="261" alt="image" src="https://github.com/user-attachments/assets/c2beb79e-28f4-4636-805c-738e62c0bf2c" />


Stop publishing the Python CLI and Python SDK to PyPI on every push to `main`.

PyPI package versions are immutable, so triggering package publishes from regular `main` branch changes causes repeated failures when the package version has not been bumped. This change limits Python package publishing to release tags and manual dispatches, which matches the expected release flow more closely and avoids noisy deployment failures.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This is a stopgap change only. It does not define the long-term Python package versioning or release policy yet.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
