### PR TITLE
fix: skip redis.Nil in pipeline Exec to prevent GC batch abort on orphaned zset entries

### DIFF
--- a/pkg/store/store_redis.go
+++ b/pkg/store/store_redis.go
@@ -89,7 +89,7 @@ func (rs *redisStore) loadSandboxesBySessionIDs(ctx context.Context, sessionIDs 
 		sandboxCommands[i] = pipe.Get(ctx, sessionKey)
 	}
 	_, pipeErr := pipe.Exec(ctx)
-	if pipeErr != nil {
+	if pipeErr != nil && !errors.Is(pipeErr, redisv9.Nil) {
 		return nil, fmt.Errorf("redis pipeline exec failed: %w", pipeErr)
 	}
 

--- a/pkg/store/store_redis_test.go
+++ b/pkg/store/store_redis_test.go
@@ -240,6 +240,44 @@ func TestListInactiveSandboxes(t *testing.T) {
 	}
 }
 
+// TestLoadSandboxesBySessionIDs_OrphanedZSetEntry verifies that
+// loadSandboxesBySessionIDs skips session IDs whose hash key has been evicted
+// from Redis (orphaned sorted-set entry) instead of aborting the entire batch.
+//
+// This scenario occurs in production when Redis evicts hash keys under memory
+// pressure (allkeys-lru policy) while leaving sorted-set index entries intact,
+// causing garbage collection to fail for the whole batch.
+func TestLoadSandboxesBySessionIDs_OrphanedZSetEntry(t *testing.T) {
+	ctx := context.Background()
+	c, mr := newTestRedisClient(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	sb1 := newTestSandbox("sb-orphan", "sess-orphan", now.Add(-1*time.Hour))
+	sb2 := newTestSandbox("sb-alive", "sess-alive", now.Add(-2*time.Hour))
+
+	if err := c.StoreSandbox(ctx, sb1); err != nil {
+		t.Fatalf("StoreSandbox sb1 error: %v", err)
+	}
+	if err := c.StoreSandbox(ctx, sb2); err != nil {
+		t.Fatalf("StoreSandbox sb2 error: %v", err)
+	}
+
+	// Simulate Redis evicting the hash key for sb1 while leaving its zset entry.
+	mr.Del(c.sessionKey("sess-orphan"))
+
+	result, err := c.loadSandboxesBySessionIDs(ctx, []string{"sess-orphan", "sess-alive"})
+	if err != nil {
+		t.Fatalf("expected no error with orphaned zset entry, got: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 sandbox (the non-evicted one), got %d", len(result))
+	}
+	if result[0].SandboxID != "sb-alive" {
+		t.Fatalf("expected sb-alive, got %s", result[0].SandboxID)
+	}
+}
+
 func TestUpdateSandboxLastActivity(t *testing.T) {
 	ctx := context.Background()
 	c, mr := newTestRedisClient(t)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`loadSandboxesBySessionIDs` uses a Redis pipeline to batch-fetch session hash
keys. `go-redis/v9` `Pipeline.Exec` returns the first error from any queued
command — including `redis.Nil` for a missing key. The existing early-return on
`pipeErr != nil` fired before the per-command loop that correctly skipped
missing keys with `continue`, causing the entire GC batch to be aborted
whenever any session's hash key was absent.

In production this surfaces when Redis evicts hash keys under memory pressure
(`allkeys-lru`) while leaving sorted-set index entries intact. Every subsequent
GC batch that includes those orphaned entries fails, preventing expired and idle
sandboxes from being cleaned up and causing orphaned index entries to accumulate
indefinitely.

Fix: guard the early return with `!errors.Is(pipeErr, redisv9.Nil)` so only
real errors (network failures, etc.) abort the batch. Missing keys continue to
be skipped per-command as intended. A regression test using `miniredis` is
included that directly reproduces the failure.

**Which issue(s) this PR fixes**:
Fixes #279 

**Special notes for your reviewer**:

The valkey store (`store_valkey.go`) uses `MGET` which returns empty strings for
missing keys and is not affected by this bug.

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a bug where Redis LRU eviction of session hash keys caused garbage
collection to silently skip entire batches of expired/idle sandboxes.