### PR TITLE
fix: create workspace directory at startup and default execution dir to workspace

### DIFF
--- a/pkg/picod/execute.go
+++ b/pkg/picod/execute.go
@@ -92,13 +92,21 @@ func (s *Server) ExecuteHandler(c *gin.Context) {
 	// Use the first element as the command and the rest as arguments
 	cmd := exec.CommandContext(ctx, req.Command[0], req.Command[1:]...) //nolint:gosec // This is an agent designed to execute arbitrary commands
 
-	// Set working directory
+	// Default working directory to workspace; override if the request specifies one.
+	cmd.Dir = s.workspaceDir
 	if req.WorkingDir != "" {
 		safeWorkingDir, err := s.sanitizePath(req.WorkingDir)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error": fmt.Sprintf("Invalid working directory: %v", err),
 				"code":  http.StatusBadRequest,
+			})
+			return
+		}
+		if err := os.MkdirAll(safeWorkingDir, 0755); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": fmt.Sprintf("Failed to create working directory: %v", err),
+				"code":  http.StatusInternalServerError,
 			})
 			return
 		}

--- a/pkg/picod/execute.go
+++ b/pkg/picod/execute.go
@@ -103,7 +103,7 @@ func (s *Server) ExecuteHandler(c *gin.Context) {
 			})
 			return
 		}
-		if err := os.MkdirAll(safeWorkingDir, 0755); err != nil {
+		if err := s.mkdirSafe(safeWorkingDir); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": fmt.Sprintf("Failed to create working directory: %v", err),
 				"code":  http.StatusInternalServerError,

--- a/pkg/picod/execute.go
+++ b/pkg/picod/execute.go
@@ -103,12 +103,14 @@ func (s *Server) ExecuteHandler(c *gin.Context) {
 			})
 			return
 		}
-		if err := s.mkdirSafe(safeWorkingDir); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to create working directory: %v", err),
-				"code":  http.StatusInternalServerError,
-			})
-			return
+		if _, statErr := os.Stat(safeWorkingDir); os.IsNotExist(statErr) {
+			if err := s.mkdirSafe(safeWorkingDir); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"error": fmt.Sprintf("Failed to create working directory: %v", err),
+					"code":  http.StatusInternalServerError,
+				})
+				return
+			}
 		}
 		cmd.Dir = safeWorkingDir
 	}

--- a/pkg/picod/execute_test.go
+++ b/pkg/picod/execute_test.go
@@ -256,6 +256,34 @@ func TestExecuteHandler_WorkingDirectory(t *testing.T) {
 	}
 }
 
+func TestExecuteHandler_WorkingDirectory_SymlinkEscape(t *testing.T) {
+	server, tmpDir := setupExecuteTestServer(t)
+	defer os.RemoveAll(tmpDir)
+	defer os.Unsetenv(PublicKeyEnvVar)
+
+	// Plant a symlink inside the workspace that points outside it.
+	outsideDir := t.TempDir()
+	symlinkPath := filepath.Join(tmpDir, "escape")
+	require.NoError(t, os.Symlink(outsideDir, symlinkPath))
+
+	// Attempt to execute in a subdirectory of the symlink — mkdirSafe should reject this.
+	req := ExecuteRequest{
+		Command:    []string{"pwd"},
+		WorkingDir: "escape/newdir",
+	}
+	body, _ := json.Marshal(req)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest("POST", "/api/execute", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	server.ExecuteHandler(c)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "Failed to create working directory")
+}
+
 func TestExecuteHandler_DefaultsToWorkspace(t *testing.T) {
 	server, tmpDir := setupExecuteTestServer(t)
 	defer os.RemoveAll(tmpDir)

--- a/pkg/picod/execute_test.go
+++ b/pkg/picod/execute_test.go
@@ -27,6 +27,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -219,8 +220,13 @@ func TestExecuteHandler_WorkingDirectory(t *testing.T) {
 			errorContains: "Invalid working directory",
 		},
 		{
-			name:        "valid subdirectory",
+			name:        "valid subdirectory (already exists)",
 			workingDir:  "subdir",
+			expectError: false,
+		},
+		{
+			name:        "non-existent subdirectory is auto-created",
+			workingDir:  "newdir/nested",
 			expectError: false,
 		},
 	}
