### PR TITLE
fix: skip redis.Nil in pipeline exec to prevent GC list failures when a session key is concurrently deleted

### DIFF
--- a/pkg/store/store_redis.go
+++ b/pkg/store/store_redis.go
@@ -89,7 +89,8 @@ func (rs *redisStore) loadSandboxesBySessionIDs(ctx context.Context, sessionIDs 
 		sandboxCommands[i] = pipe.Get(ctx, sessionKey)
 	}
 	_, pipeErr := pipe.Exec(ctx)
-	if pipeErr != nil {
+	// redis.Nil means a GET found no key (concurrent delete); skip it, the per-command loop handles it.
+	if pipeErr != nil && !errors.Is(pipeErr, redisv9.Nil) {
 		return nil, fmt.Errorf("redis pipeline exec failed: %w", pipeErr)
 	}
 

--- a/pkg/store/store_redis_test.go
+++ b/pkg/store/store_redis_test.go
@@ -183,6 +183,43 @@ func TestListExpiredSandboxes(t *testing.T) {
 	}
 }
 
+// TestListExpiredSandboxes_MissingKey verifies that ListExpiredSandboxes
+// gracefully skips session IDs whose data key was concurrently deleted
+// (e.g. by a parallel GC run) between the sorted-set scan and the GET pipeline.
+// Previously, the pipeline's redis.Nil would surface as a fatal error and
+// prevent any sandboxes from being returned.
+func TestListExpiredSandboxes_MissingKey(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	ctx := context.Background()
+	c, mr := newTestRedisClient(t)
+
+	sb1 := newTestSandbox("sb-1", "sess-1", now.Add(-2*time.Hour))
+	sb2 := newTestSandbox("sb-2", "sess-2", now.Add(-1*time.Hour))
+
+	if err := c.StoreSandbox(ctx, sb1); err != nil {
+		t.Fatalf("StoreSandbox sb1: %v", err)
+	}
+	if err := c.StoreSandbox(ctx, sb2); err != nil {
+		t.Fatalf("StoreSandbox sb2: %v", err)
+	}
+
+	// Simulate a concurrent delete: remove the session data key for sess-1
+	// but leave its entry in the expiry sorted set (the race window).
+	mr.Del(c.sessionKey("sess-1"))
+
+	// Should return sb2 without error; sb1's missing key is skipped gracefully.
+	list, err := c.ListExpiredSandboxes(ctx, now, 10)
+	if err != nil {
+		t.Fatalf("ListExpiredSandboxes returned unexpected error: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 sandbox, got %d", len(list))
+	}
+	if list[0].SandboxID != "sb-2" {
+		t.Fatalf("expected sb-2, got %s", list[0].SandboxID)
+	}
+}
+
 func TestListInactiveSandboxes(t *testing.T) {
 	ctx := context.Background()
 	c, _ := newTestRedisClient(t)

--- a/pkg/store/store_redis_test.go
+++ b/pkg/store/store_redis_test.go
@@ -220,6 +220,26 @@ func TestListExpiredSandboxes_MissingKey(t *testing.T) {
 	}
 }
 
+// TestLoadSandboxesBySessionIDs_PipelineError verifies that a genuine pipeline
+// failure (not redis.Nil) is still surfaced as an error.
+func TestLoadSandboxesBySessionIDs_PipelineError(t *testing.T) {
+	ctx := context.Background()
+	c, mr := newTestRedisClient(t)
+
+	sb := newTestSandbox("sb-1", "sess-1", time.Now().Add(time.Hour))
+	if err := c.StoreSandbox(ctx, sb); err != nil {
+		t.Fatalf("StoreSandbox: %v", err)
+	}
+
+	// Close miniredis to force a real connection error (not redis.Nil) in the pipeline.
+	mr.Close()
+
+	_, err := c.loadSandboxesBySessionIDs(ctx, []string{"sess-1"})
+	if err == nil {
+		t.Fatal("expected error from closed redis, got nil")
+	}
+}
+
 func TestListInactiveSandboxes(t *testing.T) {
 	ctx := context.Background()
 	c, _ := newTestRedisClient(t)


### PR DESCRIPTION
/kind bug

## What this PR does / why we need it

`Pipeline.Exec()` in go-redis v9 returns the first non-nil error from any command, which includes `redis.Nil` when a `GET` hits a missing key. In `loadSandboxesBySessionIDs`, the pipeline-level error check was firing on `redis.Nil` and returning early — before the per-command loop (which already handles `redis.Nil` via `continue`) could run.

This caused both `ListExpiredSandboxes` and `ListInactiveSandboxes` to return an error and zero results whenever a session key was concurrently deleted between the sorted-set scan and the GET pipeline. A realistic race: `DeleteSandboxBySessionID` uses a non-atomic pipeline, so a parallel GC run can remove the key while its sorted-set entry is still visible. The net effect was the garbage collector silently doing nothing and expired/inactive sandboxes accumulating.

## Code Change (`pkg/store/store_redis.go`)

```go
// Before
_, pipeErr := pipe.Exec(ctx)
if pipeErr != nil {
    return nil, fmt.Errorf("redis pipeline exec failed: %w", pipeErr)
}

// After
_, pipeErr := pipe.Exec(ctx)
// redis.Nil means a GET found no key (concurrent delete); skip it, the per-command loop handles it.
if pipeErr != nil && !errors.Is(pipeErr, redisv9.Nil) {
    return nil, fmt.Errorf("redis pipeline exec failed: %w", pipeErr)
}
```

## Which issue(s) this PR fixes

None — self-contained bug found during code review.

## Special notes for reviewer

`TestListExpiredSandboxes_MissingKey` reproduces the race exactly: stores two sandboxes, manually deletes one session key while leaving its sorted-set entry intact, then asserts the list returns the remaining sandbox without error. This test fails against the previous code.

## Release Note

```release-note
Fix Redis store GC silently skipping all expired/inactive sandbox cleanup when any session key is concurrently deleted
```
