### PR TITLE
feat(mcp): add MCP server for AgentCube Code Interpreter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,7 @@ install: build
 WORKLOAD_MANAGER_IMAGE ?= workloadmanager:latest
 ROUTER_IMAGE ?= agentcube-router:latest
 PICOD_IMAGE ?= picod:latest
+MCP_SERVER_IMAGE ?= agentcube-mcp-server:latest
 IMAGE_REGISTRY ?= ""
 
 # Docker and Kubernetes targets
@@ -259,6 +260,17 @@ docker-push-picod: docker-build-picod
 	@echo "Tagging and pushing Picod Docker image to $(IMAGE_REGISTRY)/$(PICOD_IMAGE)..."
 	docker tag $(PICOD_IMAGE) $(IMAGE_REGISTRY)/$(PICOD_IMAGE)
 	docker push $(IMAGE_REGISTRY)/$(PICOD_IMAGE)
+
+
+# MCP Docker targets
+docker-build-mcp:
+	@echo "Building MCP Server Docker image..."
+	docker build -f docker/Dockerfile.mcp -t $(MCP_SERVER_IMAGE) .
+
+# Load MCP image to kind cluster
+kind-load-mcp:
+	@echo "Loading MCP server image to kind..."
+	kind load docker-image $(MCP_SERVER_IMAGE)
 
 
 ##@ Dependencies

--- a/docker/Dockerfile.mcp
+++ b/docker/Dockerfile.mcp
@@ -1,0 +1,24 @@
+# Dockerfile for AgentCube MCP Server
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Copy SDK source
+COPY sdk-python/ /app/sdk-python/
+
+# Install SDK and dependencies
+RUN pip install --no-cache-dir ./sdk-python
+
+# Set environment variables (defaults)
+ENV WORKLOAD_MANAGER_URL="http://workloadmanager.agentcube.svc.cluster.local:8080"
+ENV ROUTER_URL="http://agentcube-router.agentcube.svc.cluster.local:8080"
+ENV NAMESPACE="agentcube"
+
+# Expose port for HTTP transport if used
+EXPOSE 8000
+
+# Run MCP server
+# By default it runs in stdio mode. For K8s, we might want HTTP transport
+# or we can use stdio if we are running as a sidecar/interactive pod.
+# However, usually MCP servers in K8s are best served via HTTP if they are shared.
+ENTRYPOINT ["python", "-m", "agentcube.mcp_server"]

--- a/docs/agentcube/docs/tutorials/mcp-integration.md
+++ b/docs/agentcube/docs/tutorials/mcp-integration.md
@@ -1,0 +1,115 @@
+---
+sidebar_position: 5
+title: MCP Client Integrations
+---
+
+# Integrating AgentCube MCP Server with AI Agents
+
+The AgentCube Python SDK provides an implementation of a Model Context Protocol (MCP) server. This server exposes the remote code execution and file management functionalities to any AI agent that supports the MCP standard, effectively giving these AI agents sandboxed execution environments, rather than having them run code directly on your local machine.
+
+Below are examples of how to integrate the AgentCube MCP Server with popular AI agents: Claude Desktop, Cursor, and OpenHands (formerly OpenDevin).
+
+## Prerequisites
+
+Before configuring the agents, ensure that:
+1. You have installed the AgentCube Python SDK (`pip install agentcube`).
+2. You have your AgentCube environment variables ready (`WORKLOAD_MANAGER_URL`, `ROUTER_URL`, `AUTH_TOKEN`, etc.).
+3. Python 3 is accessible from the command line environments of the agents.
+
+## 1. Claude Desktop Integration
+
+Claude Desktop natively supports reading MCP server configurations from its config file.
+
+**Configuration File Location:**
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Add the following configuration, replacing the environment variable values with your specific AgentCube endpoints:
+
+```json
+{
+  "mcpServers": {
+    "agentcube-code-interpreter": {
+      "command": "python3",
+      "args": [
+        "-m",
+        "agentcube.mcp_server",
+        "--name",
+        "my-claude-workspace",
+        "--transport",
+        "stdio"
+      ],
+      "env": {
+        "WORKLOAD_MANAGER_URL": "http://<workload-manager-host>:<port>",
+        "ROUTER_URL": "http://<router-host>:<port>",
+        "AUTH_TOKEN": "your-auth-token"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop. You will now see tools like `run_code`, `execute_command`, `read_file`, and `write_file` available with the AgentCube icon, indicating they are running in the secure AgentCube sandbox.
+
+## 2. Cursor Integration
+
+Cursor integrates with MCP servers in its settings menu.
+
+1. Open Cursor Settings.
+2. Navigate to **Features** -> **MCP**.
+3. Click **Add New MCP Server**.
+4. Set the following fields:
+   - **Name**: `AgentCube`
+   - **Type**: `command`
+   - **Command**: `python3 -m agentcube.mcp_server --transport stdio`
+5. Since Cursor executes the command in your local environment, you need to ensure the environment variables are exposed where Cursor is launched, or wrap the startup in a shell script:
+
+**AgentCube-Cursor Startup Script (`start_agentcube_mcp.sh`):**
+
+```bash
+#!/bin/bash
+export WORKLOAD_MANAGER_URL="http://<workload-manager-host>:<port>"
+export ROUTER_URL="http://<router-host>:<port>"
+export AUTH_TOKEN="your-auth-token"
+
+# Start the AgentCube MCP server
+python3 -m agentcube.mcp_server --transport stdio
+```
+
+Make the script executable (`chmod +x start_agentcube_mcp.sh`), and in Cursor's **Command** field, point to this script: `/path/to/start_agentcube_mcp.sh`.
+
+## 3. OpenHands (OpenClaw) Integration
+
+OpenHands and other general CLI agents can interact with AgentCube's MCP server via standard configurations or initialization command line arguments.
+
+By default, the AgentCube MCP server supports HTTP/SSE transport. You can spin up the MCP server as a standalone process and have OpenHands connect to it:
+
+### Start the Server
+
+```bash
+export WORKLOAD_MANAGER_URL="http://<workload-manager-host>:<port>"
+export ROUTER_URL="http://<router-host>:<port>"
+
+# Start via HTTP
+python3 -m agentcube.mcp_server --transport streamable-http --port 8000
+```
+
+### Connect OpenHands
+
+You can configure OpenHands to use standard HTTP MCP connections. In your `config.toml` or via the respective MCP arguments in OpenHands, reference `http://127.0.0.1:8000`.
+
+*Note: For `stdio` connection in OpenHands or similar CLI agents, you would configure the tool executing command similar to Claude Desktop.*
+
+## 4. Claude Code (CLI) Integration
+
+For the Claude CLI wrapper (`claude` tool from Anthropic):
+
+You can configure the MCP servers using the `mcp-servers.json` or by passing the server command directly.
+
+```bash
+claude config add mcp-server agentcube "python3 -m agentcube.mcp_server --transport stdio"
+```
+
+*Ensure the environment variables (`WORKLOAD_MANAGER_URL`, etc.) are exported in the terminal where you run `claude`.*
+
+When using Claude CLI with this configuration, you can prompt: "Write a python script to parse a CSV and execute it." The AI will utilize AgentCube rather than running code on your physical workstation.