@@ -248,6 +254,41 @@ func TestExecuteHandler_WorkingDirectory(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExecuteHandler_DefaultsToWorkspace(t *testing.T) {
+	server, tmpDir := setupExecuteTestServer(t)
+	defer os.RemoveAll(tmpDir)
+	defer os.Unsetenv(PublicKeyEnvVar)
+
+	// No WorkingDir set — command should run inside the workspace directory.
+	req := ExecuteRequest{
+		Command: []string{"pwd"},
+	}
+	body, _ := json.Marshal(req)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest("POST", "/api/execute", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	server.ExecuteHandler(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ExecuteResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, 0, resp.ExitCode)
+
+	// Resolve symlinks on both sides so the comparison is stable on macOS
+	// where /tmp and /var are symlinks to /private/tmp and /private/var.
+	pwdOutput := strings.TrimSpace(resp.Stdout)
+	resolvedPwd, err := filepath.EvalSymlinks(pwdOutput)
+	require.NoError(t, err)
+	resolvedWorkspace, err := filepath.EvalSymlinks(server.workspaceDir)
+	require.NoError(t, err)
+	assert.Equal(t, resolvedWorkspace, resolvedPwd, "command should run inside the workspace directory")
 }
 
 func TestExecuteHandler_ExitCodes(t *testing.T) {

--- a/pkg/picod/files.go
+++ b/pkg/picod/files.go
@@ -386,6 +386,44 @@ func parseFileMode(modeStr string) os.FileMode {
 	return os.FileMode(mode)
 }
 
+// mkdirSafe creates dir and all parents within the workspace, guarding against
+// symlink-based directory traversal in existing path components.
+//
+// os.MkdirAll follows symlinks in the existing portion of the path.  If an
+// attacker has placed a symlink inside the workspace that points outside (e.g.
+// workspace/link -> /), MkdirAll("workspace/link/newdir") would silently create
+// /newdir.  mkdirSafe walks up to the deepest existing ancestor, resolves its
+// symlinks, and verifies it is still inside the workspace before proceeding.
+func (s *Server) mkdirSafe(dir string) error {
+	resolvedWorkspace, err := filepath.EvalSymlinks(s.workspaceDir)
+	if err != nil {
+		resolvedWorkspace = filepath.Clean(s.workspaceDir)
+	}
+
+	// Walk up to the deepest ancestor that already exists.
+	existing := dir
+	for {
+		if _, err := os.Lstat(existing); err == nil {
+			resolved, err := filepath.EvalSymlinks(existing)
+			if err != nil {
+				return fmt.Errorf("failed to resolve path %q: %w", existing, err)
+			}
+			rel, relErr := filepath.Rel(resolvedWorkspace, resolved)
+			if relErr != nil || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || rel == ".." {
+				return fmt.Errorf("access denied: path %q escapes workspace jail via symlink", dir)
+			}
+			break
+		}
+		parent := filepath.Dir(existing)
+		if parent == existing {
+			// Reached filesystem root — workspace itself will be created by MkdirAll.
+			break
+		}
+		existing = parent
+	}
+	return os.MkdirAll(dir, 0755)
+}
+
 // setWorkspace sets the workspace directory and creates it if it does not exist.
 func (s *Server) setWorkspace(dir string) error {
 	klog.Infof("setWorkspace called with dir: %q", dir)

--- a/pkg/picod/files.go
+++ b/pkg/picod/files.go
@@ -386,8 +386,8 @@ func parseFileMode(modeStr string) os.FileMode {
 	return os.FileMode(mode)
 }
 
-// setWorkspace sets the global workspace directory
-func (s *Server) setWorkspace(dir string) {
+// setWorkspace sets the workspace directory and creates it if it does not exist.
+func (s *Server) setWorkspace(dir string) error {
 	klog.Infof("setWorkspace called with dir: %q", dir)
 	absDir, err := filepath.Abs(dir)
 	if err != nil {
@@ -397,6 +397,11 @@ func (s *Server) setWorkspace(dir string) {
 		s.workspaceDir = absDir
 		klog.Infof("Resolved workspace to absolute path: %q", s.workspaceDir)
 	}
+	if err := os.MkdirAll(s.workspaceDir, 0755); err != nil {
+		return fmt.Errorf("failed to create workspace directory %q: %w", s.workspaceDir, err)
+	}
+	klog.Infof("Workspace directory ensured: %q", s.workspaceDir)
+	return nil
 }
 
 // sanitizePath ensures path is within allowed scope, preventing directory traversal attacks

--- a/pkg/picod/files.go
+++ b/pkg/picod/files.go
@@ -429,12 +429,10 @@ func (s *Server) setWorkspace(dir string) error {
 	klog.Infof("setWorkspace called with dir: %q", dir)
 	absDir, err := filepath.Abs(dir)
 	if err != nil {
-		klog.Warningf("Failed to resolve absolute path for workspace '%s': %v", dir, err)
-		s.workspaceDir = dir // Fallback to provided path
-	} else {
-		s.workspaceDir = absDir
-		klog.Infof("Resolved workspace to absolute path: %q", s.workspaceDir)
+		return fmt.Errorf("failed to resolve absolute path for workspace %q: %w", dir, err)
 	}
+	s.workspaceDir = absDir
+	klog.Infof("Resolved workspace to absolute path: %q", s.workspaceDir)
 	if err := os.MkdirAll(s.workspaceDir, 0755); err != nil {
 		return fmt.Errorf("failed to create workspace directory %q: %w", s.workspaceDir, err)
 	}

--- a/pkg/picod/files_test.go
+++ b/pkg/picod/files_test.go
@@ -252,7 +252,8 @@ func TestSetWorkspace(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := &Server{}
-			server.setWorkspace(tt.dir)
+			err := server.setWorkspace(tt.dir)
+			assert.NoError(t, err)
 
 			if tt.checkAbs {
 				// Verify workspace is set to absolute path
@@ -269,7 +270,8 @@ func TestSetWorkspace_WithTemporaryDirectory(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	server := &Server{}
-	server.setWorkspace(tmpDir)
+	err = server.setWorkspace(tmpDir)
+	assert.NoError(t, err)
 
 	assert.Equal(t, tmpDir, server.workspaceDir)
 }

--- a/pkg/picod/picod_test.go
+++ b/pkg/picod/picod_test.go
@@ -397,7 +397,8 @@ func TestPicoD_SetWorkspace(t *testing.T) {
 	// Case 1: Absolute Path
 	absPath, err := filepath.Abs(realDir)
 	require.NoError(t, err)
-	server.setWorkspace(realDir)
+	err = server.setWorkspace(realDir)
+	require.NoError(t, err)
 	assert.Equal(t, resolve(absPath), resolve(server.workspaceDir))
 
 	// Case 2: Relative Path
@@ -407,12 +408,14 @@ func TestPicoD_SetWorkspace(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, os.Chdir(originalWd)) }()
 
-	server.setWorkspace("real")
+	err = server.setWorkspace("real")
+	require.NoError(t, err)
 	assert.Equal(t, resolve(absPath), resolve(server.workspaceDir))
 
 	// Case 3: Symlink
 	absLinkPath, err := filepath.Abs(linkDir)
 	require.NoError(t, err)
-	server.setWorkspace(linkDir)
+	err = server.setWorkspace(linkDir)
+	require.NoError(t, err)
 	assert.Equal(t, resolve(absLinkPath), resolve(server.workspaceDir))
 }

--- a/pkg/picod/server.go
+++ b/pkg/picod/server.go
@@ -51,17 +51,16 @@ func NewServer(config Config) *Server {
 
 	// Initialize workspace directory
 	klog.Infof("Initializing workspace with config.Workspace: %q", config.Workspace)
-	if config.Workspace != "" {
-		s.setWorkspace(config.Workspace)
-		klog.Infof("Set workspace to configured value: %q", config.Workspace)
-	} else {
-		// Default to current working directory if not specified
+	workspaceDir := config.Workspace
+	if workspaceDir == "" {
 		cwd, err := os.Getwd()
 		if err != nil {
 			klog.Fatalf("Failed to get current working directory: %v", err)
 		}
-		s.setWorkspace(cwd)
-		klog.Infof("Set workspace to current working directory: %q", cwd)
+		workspaceDir = cwd
+	}
+	if err := s.setWorkspace(workspaceDir); err != nil {
+		klog.Fatalf("Failed to initialize workspace: %v", err)
 	}
 	klog.Infof("Final workspace directory: %q", s.workspaceDir)
 

--- a/pkg/picod/server_test.go
+++ b/pkg/picod/server_test.go
@@ -100,6 +100,24 @@ func TestNewServer_WorkspaceConfiguration(t *testing.T) {
 			},
 		},
 		{
+			name: "non-existent workspace directory is created",
+			setupWorkDir: func(t *testing.T) (string, func()) {
+				tmpDir, err := os.MkdirTemp("", "picod-server-test-*")
+				require.NoError(t, err)
+				// Point to a subdirectory that does not exist yet
+				nonExistent := filepath.Join(tmpDir, "workspace", "nested")
+				return nonExistent, func() { os.RemoveAll(tmpDir) }
+			},
+			verifyResult: func(t *testing.T, server *Server) {
+				assert.NotNil(t, server)
+				assert.True(t, filepath.IsAbs(server.workspaceDir))
+				// Directory must have been created by setWorkspace
+				info, err := os.Stat(server.workspaceDir)
+				assert.NoError(t, err, "workspace directory should exist after NewServer")
+				assert.True(t, info.IsDir())
+			},
+		},
+		{
 			name: "with relative path workspace",
 			setupWorkDir: func(t *testing.T) (string, func()) {
 				tmpDir, err := os.MkdirTemp("", "picod-server-test-*")


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When picod is started with `--workspace` set to a directory other than `/root` (e.g. `--workspace=/workspace`), two problems occur:

1. The workspace directory is never created — `setWorkspace` only resolves the path but never calls `os.MkdirAll`, so if the directory doesn't exist the container starts but all file and execution operations fail immediately.

2. When a client sends an execute request without an explicit `working_dir`, the command runs in the picod process's current working directory instead of the configured workspace, causing unexpected behavior depending on how the container is launched.

**Changes:**
- `setWorkspace` (`files.go`) now calls `os.MkdirAll` to create the workspace directory (including any parent directories) if it does not already exist, and returns an error on failure
- `NewServer` (`server.go`) handles the error from `setWorkspace` and calls `klog.Fatalf` if workspace initialization fails
- `ExecuteHandler` (`execute.go`) defaults `cmd.Dir` to `s.workspaceDir` when no `working_dir` is provided in the request; also auto-creates the requested subdirectory with `os.MkdirAll` so users do not need to pre-create subdirectories before executing inside them

**Which issue(s) this PR fixes**:
Fixes #154

**Special notes for your reviewer**:

The `TestSanitizePath` failure visible in local macOS runs is a pre-existing issue (present on `main` before this PR) caused by macOS `/tmp` → `/private/tmp` symlink resolution. It does not affect Linux CI and is unrelated to these changes.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed picod failing to execute code when `--workspace` is set to a directory other than `/root`. The workspace directory is now created automatically at startup, and commands default to running inside the workspace when no working directory is specified in the request.
```

