### PR TITLE
fix: copy pod labels in buildSandboxObject to avoid mutating the informer cache

### DIFF
--- a/pkg/workloadmanager/workload_builder.go
+++ b/pkg/workloadmanager/workload_builder.go
@@ -167,8 +167,11 @@ func buildSandboxObject(params *buildSandboxParams) *sandboxv1alpha1.Sandbox {
 	podLabels[SessionIdLabelKey] = params.sessionID
 	podLabels[SandboxNameLabelKey] = params.sandboxName
 
-	podAnnotations := make(map[string]string, len(params.podAnnotations))
-	maps.Copy(podAnnotations, params.podAnnotations)
+	var podAnnotations map[string]string
+	if params.podAnnotations != nil {
+		podAnnotations = make(map[string]string, len(params.podAnnotations))
+		maps.Copy(podAnnotations, params.podAnnotations)
+	}
 
 	// Create Sandbox object using agent-sandbox types
 	sandbox := &sandboxv1alpha1.Sandbox{

--- a/pkg/workloadmanager/workload_builder.go
+++ b/pkg/workloadmanager/workload_builder.go
@@ -161,7 +161,8 @@ func buildSandboxObject(params *buildSandboxParams) *sandboxv1alpha1.Sandbox {
 
 	shutdownTime := metav1.NewTime(time.Now().Add(params.ttl))
 
-	// Always allocate fresh maps so we never mutate the informer-cached object.
+	// Allocate fresh maps for copied metadata so we never mutate informer-cached input.
+	// Annotations are only copied when params.podAnnotations is non-nil.
 	podLabels := make(map[string]string, len(params.podLabels)+2)
 	maps.Copy(podLabels, params.podLabels)
 	podLabels[SessionIdLabelKey] = params.sessionID

--- a/pkg/workloadmanager/workload_builder.go
+++ b/pkg/workloadmanager/workload_builder.go
@@ -19,6 +19,7 @@ package workloadmanager
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"sync"
 	"time"
@@ -159,6 +160,13 @@ func buildSandboxObject(params *buildSandboxParams) *sandboxv1alpha1.Sandbox {
 	}
 
 	shutdownTime := metav1.NewTime(time.Now().Add(params.ttl))
+
+	// Always allocate a fresh map so we never mutate the informer-cached object.
+	podLabels := make(map[string]string, len(params.podLabels)+2)
+	maps.Copy(podLabels, params.podLabels)
+	podLabels[SessionIdLabelKey] = params.sessionID
+	podLabels[SandboxNameLabelKey] = params.sandboxName
+
 	// Create Sandbox object using agent-sandbox types
 	sandbox := &sandboxv1alpha1.Sandbox{
 		TypeMeta: metav1.TypeMeta{
@@ -171,7 +179,7 @@ func buildSandboxObject(params *buildSandboxParams) *sandboxv1alpha1.Sandbox {
 			Labels: map[string]string{
 				SessionIdLabelKey:    params.sessionID,
 				WorkloadNameLabelKey: params.workloadName,
-				"managed-by":         "agentcube-workload-manager",
+				"managed-by":        "agentcube-workload-manager",
 			},
 			Annotations: map[string]string{
 				IdleTimeoutAnnotationKey: params.idleTimeout.String(),
@@ -181,7 +189,7 @@ func buildSandboxObject(params *buildSandboxParams) *sandboxv1alpha1.Sandbox {
 			PodTemplate: sandboxv1alpha1.PodTemplate{
 				Spec: params.podSpec,
 				ObjectMeta: sandboxv1alpha1.PodMetadata{
-					Labels:      params.podLabels,
+					Labels:      podLabels,
 					Annotations: params.podAnnotations,
 				},
 			},
@@ -191,11 +199,6 @@ func buildSandboxObject(params *buildSandboxParams) *sandboxv1alpha1.Sandbox {
 			Replicas: ptr.To[int32](1),
 		},
 	}
-	if len(sandbox.Spec.PodTemplate.ObjectMeta.Labels) == 0 {
-		sandbox.Spec.PodTemplate.ObjectMeta.Labels = make(map[string]string, 2)
-	}
-	sandbox.Spec.PodTemplate.ObjectMeta.Labels[SessionIdLabelKey] = params.sessionID
-	sandbox.Spec.PodTemplate.ObjectMeta.Labels[SandboxNameLabelKey] = params.sandboxName
 	return sandbox
 }
 

--- a/pkg/workloadmanager/workload_builder.go
+++ b/pkg/workloadmanager/workload_builder.go
@@ -167,11 +167,8 @@ func buildSandboxObject(params *buildSandboxParams) *sandboxv1alpha1.Sandbox {
 	podLabels[SessionIdLabelKey] = params.sessionID
 	podLabels[SandboxNameLabelKey] = params.sandboxName
 
-	var podAnnotations map[string]string
-	if params.podAnnotations != nil {
-		podAnnotations = make(map[string]string, len(params.podAnnotations))
-		maps.Copy(podAnnotations, params.podAnnotations)
-	}
+	podAnnotations := make(map[string]string, len(params.podAnnotations))
+	maps.Copy(podAnnotations, params.podAnnotations)
 
 	// Create Sandbox object using agent-sandbox types
 	sandbox := &sandboxv1alpha1.Sandbox{

--- a/pkg/workloadmanager/workload_builder.go
+++ b/pkg/workloadmanager/workload_builder.go
@@ -161,11 +161,14 @@ func buildSandboxObject(params *buildSandboxParams) *sandboxv1alpha1.Sandbox {
 
 	shutdownTime := metav1.NewTime(time.Now().Add(params.ttl))
 
-	// Always allocate a fresh map so we never mutate the informer-cached object.
+	// Always allocate fresh maps so we never mutate the informer-cached object.
 	podLabels := make(map[string]string, len(params.podLabels)+2)
 	maps.Copy(podLabels, params.podLabels)
 	podLabels[SessionIdLabelKey] = params.sessionID
 	podLabels[SandboxNameLabelKey] = params.sandboxName
+
+	podAnnotations := make(map[string]string, len(params.podAnnotations))
+	maps.Copy(podAnnotations, params.podAnnotations)
 
 	// Create Sandbox object using agent-sandbox types
 	sandbox := &sandboxv1alpha1.Sandbox{
@@ -190,7 +193,7 @@ func buildSandboxObject(params *buildSandboxParams) *sandboxv1alpha1.Sandbox {
 				Spec: params.podSpec,
 				ObjectMeta: sandboxv1alpha1.PodMetadata{
 					Labels:      podLabels,
-					Annotations: params.podAnnotations,
+					Annotations: podAnnotations,
 				},
 			},
 			Lifecycle: sandboxv1alpha1.Lifecycle{

--- a/pkg/workloadmanager/workload_builder_test.go
+++ b/pkg/workloadmanager/workload_builder_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloadmanager
+
+import (
+	"testing"
+	"time"
+)
+
+// TestBuildSandboxObject_DoesNotMutateCallerLabels verifies that buildSandboxObject
+// does not write session-specific labels back into the caller's map, which would
+// corrupt the informer-cached CRD object shared across goroutines.
+func TestBuildSandboxObject_DoesNotMutateCallerLabels(t *testing.T) {
+	original := map[string]string{
+		"app": "my-app",
+		"env": "test",
+	}
+	// Take a snapshot before the call.
+	before := make(map[string]string, len(original))
+	for k, v := range original {
+		before[k] = v
+	}
+
+	params := &buildSandboxParams{
+		namespace:   "default",
+		sandboxName: "sandbox-abc",
+		sessionID:   "session-123",
+		ttl:         DefaultSandboxTTL,
+		idleTimeout: DefaultSandboxIdleTimeout,
+		podLabels:   original,
+	}
+
+	sandbox := buildSandboxObject(params)
+
+	// The caller's map must be unchanged.
+	if len(original) != len(before) {
+		t.Fatalf("caller labels map was mutated: before=%v after=%v", before, original)
+	}
+	for k, v := range before {
+		if original[k] != v {
+			t.Fatalf("caller labels map was mutated: key %q changed from %q to %q", k, v, original[k])
+		}
+	}
+
+	// The sandbox pod-template labels must contain both original and injected keys.
+	podLabels := sandbox.Spec.PodTemplate.ObjectMeta.Labels
+	if podLabels["app"] != "my-app" {
+		t.Errorf("expected pod label app=my-app, got %q", podLabels["app"])
+	}
+	if podLabels[SessionIdLabelKey] != "session-123" {
+		t.Errorf("expected pod label %s=session-123, got %q", SessionIdLabelKey, podLabels[SessionIdLabelKey])
+	}
+	if podLabels[SandboxNameLabelKey] != "sandbox-abc" {
+		t.Errorf("expected pod label %s=sandbox-abc, got %q", SandboxNameLabelKey, podLabels[SandboxNameLabelKey])
+	}
+}
+
+// TestBuildSandboxObject_NilLabels verifies that a nil podLabels input still
+// produces a sandbox with the injected session labels.
+func TestBuildSandboxObject_NilLabels(t *testing.T) {
+	params := &buildSandboxParams{
+		namespace:   "default",
+		sandboxName: "sandbox-xyz",
+		sessionID:   "session-456",
+		ttl:         time.Hour,
+		idleTimeout: 15 * time.Minute,
+		podLabels:   nil,
+	}
+
+	sandbox := buildSandboxObject(params)
+
+	podLabels := sandbox.Spec.PodTemplate.ObjectMeta.Labels
+	if podLabels[SessionIdLabelKey] != "session-456" {
+		t.Errorf("expected %s=session-456, got %q", SessionIdLabelKey, podLabels[SessionIdLabelKey])
+	}
+	if podLabels[SandboxNameLabelKey] != "sandbox-xyz" {
+		t.Errorf("expected %s=sandbox-xyz, got %q", SandboxNameLabelKey, podLabels[SandboxNameLabelKey])
+	}
+}

--- a/pkg/workloadmanager/workload_builder_test.go
+++ b/pkg/workloadmanager/workload_builder_test.go
@@ -67,6 +67,17 @@ func TestBuildSandboxObject_DoesNotMutateCallerLabels(t *testing.T) {
 	if podLabels[SandboxNameLabelKey] != "sandbox-abc" {
 		t.Errorf("expected pod label %s=sandbox-abc, got %q", SandboxNameLabelKey, podLabels[SandboxNameLabelKey])
 	}
+
+	// Mutating the returned sandbox labels must not affect the caller's map.
+	podLabels["app"] = "mutated-app"
+	delete(podLabels, "env")
+
+	if original["app"] != before["app"] {
+		t.Fatalf("caller labels map was aliased through sandbox labels: key %q changed from %q to %q", "app", before["app"], original["app"])
+	}
+	if original["env"] != before["env"] {
+		t.Fatalf("caller labels map was aliased through sandbox labels: key %q changed from %q to %q", "env", before["env"], original["env"])
+	}
 }
 
 // TestBuildSandboxObject_NilLabels verifies that a nil podLabels input still


### PR DESCRIPTION
/kind bug

## What this PR does / why we need it

`buildSandboxObject` injected `SessionIdLabelKey` and `SandboxNameLabelKey` directly into `params.podLabels` in-place. Both `buildSandboxByAgentRuntime` and `buildSandboxByCodeInterpreter` assigned the labels map from the informer-cached CRD object to `params.podLabels` without copying it first.

Because `params.podLabels` and `sandbox.Spec.PodTemplate.ObjectMeta.Labels` pointed at the same underlying map as the informer cache, every sandbox creation silently wrote session-specific keys back into the shared cache. Under concurrent requests for the same AgentRuntime or CodeInterpreter, multiple goroutines mutated the same map simultaneously  a data race  and each request could overwrite the session label left by the previous one, causing pods to carry the wrong session ID.

Note: `envVars` in `buildSandboxByCodeInterpreter` was already explicitly copied with `make` + `copy` to avoid this exact problem. The labels map was missed.

## Code Change

```go
// Before: params.podLabels points directly at the informer-cached CRD labels map
sandbox.Spec.PodTemplate.ObjectMeta.Labels[SessionIdLabelKey] = params.sessionID
sandbox.Spec.PodTemplate.ObjectMeta.Labels[SandboxNameLabelKey] = params.sandboxName

// After: always allocate a fresh map so we never mutate the informer-cached object
podLabels := make(map[string]string, len(params.podLabels)+2)
maps.Copy(podLabels, params.podLabels)
podLabels[SessionIdLabelKey] = params.sessionID
podLabels[SandboxNameLabelKey] = params.sandboxName
```

## What tests cover this fix

New test file `pkg/workloadmanager/workload_builder_test.go` with two cases:

- `TestBuildSandboxObject_DoesNotMutateCallerLabels`  passes a labels map, calls `buildSandboxObject`, and asserts the original map is unchanged. Fails on old code, passes on the fix.
- `TestBuildSandboxObject_NilLabels`  verifies that a nil `podLabels` input still produces a sandbox with the correct injected session labels.



## Special notes for reviewer

PR #268 also modifies `workload_builder.go` (SessionTimeout propagation). If that lands first there may be a trivial merge conflict in this file the two fixes touch different lines and are independent.

## Release Note

```release-note
fix: pod labels injected by workload-manager no longer race against concurrent sandbox creation requests for the same AgentRuntime or CodeInterpreter
```