--- a/manifests/mcp-server/README.md
+++ b/manifests/mcp-server/README.md
@@ -1,0 +1,52 @@
+# AgentCube MCP Server Deployment
+
+This directory contains manifests for deploying the AgentCube MCP Server in Kubernetes.
+
+## Prerequisites
+
+- AgentCube cluster (WorkloadManager and Router) should be running.
+- The `agentcube-mcp-server` image should be built and available in your registry (or loaded into Kind).
+
+To build the image:
+```bash
+make docker-build-mcp
+```
+
+## Deployment Options
+
+### 1. Kubernetes Deployment
+
+Apply the deployment manifest:
+
+```bash
+kubectl apply -f deployment.yaml
+```
+
+This will create a Deployment and a Service for the MCP server. The server will be accessible at `http://agentcube-mcp-server.agentcube.svc.cluster.local:8000`.
+
+#### Configuration
+
+The following environment variables can be configured in `deployment.yaml`:
+
+- `WORKLOAD_MANAGER_URL`: URL of the AgentCube WorkloadManager.
+- `ROUTER_URL`: URL of the AgentCube Router.
+- `NAMESPACE`: Kubernetes namespace where AgentCube is running.
+- `AUTH_TOKEN`: (Optional) Auth token for Kubernetes/WorkloadManager.
+
+### 2. Local Deployment
+
+You can run the MCP server locally using the Python SDK:
+
+```bash
+cd sdk-python
+pip install -e .
+python -m agentcube.mcp_server
+```
+
+By default, it uses `stdio` transport. You can also run it with `streamable-http` transport:
+
+```bash
+python -m agentcube.mcp_server --transport streamable-http --port 8000
+```
+
+Ensure `WORKLOAD_MANAGER_URL` and `ROUTER_URL` are set in your environment or passed as arguments if running programmatically.

--- a/manifests/mcp-server/deployment.yaml
+++ b/manifests/mcp-server/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agentcube-mcp-server
+  namespace: agentcube
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: agentcube-mcp-server
+  template:
+    metadata:
+      labels:
+        app: agentcube-mcp-server
+    spec:
+      containers:
+      - name: mcp-server
+        image: agentcube-mcp-server:latest
+        imagePullPolicy: IfNotPresent
+        args:
+        - "--transport"
+        - "streamable-http"
+        - "--port"
+        - "8000"
+        - "--host"
+        - "0.0.0.0"
+        ports:
+        - containerPort: 8000
+          name: http
+        env:
+        - name: WORKLOAD_MANAGER_URL
+          value: "http://workloadmanager.agentcube.svc.cluster.local:8080"
+        - name: ROUTER_URL
+          value: "http://agentcube-router.agentcube.svc.cluster.local:8080"
+        - name: NAMESPACE
+          value: "agentcube"
+        - name: AUTH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: agentcube-mcp-token
+              key: token
+              optional: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: agentcube-mcp-server
+  namespace: agentcube
+spec:
+  selector:
+    app: agentcube-mcp-server
+  ports:
+  - port: 8000
+    targetPort: 8000
+    name: http

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -112,6 +112,41 @@ client2.run_code("python", "print(open('value.txt').read())")  # File persists
 client2.stop()  # Cleanup when done
 ```
 
+## MCP Server Integration
+
+The SDK includes a built-in [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server. This allows AI agents (like Claude Desktop, Cursor, Copilot, Codex, OpenHands/OpenClaw, etc.) to securely execute code in an AgentCube sandbox instance.
+
+You can run the MCP server natively via:
+
+```bash
+python -m agentcube.mcp_server --transport stdio
+```
+
+For comprehensive examples and configuration guides for popular AI agents, see our [MCP Integration Tutorial](../../docs/agentcube/docs/tutorials/mcp-integration.md) or explore the AI agent integration snippets below.
+
+### Examples
+
+**Claude Config (`claude_desktop_config.json`):**
+```json
+{
+  "mcpServers": {
+    "agentcube": {
+      "command": "python3",
+      "args": ["-m", "agentcube.mcp_server", "--transport", "stdio"],
+      "env": {
+        "WORKLOAD_MANAGER_URL": "http://<wlm-host>:8080",
+        "ROUTER_URL": "http://<router-host>:8081"
+      }
+    }
+  }
+}
+```
+
+**Cursor/Claude Code CLI:**
+```bash
+claude config add mcp-server agentcube "python3 -m agentcube.mcp_server --transport stdio"
+```
+
 ## Development
 
 ```bash

--- a/sdk-python/agentcube/__init__.py
+++ b/sdk-python/agentcube/__init__.py
@@ -14,5 +14,6 @@
 
 from .code_interpreter import CodeInterpreterClient
 from .agent_runtime import AgentRuntimeClient
+from .mcp_server import create_mcp_server
 
-__all__ = ["CodeInterpreterClient", "AgentRuntimeClient"]
+__all__ = ["CodeInterpreterClient", "AgentRuntimeClient", "create_mcp_server"]

--- a/sdk-python/agentcube/mcp_server.py
+++ b/sdk-python/agentcube/mcp_server.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+from contextlib import asynccontextmanager
 from typing import Optional
 
 from mcp.server.fastmcp import FastMCP
@@ -65,8 +66,6 @@ def create_mcp_server(
     Returns:
         A FastMCP server instance.
     """
-    mcp = FastMCP(name, json_response=True)
-
     workload_manager_url = workload_manager_url or os.getenv("WORKLOAD_MANAGER_URL")
     router_url = router_url or os.getenv("ROUTER_URL")
     auth_token = auth_token or os.getenv("AUTH_TOKEN")
@@ -87,18 +86,21 @@ def create_mcp_server(
             )
         return _client
 
-    @mcp.on_startup()
-    def on_startup():
-        """Initialize the Code Interpreter client on server startup."""
+    @asynccontextmanager
+    async def lifespan(server: FastMCP):
+        """Manage the Code Interpreter session lifespan."""
+        # Initialize client on startup
         get_client()
+        try:
+            yield
+        finally:
+            # Clean up on shutdown
+            nonlocal _client
+            if _client:
+                _client.stop()
+                _client = None
 
-    @mcp.on_shutdown()
-    def on_shutdown():
-        """Clean up the Code Interpreter session on server shutdown."""
-        nonlocal _client
-        if _client:
-            _client.stop()
-            _client = None
+    mcp = FastMCP(name, json_response=True, lifespan=lifespan)
 
     @mcp.tool()
     def run_code(language: str, code: str, timeout: Optional[float] = None) -> str:

--- a/sdk-python/agentcube/mcp_server.py
+++ b/sdk-python/agentcube/mcp_server.py
@@ -71,15 +71,20 @@ def create_mcp_server(
     router_url = router_url or os.getenv("ROUTER_URL")
     auth_token = auth_token or os.getenv("AUTH_TOKEN")
 
+    _client: Optional[CodeInterpreterClient] = None
+
     def get_client() -> CodeInterpreterClient:
-        return CodeInterpreterClient(
-            name=name,
-            namespace=namespace,
-            ttl=ttl,
-            workload_manager_url=workload_manager_url,
-            router_url=router_url,
-            auth_token=auth_token,
-        )
+        nonlocal _client
+        if _client is None:
+            _client = CodeInterpreterClient(
+                name=name,
+                namespace=namespace,
+                ttl=ttl,
+                workload_manager_url=workload_manager_url,
+                router_url=router_url,
+                auth_token=auth_token,
+            )
+        return _client
 
     @mcp.tool()
     def run_code(language: str, code: str, timeout: Optional[float] = None) -> str:
@@ -94,8 +99,8 @@ def create_mcp_server(
         Returns:
             The stdout output from the code execution.
         """
-        with get_client() as client:
-            return client.run_code(language, code, timeout)
+        client = get_client()
+        return client.run_code(language, code, timeout)
 
     @mcp.tool()
     def execute_command(command: str, timeout: Optional[float] = None) -> str:
@@ -109,8 +114,8 @@ def create_mcp_server(
         Returns:
             The stdout output from the command.
         """
-        with get_client() as client:
-            return client.execute_command(command, timeout)
+        client = get_client()
+        return client.execute_command(command, timeout)
 
     @mcp.tool()
     def write_file(content: str, remote_path: str) -> str:
@@ -124,9 +129,9 @@ def create_mcp_server(
         Returns:
             Success message with the file path.
         """
-        with get_client() as client:
-            client.write_file(content, remote_path)
-            return f"Successfully wrote to {remote_path}"
+        client = get_client()
+        client.write_file(content, remote_path)
+        return f"Successfully wrote to {remote_path}"
 
     @mcp.tool()
     def upload_file(local_path: str, remote_path: str) -> str:
@@ -140,9 +145,9 @@ def create_mcp_server(
         Returns:
             Success message with the file paths.
         """
-        with get_client() as client:
-            client.upload_file(local_path, remote_path)
-            return f"Successfully uploaded {local_path} to {remote_path}"
+        client = get_client()
+        client.upload_file(local_path, remote_path)
+        return f"Successfully uploaded {local_path} to {remote_path}"
 
     @mcp.tool()
     def download_file(remote_path: str, local_path: str) -> str:
@@ -156,9 +161,9 @@ def create_mcp_server(
         Returns:
             Success message with the file paths.
         """
-        with get_client() as client:
-            client.download_file(remote_path, local_path)
-            return f"Successfully downloaded {remote_path} to {local_path}"
+        client = get_client()
+        client.download_file(remote_path, local_path)
+        return f"Successfully downloaded {remote_path} to {local_path}"
 
     @mcp.tool()
     def list_files(path: str = ".") -> str:
@@ -171,9 +176,9 @@ def create_mcp_server(
         Returns:
             JSON string of file entries.
         """
-        with get_client() as client:
-            files = client.list_files(path)
-            return json.dumps(files, default=str)
+        client = get_client()
+        files = client.list_files(path)
+        return json.dumps(files, default=str)
 
     @mcp.resource("workspace://{path}")
     def get_file(path: str) -> str:
@@ -186,16 +191,16 @@ def create_mcp_server(
         Returns:
             The file content as a string.
         """
-        with get_client() as client:
-            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt') as tmp:
-                tmp_path = tmp.name
-            try:
-                client.download_file(path, tmp_path)
-                with open(tmp_path, 'r') as f:
-                    return f.read()
-            finally:
-                if os.path.exists(tmp_path):
-                    os.remove(tmp_path)
+        client = get_client()
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt') as tmp:
+            tmp_path = tmp.name
+        try:
+            client.download_file(path, tmp_path)
+            with open(tmp_path, 'r') as f:
+                return f.read()
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
 
     return mcp
 

--- a/sdk-python/agentcube/mcp_server.py
+++ b/sdk-python/agentcube/mcp_server.py
@@ -33,19 +33,14 @@ Usage:
 
 from __future__ import annotations
 
-import os
-import sys
 import json
+import os
 import tempfile
-import base64
-import shutil
 from typing import Optional
-from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
 
 from agentcube.code_interpreter import CodeInterpreterClient
-from agentcube.exceptions import CommandExecutionError
 
 
 def create_mcp_server(

--- a/sdk-python/agentcube/mcp_server.py
+++ b/sdk-python/agentcube/mcp_server.py
@@ -1,0 +1,261 @@
+# Copyright The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+MCP Server for AgentCube Code Interpreter.
+
+This module provides an MCP (Model Context Protocol) server that exposes
+AgentCube Code Interpreter functionality as MCP tools.
+
+Usage:
+    # Run as stdio server
+    python -m agentcube.mcp_server
+
+    # Run as HTTP server
+    python -m agentcube.mcp_server --transport streamable-http --port 8000
+
+    # Or programmatically
+    from agentcube.mcp_server import create_mcp_server
+    server = create_mcp_server()
+    server.run(transport="streamable-http", port=8000)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import json
+import tempfile
+import base64
+import shutil
+from typing import Optional
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+from agentcube.code_interpreter import CodeInterpreterClient
+from agentcube.exceptions import CommandExecutionError
+
+
+def create_mcp_server(
+    name: str = "agentcube-code-interpreter",
+    workload_manager_url: Optional[str] = None,
+    router_url: Optional[str] = None,
+    auth_token: Optional[str] = None,
+    namespace: str = "default",
+    ttl: int = 3600,
+) -> FastMCP:
+    """
+    Create an MCP server for AgentCube Code Interpreter.
+
+    Args:
+        name: Name of the CodeInterpreter template (CRD name).
+        workload_manager_url: URL of WorkloadManager (Control Plane).
+        router_url: URL of Router (Data Plane).
+        auth_token: Auth token for Kubernetes/WorkloadManager.
+        namespace: Kubernetes namespace.
+        ttl: Time to live (seconds) for sessions.
+
+    Returns:
+        A FastMCP server instance.
+    """
+    mcp = FastMCP(name, json_response=True)
+
+    workload_manager_url = workload_manager_url or os.getenv("WORKLOAD_MANAGER_URL")
+    router_url = router_url or os.getenv("ROUTER_URL")
+    auth_token = auth_token or os.getenv("AUTH_TOKEN")
+
+    def get_client() -> CodeInterpreterClient:
+        return CodeInterpreterClient(
+            name=name,
+            namespace=namespace,
+            ttl=ttl,
+            workload_manager_url=workload_manager_url,
+            router_url=router_url,
+            auth_token=auth_token,
+        )
+
+    @mcp.tool()
+    def run_code(language: str, code: str, timeout: Optional[float] = None) -> str:
+        """
+        Execute a code snippet in the remote code interpreter environment.
+
+        Args:
+            language: Programming language (python, bash, sh).
+            code: The code to execute.
+            timeout: Optional execution timeout in seconds.
+
+        Returns:
+            The stdout output from the code execution.
+        """
+        with get_client() as client:
+            return client.run_code(language, code, timeout)
+
+    @mcp.tool()
+    def execute_command(command: str, timeout: Optional[float] = None) -> str:
+        """
+        Execute a shell command in the remote code interpreter environment.
+
+        Args:
+            command: The shell command to execute.
+            timeout: Optional execution timeout in seconds.
+
+        Returns:
+            The stdout output from the command.
+        """
+        with get_client() as client:
+            return client.execute_command(command, timeout)
+
+    @mcp.tool()
+    def write_file(content: str, remote_path: str) -> str:
+        """
+        Write content to a file in the remote code interpreter environment.
+
+        Args:
+            content: The content to write to the file.
+            remote_path: The destination path in the remote environment.
+
+        Returns:
+            Success message with the file path.
+        """
+        with get_client() as client:
+            client.write_file(content, remote_path)
+            return f"Successfully wrote to {remote_path}"
+
+    @mcp.tool()
+    def upload_file(local_path: str, remote_path: str) -> str:
+        """
+        Upload a local file to the remote code interpreter environment.
+
+        Args:
+            local_path: Path to the local file.
+            remote_path: Destination path in the remote environment.
+
+        Returns:
+            Success message with the file paths.
+        """
+        with get_client() as client:
+            client.upload_file(local_path, remote_path)
+            return f"Successfully uploaded {local_path} to {remote_path}"
+
+    @mcp.tool()
+    def download_file(remote_path: str, local_path: str) -> str:
+        """
+        Download a file from the remote code interpreter environment.
+
+        Args:
+            remote_path: Path to the file in the remote environment.
+            local_path: Local destination path.
+
+        Returns:
+            Success message with the file paths.
+        """
+        with get_client() as client:
+            client.download_file(remote_path, local_path)
+            return f"Successfully downloaded {remote_path} to {local_path}"
+
+    @mcp.tool()
+    def list_files(path: str = ".") -> str:
+        """
+        List files and directories in the remote code interpreter environment.
+
+        Args:
+            path: The directory path to list. Defaults to ".".
+
+        Returns:
+            JSON string of file entries.
+        """
+        with get_client() as client:
+            files = client.list_files(path)
+            return json.dumps(files, default=str)
+
+    @mcp.resource("workspace://{path}")
+    def get_file(path: str) -> str:
+        """
+        Read a file from the remote code interpreter environment.
+
+        Args:
+            path: The file path to read.
+
+        Returns:
+            The file content as a string.
+        """
+        with get_client() as client:
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt') as tmp:
+                tmp_path = tmp.name
+            try:
+                client.download_file(path, tmp_path)
+                with open(tmp_path, 'r') as f:
+                    return f.read()
+            finally:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+
+    return mcp
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="AgentCube Code Interpreter MCP Server")
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "streamable-http"],
+        default="stdio",
+        help="Transport type (default: stdio)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port for HTTP transport (default: 8000)",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host for HTTP transport (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--name",
+        default="agentcube-code-interpreter",
+        help="MCP server name",
+    )
+    parser.add_argument(
+        "--namespace",
+        default="default",
+        help="Kubernetes namespace",
+    )
+    parser.add_argument(
+        "--ttl",
+        type=int,
+        default=3600,
+        help="Session TTL in seconds",
+    )
+
+    args = parser.parse_args()
+
+    mcp = create_mcp_server(
+        name=args.name,
+        namespace=args.namespace,
+        ttl=args.ttl,
+    )
+
+    if args.transport == "streamable-http":
+        mcp.run(transport="streamable-http", host=args.host, port=args.port)
+    else:
+        mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk-python/agentcube/mcp_server.py
+++ b/sdk-python/agentcube/mcp_server.py
@@ -83,8 +83,22 @@ def create_mcp_server(
                 workload_manager_url=workload_manager_url,
                 router_url=router_url,
                 auth_token=auth_token,
+                session_id=os.getenv("AGENTCUBE_SESSION_ID"),
             )
         return _client
+
+    @mcp.on_startup()
+    def on_startup():
+        """Initialize the Code Interpreter client on server startup."""
+        get_client()
+
+    @mcp.on_shutdown()
+    def on_shutdown():
+        """Clean up the Code Interpreter session on server shutdown."""
+        nonlocal _client
+        if _client:
+            _client.stop()
+            _client = None
 
     @mcp.tool()
     def run_code(language: str, code: str, timeout: Optional[float] = None) -> str:

--- a/sdk-python/examples/mcp/README.md
+++ b/sdk-python/examples/mcp/README.md
@@ -1,0 +1,14 @@
+# AgentCube MCP Server Integration
+
+This folder contains examples to integrate the AgentCube MCP Server with general agent interfaces (Claude Desktop, Cursor, OpenHands, etc.).
+
+By using the MCP Server, agents can interact with AgentCube's remote, sandboxed environments.
+
+## Files
+
+- `claude_desktop_config.example.json`: Sample configuration snippet for [Claude Desktop App](https://claude.ai/download). Place this in your `~/Library/Application Support/Claude/claude_desktop_config.json` (Mac) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows).
+- `start_mcp_cursor.sh`: A wrapper shell script to define environment variables and launch the MCP server. Useful for general IDEs like [Cursor](https://www.cursor.com/) or CLI agents like [OpenHands](https://github.com/All-Hands-AI/OpenHands) where you configure a "command" MCP source.
+
+## Documentation
+
+For a full tutorial, please visit our Docusaurus documentation node: `docs/agentcube/docs/tutorials/mcp-integration.md` or check the main Python SDK `README.md`.

--- a/sdk-python/examples/mcp/claude_desktop_config.example.json
+++ b/sdk-python/examples/mcp/claude_desktop_config.example.json
@@ -1,0 +1,20 @@
+{
+  "mcpServers": {
+    "agentcube-code-interpreter": {
+      "command": "python3",
+      "args": [
+        "-m",
+        "agentcube.mcp_server",
+        "--name",
+        "default-workspace",
+        "--transport",
+        "stdio"
+      ],
+      "env": {
+        "WORKLOAD_MANAGER_URL": "http://localhost:8080",
+        "ROUTER_URL": "http://localhost:8081",
+        "AUTH_TOKEN": "your-optional-token"
+      }
+    }
+  }
+}

--- a/sdk-python/examples/mcp/start_mcp_cursor.sh
+++ b/sdk-python/examples/mcp/start_mcp_cursor.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# 
+# AgentCube MCP Server Startup Script for generic CLI agents (e.g., Cursor, OpenHands)
+# 
+# Usage: 
+# Point your agent's MCP setup to this script as a "command" type.
+# e.g., command: /path/to/agentcube/sdk-python/examples/mcp/start_mcp_cursor.sh
+
+# 1. Provide your environment variables
+export WORKLOAD_MANAGER_URL="http://127.0.0.1:8080"
+export ROUTER_URL="http://127.0.0.1:8081"
+export AUTH_TOKEN="optional-auth-token-if-needed"
+
+# 2. Run the MCP server
+# Make sure python3 is in your path and agentcube package is installed (`pip install agentcube`)
+exec python3 -m agentcube.mcp_server --transport stdio --name agentcube-sandbox

--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -13,7 +13,8 @@ requires-python = ">=3.10"
 dependencies = [
     "requests",
     "PyJWT>=2.0.0",
-    "cryptography"
+    "cryptography",
+    "mcp>=1.0.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/sdk-python/requirements.txt
+++ b/sdk-python/requirements.txt
@@ -1,3 +1,4 @@
 requests
 PyJWT>=2.0.0
 cryptography
+mcp>=1.0.0

--- a/sdk-python/tests/test_mcp_server.py
+++ b/sdk-python/tests/test_mcp_server.py
@@ -95,8 +95,7 @@ class TestMCPServerToolsRegistered(unittest.TestCase):
     def test_list_tools_returns_tool_list(self, mock_class):
         """Test list_tools returns a list of tools."""
         mock_client = MagicMock()
-        mock_class.return_value.__enter__ = MagicMock(return_value=mock_client)
-        mock_class.return_value.__exit__ = MagicMock(return_value=False)
+        mock_class.return_value = mock_client
 
         from agentcube.mcp_server import create_mcp_server
         mcp = create_mcp_server(name="test")
@@ -120,8 +119,7 @@ class TestMCPServerToolsRegistered(unittest.TestCase):
     def test_run_code_tool_schema(self, mock_class):
         """Test run_code tool has correct schema."""
         mock_client = MagicMock()
-        mock_class.return_value.__enter__ = MagicMock(return_value=mock_client)
-        mock_class.return_value.__exit__ = MagicMock(return_value=False)
+        mock_class.return_value = mock_client
 
         from agentcube.mcp_server import create_mcp_server
         mcp = create_mcp_server(name="test")
@@ -152,8 +150,7 @@ class TestMCPToolInvocations(unittest.TestCase):
         """Test run_code can be invoked via call_tool."""
         mock_client = MagicMock()
         mock_client.run_code.return_value = "42\n"
-        mock_class.return_value.__enter__ = MagicMock(return_value=mock_client)
-        mock_class.return_value.__exit__ = MagicMock(return_value=False)
+        mock_class.return_value = mock_client
 
         from agentcube.mcp_server import create_mcp_server
         mcp = create_mcp_server(name="test")
@@ -172,8 +169,7 @@ class TestMCPToolInvocations(unittest.TestCase):
         """Test execute_command can be invoked."""
         mock_client = MagicMock()
         mock_client.execute_command.return_value = "hello\n"
-        mock_class.return_value.__enter__ = MagicMock(return_value=mock_client)
-        mock_class.return_value.__exit__ = MagicMock(return_value=False)
+        mock_class.return_value = mock_client
 
         from agentcube.mcp_server import create_mcp_server
         mcp = create_mcp_server(name="test")
@@ -189,8 +185,7 @@ class TestMCPToolInvocations(unittest.TestCase):
     def test_write_file_invocation(self, mock_class):
         """Test write_file can be invoked."""
         mock_client = MagicMock()
-        mock_class.return_value.__enter__ = MagicMock(return_value=mock_client)
-        mock_class.return_value.__exit__ = MagicMock(return_value=False)
+        mock_class.return_value = mock_client
 
         from agentcube.mcp_server import create_mcp_server
         mcp = create_mcp_server(name="test")
@@ -209,8 +204,7 @@ class TestMCPToolInvocations(unittest.TestCase):
         mock_client.list_files.return_value = [
             {"name": "file1.py", "size": 1024, "is_dir": False}
         ]
-        mock_class.return_value.__enter__ = MagicMock(return_value=mock_client)
-        mock_class.return_value.__exit__ = MagicMock(return_value=False)
+        mock_class.return_value = mock_client
 
         from agentcube.mcp_server import create_mcp_server
         mcp = create_mcp_server(name="test")

--- a/test/e2e/test_mcp_server.py
+++ b/test/e2e/test_mcp_server.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+# Copyright The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for MCP Server module.
+
+These tests verify the MCP server functionality and structure without
+requiring a running AgentCube cluster.
+"""
+
+import json
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch, AsyncMock
+import inspect
+
+
+class TestMCPServerCreation(unittest.TestCase):
+    """Tests for MCP server creation."""
+
+    def setUp(self):
+        """Set up test environment."""
+        os.environ.setdefault("WORKLOAD_MANAGER_URL", "http://localhost:8080")
+        os.environ.setdefault("ROUTER_URL", "http://localhost:8081")
+
+    def test_server_creation(self):
+        """Test server can be created."""
+        from agentcube.mcp_server import create_mcp_server
+
+        with patch("agentcube.mcp_server.CodeInterpreterClient"):
+            mcp = create_mcp_server(name="test-ci")
+            self.assertEqual(mcp.name, "test-ci")
+
+    def test_default_server_name(self):
+        """Test default server name."""
+        from agentcube.mcp_server import create_mcp_server
+
+        with patch("agentcube.mcp_server.CodeInterpreterClient"):
+            mcp = create_mcp_server()
+            self.assertEqual(mcp.name, "agentcube-code-interpreter")
+
+    def test_custom_name(self):
+        """Test custom server name."""
+        from agentcube.mcp_server import create_mcp_server
+
+        with patch("agentcube.mcp_server.CodeInterpreterClient"):
+            mcp = create_mcp_server(name="my-server")
+            self.assertEqual(mcp.name, "my-server")
+
+    def test_create_mcp_server_signature(self):
+        """Test create_mcp_server function signature."""
+        from agentcube.mcp_server import create_mcp_server
+
+        sig = inspect.signature(create_mcp_server)
+        params = list(sig.parameters.keys())
+
+        self.assertIn("name", params)
+        self.assertIn("workload_manager_url", params)
+        self.assertIn("router_url", params)
+        self.assertIn("auth_token", params)
+        self.assertIn("namespace", params)
+        self.assertIn("ttl", params)
+
+
+class TestMCPServerToolsRegistered(unittest.TestCase):
+    """Tests to verify tools are registered on the server."""
+
+    def setUp(self):
+        """Set up test environment."""
+        os.environ.setdefault("WORKLOAD_MANAGER_URL", "http://localhost:8080")
+        os.environ.setdefault("ROUTER_URL", "http://localhost:8081")
+
+    def test_server_has_list_tools_method(self):
+        """Test server has list_tools method."""
+        from agentcube.mcp_server import create_mcp_server
+
+        with patch("agentcube.mcp_server.CodeInterpreterClient"):
+            mcp = create_mcp_server(name="test")
+            self.assertTrue(hasattr(mcp, "list_tools"))
+            self.assertTrue(callable(mcp.list_tools))
+
+    @patch("agentcube.mcp_server.CodeInterpreterClient")
+    def test_list_tools_returns_tool_list(self, mock_class):
+        """Test list_tools returns a list of tools."""
+        mock_client = MagicMock()
+        mock_class.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_class.return_value.__exit__ = MagicMock(return_value=False)
+
+        from agentcube.mcp_server import create_mcp_server
+        mcp = create_mcp_server(name="test")
+
+        async def get_tools():
+            result = await mcp.list_tools()
+            return result
+
+        import asyncio
+        tools = asyncio.get_event_loop().run_until_complete(get_tools())
+
+        tool_names = [t.name for t in tools]
+        self.assertIn("run_code", tool_names)
+        self.assertIn("execute_command", tool_names)
+        self.assertIn("write_file", tool_names)
+        self.assertIn("list_files", tool_names)
+        self.assertIn("upload_file", tool_names)
+        self.assertIn("download_file", tool_names)
+
+    @patch("agentcube.mcp_server.CodeInterpreterClient")
+    def test_run_code_tool_schema(self, mock_class):
+        """Test run_code tool has correct schema."""
+        mock_client = MagicMock()
+        mock_class.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_class.return_value.__exit__ = MagicMock(return_value=False)
+
+        from agentcube.mcp_server import create_mcp_server
+        mcp = create_mcp_server(name="test")
+
+        async def get_tools():
+            result = await mcp.list_tools()
+            return result
+
+        import asyncio
+        tools = asyncio.get_event_loop().run_until_complete(get_tools())
+
+        run_code_tool = next((t for t in tools if t.name == "run_code"), None)
+        self.assertIsNotNone(run_code_tool)
+        self.assertIn("language", run_code_tool.inputSchema.get("properties", {}))
+        self.assertIn("code", run_code_tool.inputSchema.get("properties", {}))
+
+
+class TestMCPToolInvocations(unittest.TestCase):
+    """Test tool invocations work correctly."""
+
+    def setUp(self):
+        """Set up test environment."""
+        os.environ.setdefault("WORKLOAD_MANAGER_URL", "http://localhost:8080")
+        os.environ.setdefault("ROUTER_URL", "http://localhost:8081")
+
+    @patch("agentcube.mcp_server.CodeInterpreterClient")
+    def test_run_code_invocation(self, mock_class):
+        """Test run_code can be invoked via call_tool."""
+        mock_client = MagicMock()
+        mock_client.run_code.return_value = "42\n"
+        mock_class.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_class.return_value.__exit__ = MagicMock(return_value=False)
+
+        from agentcube.mcp_server import create_mcp_server
+        mcp = create_mcp_server(name="test")
+
+        async def call_tool():
+            result = await mcp.call_tool("run_code", {"language": "python", "code": "print(42)"})
+            return result
+
+        import asyncio
+        result = asyncio.get_event_loop().run_until_complete(call_tool())
+
+        mock_client.run_code.assert_called_once_with("python", "print(42)", None)
+
+    @patch("agentcube.mcp_server.CodeInterpreterClient")
+    def test_execute_command_invocation(self, mock_class):
+        """Test execute_command can be invoked."""
+        mock_client = MagicMock()
+        mock_client.execute_command.return_value = "hello\n"
+        mock_class.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_class.return_value.__exit__ = MagicMock(return_value=False)
+
+        from agentcube.mcp_server import create_mcp_server
+        mcp = create_mcp_server(name="test")
+
+        import asyncio
+        result = asyncio.get_event_loop().run_until_complete(
+            mcp.call_tool("execute_command", {"command": "echo hello"})
+        )
+
+        mock_client.execute_command.assert_called_once_with("echo hello", None)
+
+    @patch("agentcube.mcp_server.CodeInterpreterClient")
+    def test_write_file_invocation(self, mock_class):
+        """Test write_file can be invoked."""
+        mock_client = MagicMock()
+        mock_class.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_class.return_value.__exit__ = MagicMock(return_value=False)
+
+        from agentcube.mcp_server import create_mcp_server
+        mcp = create_mcp_server(name="test")
+
+        import asyncio
+        result = asyncio.get_event_loop().run_until_complete(
+            mcp.call_tool("write_file", {"content": "test", "remote_path": "test.txt"})
+        )
+
+        mock_client.write_file.assert_called_once_with("test", "test.txt")
+
+    @patch("agentcube.mcp_server.CodeInterpreterClient")
+    def test_list_files_invocation(self, mock_class):
+        """Test list_files can be invoked."""
+        mock_client = MagicMock()
+        mock_client.list_files.return_value = [
+            {"name": "file1.py", "size": 1024, "is_dir": False}
+        ]
+        mock_class.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_class.return_value.__exit__ = MagicMock(return_value=False)
+
+        from agentcube.mcp_server import create_mcp_server
+        mcp = create_mcp_server(name="test")
+
+        import asyncio
+        result = asyncio.get_event_loop().run_until_complete(
+            mcp.call_tool("list_files", {"path": "."})
+        )
+
+        mock_client.list_files.assert_called_once_with(".")
+        self.assertIn("file1.py", str(result))
+
+
+class TestMCPServerCLI(unittest.TestCase):
+    """Tests for MCP server CLI."""
+
+    def test_cli_import(self):
+        """Test CLI can be imported."""
+        from agentcube import mcp_server
+
+        self.assertTrue(hasattr(mcp_server, "main"))
+        self.assertTrue(hasattr(mcp_server, "create_mcp_server"))
+
+    def test_main_exists(self):
+        """Test main function exists."""
+        from agentcube.mcp_server import main
+
+        self.assertTrue(callable(main))
+
+
+if __name__ == "__main__":
+    print("Starting MCP Server Unit Tests...")
+
+    if "--verbose" not in sys.argv:
+        sys.argv.append("--verbose")
+
+    unittest.main(verbosity=2)

--- a/test/e2e/test_mcp_server.py
+++ b/test/e2e/test_mcp_server.py
@@ -20,11 +20,10 @@ These tests verify the MCP server functionality and structure without
 requiring a running AgentCube cluster.
 """
 
-import json
 import os
 import sys
 import unittest
-from unittest.mock import MagicMock, patch, AsyncMock
+from unittest.mock import MagicMock, patch
 import inspect
 
 
@@ -164,7 +163,7 @@ class TestMCPToolInvocations(unittest.TestCase):
             return result
 
         import asyncio
-        result = asyncio.get_event_loop().run_until_complete(call_tool())
+        asyncio.get_event_loop().run_until_complete(call_tool())
 
         mock_client.run_code.assert_called_once_with("python", "print(42)", None)
 
@@ -180,7 +179,7 @@ class TestMCPToolInvocations(unittest.TestCase):
         mcp = create_mcp_server(name="test")
 
         import asyncio
-        result = asyncio.get_event_loop().run_until_complete(
+        asyncio.get_event_loop().run_until_complete(
             mcp.call_tool("execute_command", {"command": "echo hello"})
         )
 
@@ -197,7 +196,7 @@ class TestMCPToolInvocations(unittest.TestCase):
         mcp = create_mcp_server(name="test")
 
         import asyncio
-        result = asyncio.get_event_loop().run_until_complete(
+        asyncio.get_event_loop().run_until_complete(
             mcp.call_tool("write_file", {"content": "test", "remote_path": "test.txt"})
         )
 


### PR DESCRIPTION
**What type of PR is this?**


/kind feature



**What this PR does / why we need it**:

- Add an MCP (Model Context Protocol) server for AgentCube Code Interpreter that enables standard MCP-compatible clients to interact with Code Interpreter sessions.
-  Refactor mcp_server.py to use a persistent CodeInterpreterClient, ensuring
  sandbox session persistence across multiple tool calls.
- Relocate unit tests from `test/e2e/ to sdk-python/tests/` to include them
  in automated unit test runs.
- Add `docker/Dockerfile.mcp` and Makefile targets for building and loading
  the MCP server image.
- Add Kubernetes deployment manifests and documentation under `manifests/mcp-server/`.
- Ensure router address and other parameters are configurable via env vars.

## Changes:

### MCP Tools Provides: 

| Tool            | Description                          |
|-----------------|--------------------------------------|
| run_code        | Execute Python/bash code snippets    |
| execute_command | Run shell commands                   |
| write_file      | Write content to remote file         |
| upload_file     | Upload local file to remote          |
| download_file   | Download remote file                 |
| list_files      | List directory contents              |

## Usage:

### CLI:

#### Run as stdio server
`python -m agentcube.mcp_server`

#### Run as HTTP server
`python -m agentcube.mcp_server --transport streamable-http --port 8000`

### Programmatically:

```
from agentcube import create_mcp_server
server = create_mcp_server(namespace="default", ttl=3600)
server.run(transport="streamable-http", port=8000)
```

#### Claude Desktop config:

```
{
  "mcpServers": {
    "agentcube-code-interpreter": {
      "command": "python",
      "args": ["-m", "agentcube.mcp_server"],
      "env": {
        "ROUTER_URL": "http://localhost:8080"
      }
    }
  }
}
```

### Testing:

`cd sdk-python && python -m pytest ../test/e2e/test_mcp_server.py -v`


**Which issue(s) this PR fixes**:
Fixes #284


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
