### PR TITLE
feat: mcp server for code interpreter

### DIFF
--- a/integrations/code-interpreter-mcp/Dockerfile
+++ b/integrations/code-interpreter-mcp/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright The Volcano Authors.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Build from repository root:
+#   docker build -f integrations/code-interpreter-mcp/Dockerfile -t agentcube-code-interpreter-mcp:latest .
+
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY sdk-python /build/sdk-python
+COPY integrations/code-interpreter-mcp /build/mcp
+
+RUN pip install --no-cache-dir /build/sdk-python \
+    && pip install --no-cache-dir /build/mcp \
+    && rm -rf /build
+
+ENV MCP_TRANSPORT=streamable-http \
+    MCP_HOST=0.0.0.0 \
+    MCP_PORT=8000
+
+EXPOSE 8000
+
+ENTRYPOINT ["python", "-m", "agentcube_code_interpreter_mcp", "--transport", "streamable-http", "--host", "0.0.0.0", "--port", "8000"]

--- a/integrations/code-interpreter-mcp/README.md
+++ b/integrations/code-interpreter-mcp/README.md
@@ -1,0 +1,81 @@
+# AgentCube Code Interpreter MCP Server
+
+A [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes the AgentCube code interpreter (via the **Router** data plane and **Workload Manager** control plane) as MCP **tools**, so hosts such as Cursor or Claude Desktop can integrate without custom HTTP glue.
+
+## Configuration (environment variables)
+
+| Variable | Description |
+|----------|-------------|
+| `ROUTER_URL` | **Required.** AgentCube Router base URL, e.g. `http://localhost:8081` |
+| `WORKLOAD_MANAGER_URL` | **Required.** Workload Manager base URL, e.g. `http://localhost:8080` |
+| `API_TOKEN` | Optional. Bearer token for Workload Manager / Kubernetes (same semantics as the Python SDK) |
+| `AGENTCUBE_NAMESPACE` | Default `default` |
+| `CODE_INTERPRETER_NAME` | CodeInterpreter CRD name; default `my-interpreter` (E2E uses `e2e-code-interpreter`) |
+| `CODE_INTERPRETER_SESSION_TTL` | New session TTL in seconds; default `3600` |
+| `MCP_TRANSPORT` | `stdio` or `streamable-http` (or pass `--transport` on the CLI) |
+| `MCP_HOST` / `MCP_PORT` | Listen address for HTTP mode |
+
+## Run locally
+
+1. Install the SDK and this package:
+
+```bash
+pip install -e ./sdk-python
+pip install -e ./integrations/code-interpreter-mcp
+```
+
+2. **stdio** (typical for local MCP hosts such as Cursor):
+
+```bash
+export ROUTER_URL=http://localhost:8081
+export WORKLOAD_MANAGER_URL=http://localhost:8080
+export API_TOKEN=...   # if your environment requires it
+python -m agentcube_code_interpreter_mcp --transport stdio
+```
+
+Example Cursor `mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "agentcube-code-interpreter": {
+      "command": "python",
+      "args": ["-m", "agentcube_code_interpreter_mcp", "--transport", "stdio"],
+      "env": {
+        "ROUTER_URL": "http://localhost:8081",
+        "WORKLOAD_MANAGER_URL": "http://localhost:8080",
+        "CODE_INTERPRETER_NAME": "e2e-code-interpreter",
+        "AGENTCUBE_NAMESPACE": "agentcube"
+      }
+    }
+  }
+}
+```
+
+3. **Streamable HTTP** (debugging or remote access):
+
+```bash
+python -m agentcube_code_interpreter_mcp --transport streamable-http --host 0.0.0.0 --port 8000
+```
+
+The default MCP HTTP path is `/mcp` (per the official Python MCP SDK).
+
+## Kubernetes
+
+Build from the repository root (the context must include `sdk-python`):
+
+```bash
+docker build -f integrations/code-interpreter-mcp/Dockerfile -t agentcube-code-interpreter-mcp:latest .
+kubectl apply -f integrations/code-interpreter-mcp/deployment.yaml
+```
+
+Edit `ROUTER_URL` and `WORKLOAD_MANAGER_URL` in the Deployment to match your cluster Services. **Session affinity:** with `session_reuse=true`, the process caches `CodeInterpreterClient` instances in memory—use **one replica** or configure sticky sessions at your gateway.
+
+## Tools
+
+Aligned with public methods on Python **`CodeInterpreterClient`** for predictable naming:
+
+- `run_code`, `execute_command`, `write_file`, `list_files` — same names as the SDK methods
+- `stop_session` — ends a session (maps to `CodeInterpreterClient.stop()`); call when you are done after `session_reuse=true`
+
+All tools accept optional `session_id` and `session_reuse`, similar to the Dify plugin’s code / command / session semantics.

--- a/integrations/code-interpreter-mcp/README.md
+++ b/integrations/code-interpreter-mcp/README.md
@@ -1,39 +1,87 @@
 # AgentCube Code Interpreter MCP Server
 
-A [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes the AgentCube code interpreter (via the **Router** data plane and **Workload Manager** control plane) as MCP **tools**, so hosts such as Cursor or Claude Desktop can integrate without custom HTTP glue.
+[MCP](https://modelcontextprotocol.io/) server that exposes the AgentCube code interpreter (Router + Workload Manager) as tools for Cursor, Claude Desktop, and other hosts.
 
-## Configuration (environment variables)
+**You need a running AgentCube cluster and a `CodeInterpreter` CR before this server is useful.** Follow the steps below in order.
 
-| Variable | Description |
-|----------|-------------|
-| `ROUTER_URL` | **Required.** AgentCube Router base URL, e.g. `http://localhost:8081` |
-| `WORKLOAD_MANAGER_URL` | **Required.** Workload Manager base URL, e.g. `http://localhost:8080` |
-| `API_TOKEN` | Optional. Bearer token for Workload Manager / Kubernetes (same semantics as the Python SDK) |
-| `AGENTCUBE_NAMESPACE` | Default `default` |
-| `CODE_INTERPRETER_NAME` | CodeInterpreter CRD name; default `my-interpreter` (E2E uses `e2e-code-interpreter`) |
-| `CODE_INTERPRETER_SESSION_TTL` | New session TTL in seconds; default `3600` |
-| `MCP_TRANSPORT` | `stdio` or `streamable-http` (or pass `--transport` on the CLI) |
-| `MCP_HOST` / `MCP_PORT` | Listen address for HTTP mode |
+---
 
-## Run locally
+## 0. Deploy AgentCube (same path as the project tutorial)
 
-1. Install the SDK and this package:
+Do this once on a Kubernetes cluster (v1.24+). Full detail: [`docs/getting-started.md`](../../docs/getting-started.md).
+
+1. **agent-sandbox** — install CRDs + controller (see getting-started **Step 1**).
+2. **Redis** — create namespace `agentcube`, deploy Redis ( **Step 2** ).
+3. **AgentCube** — `git clone` the repo, then `helm install agentcube ./manifests/charts/base ...` ( **Step 3** ).
+4. **CodeInterpreter** — e.g. `kubectl apply -f example/code-interpreter/code-interpreter.yaml` ( **Step 4** ). That manifest creates `my-interpreter` in namespace **`default`**.
+
+Check:
 
 ```bash
+kubectl get pods -n agentcube
+kubectl get codeinterpreter
+```
+
+---
+
+## 1. Install the MCP server (your machine)
+
+Python 3.10+. The server calls the Python SDK at runtime, so install **both** the SDK and this package.
+
+**From a clone of this repository** (recommended while developing):
+
+```bash
+cd /path/to/agentcube
 pip install -e ./sdk-python
 pip install -e ./integrations/code-interpreter-mcp
 ```
 
-2. **stdio** (typical for local MCP hosts such as Cursor):
+**Released SDK only** (if you publish or install `agentcube-sdk` from PyPI): install the SDK, then install this package from the same repo revision so versions stay compatible.
+
+---
+
+## 2. Point the server at Router + Workload Manager
+
+From your laptop, port-forward (same pattern as [getting-started **Step 5**](../../docs/getting-started.md)):
 
 ```bash
-export ROUTER_URL=http://localhost:8081
-export WORKLOAD_MANAGER_URL=http://localhost:8080
-export API_TOKEN=...   # if your environment requires it
+# Terminal A
+kubectl port-forward -n agentcube svc/workloadmanager 8080:8080
+
+# Terminal B — local 8081 → Router service port 8080 (avoids clashing with 8080)
+kubectl port-forward -n agentcube svc/agentcube-router 8081:8080
+```
+
+Then:
+
+```bash
+export WORKLOAD_MANAGER_URL="http://localhost:8080"
+export ROUTER_URL="http://localhost:8081"
+```
+
+If your cluster enforces auth for those APIs, set `API_TOKEN` (Bearer) the same way as the Python SDK.
+
+---
+
+## 3. Run the MCP server
+
+**stdio** (typical for Cursor / Claude Desktop):
+
+```bash
 python -m agentcube_code_interpreter_mcp --transport stdio
 ```
 
-Example Cursor `mcp.json`:
+**Streamable HTTP** (debugging; default path `/mcp` per the Python MCP SDK):
+
+```bash
+python -m agentcube_code_interpreter_mcp --transport streamable-http --host 0.0.0.0 --port 8000
+```
+
+---
+
+## 4. Example: Cursor `mcp.json`
+
+Match **namespace** and **interpreter name** to your `CodeInterpreter` CR. For `example/code-interpreter/code-interpreter.yaml` (`my-interpreter` in `default`):
 
 ```json
 {
@@ -44,38 +92,50 @@ Example Cursor `mcp.json`:
       "env": {
         "ROUTER_URL": "http://localhost:8081",
         "WORKLOAD_MANAGER_URL": "http://localhost:8080",
-        "CODE_INTERPRETER_NAME": "e2e-code-interpreter",
-        "AGENTCUBE_NAMESPACE": "agentcube"
+        "AGENTCUBE_NAMESPACE": "default",
+        "CODE_INTERPRETER_NAME": "my-interpreter"
       }
     }
   }
 }
 ```
 
-3. **Streamable HTTP** (debugging or remote access):
+If the CR name is not `my-interpreter`, set `CODE_INTERPRETER_NAME` accordingly. Keep the two `kubectl port-forward` terminals open while you use the IDE.
 
-```bash
-python -m agentcube_code_interpreter_mcp --transport streamable-http --host 0.0.0.0 --port 8000
-```
+---
 
-The default MCP HTTP path is `/mcp` (per the official Python MCP SDK).
+## 5. Optional: run the MCP server inside the cluster
 
-## Kubernetes
-
-Build from the repository root (the context must include `sdk-python`):
+Build from **repository root** (Docker context must include `sdk-python`):
 
 ```bash
 docker build -f integrations/code-interpreter-mcp/Dockerfile -t agentcube-code-interpreter-mcp:latest .
 kubectl apply -f integrations/code-interpreter-mcp/deployment.yaml
 ```
 
-Edit `ROUTER_URL` and `WORKLOAD_MANAGER_URL` in the Deployment to match your cluster Services. **Session affinity:** with `session_reuse=true`, the process caches `CodeInterpreterClient` instances in memory—use **one replica** or configure sticky sessions at your gateway.
+Edit `deployment.yaml`: `ROUTER_URL` / `WORKLOAD_MANAGER_URL` must match your Services (defaults target `agentcube` namespace). Set `CODE_INTERPRETER_NAME` to your CR name.
+
+**Replicas:** with `session_reuse=true`, clients are cached in process memory — use **one** replica or sticky routing at your gateway.
+
+---
+
+## Configuration reference
+
+| Variable | Description |
+|----------|-------------|
+| `ROUTER_URL` | **Required.** Router base URL |
+| `WORKLOAD_MANAGER_URL` | **Required.** Workload Manager base URL |
+| `API_TOKEN` | Optional Bearer token (same as SDK) |
+| `AGENTCUBE_NAMESPACE` | Namespace for API paths; default `default` |
+| `CODE_INTERPRETER_NAME` | CR name; default `my-interpreter` |
+| `CODE_INTERPRETER_SESSION_TTL` | New session TTL (seconds); default `3600` |
+| `MCP_TRANSPORT` | `stdio` or `streamable-http` (or `--transport` on CLI) |
+| `MCP_HOST` / `MCP_PORT` | Listen address for HTTP mode |
+
+---
 
 ## Tools
 
-Aligned with public methods on Python **`CodeInterpreterClient`** for predictable naming:
+Names match **`CodeInterpreterClient`**: `run_code`, `execute_command`, `write_file`, `list_files`, `upload_file`, `download_file`, and `stop_session` (call when finished after `session_reuse=true`). Optional `session_id` / `session_reuse` on tools.
 
-- `run_code`, `execute_command`, `write_file`, `list_files` — same names as the SDK methods
-- `stop_session` — ends a session (maps to `CodeInterpreterClient.stop()`); call when you are done after `session_reuse=true`
-
-All tools accept optional `session_id` and `session_reuse`, similar to the Dify plugin’s code / command / session semantics.
+`upload_file` / `download_file` paths are on the **host that runs** the MCP process (not inside the sandbox).

--- a/integrations/code-interpreter-mcp/agentcube_code_interpreter_mcp/__init__.py
+++ b/integrations/code-interpreter-mcp/agentcube_code_interpreter_mcp/__init__.py
@@ -1,0 +1,10 @@
+# Copyright The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""AgentCube Code Interpreter MCP server."""
+
+from agentcube_code_interpreter_mcp.server import create_mcp_server
+
+__all__ = ["create_mcp_server"]

--- a/integrations/code-interpreter-mcp/agentcube_code_interpreter_mcp/__main__.py
+++ b/integrations/code-interpreter-mcp/agentcube_code_interpreter_mcp/__main__.py
@@ -1,0 +1,41 @@
+# Copyright The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""CLI entry for AgentCube Code Interpreter MCP server."""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+from agentcube_code_interpreter_mcp.server import create_mcp_server
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="AgentCube Code Interpreter MCP server")
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "streamable-http"],
+        default=os.environ.get("MCP_TRANSPORT", "stdio"),
+        help="MCP transport (default: stdio, or MCP_TRANSPORT)",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.environ.get("MCP_HOST", "127.0.0.1"),
+        help="Listen host for streamable-http (default: MCP_HOST or 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("MCP_PORT", "8000")),
+        help="Listen port for streamable-http (default: MCP_PORT or 8000)",
+    )
+    args = parser.parse_args()
+    mcp = create_mcp_server(host=args.host, port=args.port)
+    mcp.run(transport=args.transport)
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/code-interpreter-mcp/agentcube_code_interpreter_mcp/server.py
+++ b/integrations/code-interpreter-mcp/agentcube_code_interpreter_mcp/server.py
@@ -126,12 +126,8 @@ def create_mcp_server(
     instructions: str | None = None,
 ) -> FastMCP:
     instr = instructions or (
-        "Run code and shell commands in an isolated AgentCube Code Interpreter sandbox. "
-        "For multi-step tasks (write file then run code, list then read, etc.), set session_reuse=true "
-        "and pass session_id from the previous JSON response on each follow-up call so the same sandbox "
-        "workspace stays available. IMPORTANT: each run_code starts a new Python process—variables do not "
-        "carry between run_code calls; only workspace files persist while the session is open. "
-        "When finished with a reused session, call stop_session with that session_id."
+        "AgentCube sandbox. Multi-step: session_reuse=true, pass session_id from prior JSON; "
+        "each run_code is a new process—only files persist. stop_session when done."
     )
     app = FastMCP(
         "agentcube-code-interpreter",
@@ -148,40 +144,33 @@ def create_mcp_server(
         language: Annotated[
             str,
             Field(
-                description="Interpreter language for CodeInterpreterClient.run_code (e.g. python, bash)."
+                description="Language (python, bash)."
             ),
         ],
-        code: Annotated[str, Field(description="Source or script body to execute in the sandbox.")],
+        code: Annotated[str, Field(description="Code or script to run.")],
         session_id: Annotated[
             Optional[str],
             Field(
                 default=None,
-                description=(
-                    "Continue an existing sandbox: use the session_id string from a prior tool JSON response. "
-                    "Omit to start a new session."
-                ),
+                description="Prior session_id to continue; omit for new session.",
             ),
         ] = None,
         session_reuse: Annotated[
             bool,
             Field(
                 default=False,
-                description=(
-                    "If false (default), the server stops the sandbox after this call—later calls cannot rely "
-                    "on files from this session. If true, the sandbox stays alive for follow-up tools; you MUST "
-                    "pass the returned session_id on the next call and call stop_session when done to free resources."
-                ),
+                description="Keep sandbox; pass session_id next; stop_session when done. Default tears down after.",
             ),
         ] = False,
         timeout_seconds: Annotated[
             Optional[float],
             Field(
                 default=None,
-                description="Optional execution timeout in seconds for this run_code invocation.",
+                description="Run timeout (seconds).",
             ),
         ] = None,
     ) -> str:
-        """Execute code in an AgentCube Code Interpreter session (via Router)."""
+        """Run code in the sandbox."""
         cfg = _load_server()
         client = _client_for_call(session_id, session_reuse, cfg, CodeInterpreterClient)
         try:
@@ -197,30 +186,27 @@ def create_mcp_server(
 
     @app.tool(structured_output=False)
     def execute_command(
-        command: Annotated[str, Field(description="Shell command to run inside the interpreter sandbox.")],
+        command: Annotated[str, Field(description="Shell command in sandbox.")],
         session_id: Annotated[
             Optional[str],
             Field(
                 default=None,
-                description="Existing session_id from a prior tool response; omit for a new session.",
+                description="Prior session_id; omit for new session.",
             ),
         ] = None,
         session_reuse: Annotated[
             bool,
             Field(
                 default=False,
-                description=(
-                    "False: stop sandbox after this call. True: keep sandbox for follow-up; pass session_id next "
-                    "and stop_session when finished."
-                ),
+                description="Keep sandbox; pass session_id next; stop_session when done.",
             ),
         ] = False,
         timeout_seconds: Annotated[
             Optional[float],
-            Field(default=None, description="Optional timeout in seconds for this command."),
+            Field(default=None, description="Timeout (seconds)."),
         ] = None,
     ) -> str:
-        """Run a shell command in the Code Interpreter sandbox."""
+        """Run shell in sandbox."""
         cfg = _load_server()
         client = _client_for_call(session_id, session_reuse, cfg, CodeInterpreterClient)
         try:
@@ -231,29 +217,26 @@ def create_mcp_server(
 
     @app.tool(structured_output=False)
     def write_file(
-        content: Annotated[str, Field(description="File contents to write (text).")],
+        content: Annotated[str, Field(description="File text.")],
         remote_path: Annotated[
             str,
             Field(
-                description="Path relative to the interpreter workspace (e.g. data/input.txt)."
+                description="Path under workspace (e.g. data/input.txt)."
             ),
         ],
         session_id: Annotated[
             Optional[str],
-            Field(default=None, description="Existing session_id; omit to create a new session."),
+            Field(default=None, description="Prior session_id; omit for new session."),
         ] = None,
         session_reuse: Annotated[
             bool,
             Field(
                 default=False,
-                description=(
-                    "Set true when more steps will read or run against this file; then pass session_id on "
-                    "follow-up tools and stop_session when done. If false, the session ends after this write."
-                ),
+                description="Keep session for follow-up; pass session_id; stop_session when done.",
             ),
         ] = False,
     ) -> str:
-        """Write text to a path inside the interpreter workspace (CodeInterpreterClient.write_file)."""
+        """Write a file in the workspace."""
         cfg = _load_server()
         client = _client_for_call(session_id, session_reuse, cfg, CodeInterpreterClient)
         try:
@@ -268,22 +251,22 @@ def create_mcp_server(
             str,
             Field(
                 default=".",
-                description="Directory path inside the workspace to list (default: current/workspace root).",
+                description="Dir to list (default .).",
             ),
         ] = ".",
         session_id: Annotated[
             Optional[str],
-            Field(default=None, description="Existing session_id; omit to create a new session."),
+            Field(default=None, description="Prior session_id; omit for new session."),
         ] = None,
         session_reuse: Annotated[
             bool,
             Field(
                 default=False,
-                description="True to keep the session after listing for further tools; false to tear down after.",
+                description="Keep session for more tools; else tear down after.",
             ),
         ] = False,
     ) -> str:
-        """List files in the interpreter workspace (CodeInterpreterClient.list_files)."""
+        """List workspace directory."""
         cfg = _load_server()
         client = _client_for_call(session_id, session_reuse, cfg, CodeInterpreterClient)
         try:
@@ -296,10 +279,10 @@ def create_mcp_server(
     def stop_session(
         session_id: Annotated[
             str,
-            Field(description="The session_id to terminate; must match a session you opened with session_reuse."),
+            Field(description="session_id to stop (from session_reuse)."),
         ],
     ) -> str:
-        """Stop and delete a session (CodeInterpreterClient.stop); required after session_reuse."""
+        """Stop a reused session."""
         cfg = _load_server()
         with _SESSION_LOCK:
             client = _SESSIONS.pop(session_id, None)

--- a/integrations/code-interpreter-mcp/agentcube_code_interpreter_mcp/server.py
+++ b/integrations/code-interpreter-mcp/agentcube_code_interpreter_mcp/server.py
@@ -333,6 +333,94 @@ def create_mcp_server(
         return payload
 
     @app.tool(structured_output=False)
+    def upload_file(
+        local_path: Annotated[
+            str,
+            Field(
+                description="Path to a file on the host running this MCP server (not the sandbox).",
+            ),
+        ],
+        remote_path: Annotated[
+            str,
+            Field(
+                description="Destination in the workspace (relative to session working directory).",
+            ),
+        ],
+        session_id: Annotated[
+            Optional[str],
+            Field(default=None, description="Prior session_id; omit for new session."),
+        ] = None,
+        session_reuse: Annotated[
+            bool,
+            Field(
+                default=False,
+                description="Keep session for follow-up; pass session_id; stop_session when done.",
+            ),
+        ] = False,
+    ) -> dict[str, Any]:
+        """Upload a local file to the workspace (multipart, same as CodeInterpreterClient.upload_file)."""
+        cfg = _load_server()
+
+        def _op(c: Any) -> None:
+            c.upload_file(local_path, remote_path)
+
+        _, meta, sid = _call_with_session_recovery(
+            session_id, session_reuse, cfg, CodeInterpreterClient, _op
+        )
+        payload: dict[str, Any] = {
+            "session_id": sid,
+            "local_path": local_path,
+            "remote_path": remote_path,
+            "status": "ok",
+        }
+        payload.update(meta)
+        return payload
+
+    @app.tool(structured_output=False)
+    def download_file(
+        remote_path: Annotated[
+            str,
+            Field(
+                description="File in the workspace (relative to session working directory).",
+            ),
+        ],
+        local_path: Annotated[
+            str,
+            Field(
+                description="Destination path on the host running this MCP server (not the sandbox).",
+            ),
+        ],
+        session_id: Annotated[
+            Optional[str],
+            Field(default=None, description="Prior session_id; omit for new session."),
+        ] = None,
+        session_reuse: Annotated[
+            bool,
+            Field(
+                default=False,
+                description="Keep session for follow-up; pass session_id; stop_session when done.",
+            ),
+        ] = False,
+    ) -> dict[str, Any]:
+        """Download a workspace file to a local path (same as CodeInterpreterClient.download_file)."""
+        cfg = _load_server()
+
+        def _op(c: Any) -> None:
+            c.download_file(remote_path, local_path)
+
+        _, meta, sid = _call_with_session_recovery(
+            session_id, session_reuse, cfg, CodeInterpreterClient, _op
+        )
+        payload: dict[str, Any] = {
+            "session_id": sid,
+            "remote_path": remote_path,
+            "local_path": local_path,
+            "status": "ok",
+        }
+        payload.update(meta)
+        return payload
+
+    @app.tool(structured_output=False)
     def stop_session(
         session_id: Annotated[
             str,

--- a/integrations/code-interpreter-mcp/agentcube_code_interpreter_mcp/server.py
+++ b/integrations/code-interpreter-mcp/agentcube_code_interpreter_mcp/server.py
@@ -11,16 +11,24 @@ import json
 import os
 import threading
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Annotated, Any, Optional
 
 from mcp.server.fastmcp import FastMCP
+from pydantic import Field
 
+# In-process cache of live CodeInterpreterClient instances for session_reuse.
+# Not shared across processes or replicas — keep Deployment replicas at 1 or use sticky routing.
 _SESSION_LOCK = threading.RLock()
 _SESSIONS: dict[str, Any] = {}
 
 
+def _env_nonempty(key: str, default: str) -> str:
+    """Read env var; treat empty/whitespace-only as missing and return default."""
+    return (os.environ.get(key, default) or default).strip() or default
+
+
 @dataclass(frozen=True)
-class ServerEnv:
+class Server:
     router_url: str
     workload_manager_url: str
     namespace: str
@@ -29,7 +37,7 @@ class ServerEnv:
     ttl: int
 
 
-def _load_env() -> ServerEnv:
+def _load_server() -> Server:
     router = os.environ.get("ROUTER_URL", "").strip()
     wm = os.environ.get("WORKLOAD_MANAGER_URL", "").strip()
     if not router:
@@ -39,12 +47,11 @@ def _load_env() -> ServerEnv:
     token = os.environ.get("API_TOKEN") or os.environ.get("AGENTCUBE_API_TOKEN") or None
     if token is not None:
         token = token.strip() or None
-    return ServerEnv(
+    return Server(
         router_url=router,
         workload_manager_url=wm,
-        namespace=os.environ.get("AGENTCUBE_NAMESPACE", "default").strip() or "default",
-        code_interpreter_name=os.environ.get("CODE_INTERPRETER_NAME", "my-interpreter").strip()
-        or "my-interpreter",
+        namespace=_env_nonempty("AGENTCUBE_NAMESPACE", "default"),
+        code_interpreter_name=_env_nonempty("CODE_INTERPRETER_NAME", "my-interpreter"),
         auth_token=token,
         ttl=int(os.environ.get("CODE_INTERPRETER_SESSION_TTL", "3600")),
     )
@@ -63,7 +70,7 @@ def _import_client():
 def _client_for_call(
     session_id: Optional[str],
     session_reuse: bool,
-    env: ServerEnv,
+    cfg: Server,
     CodeInterpreterClient: type,
 ):
     with _SESSION_LOCK:
@@ -72,24 +79,24 @@ def _client_for_call(
             if cached is not None:
                 return cached
             client = CodeInterpreterClient(
-                name=env.code_interpreter_name,
-                namespace=env.namespace,
-                ttl=env.ttl,
-                workload_manager_url=env.workload_manager_url,
-                router_url=env.router_url,
-                auth_token=env.auth_token,
+                name=cfg.code_interpreter_name,
+                namespace=cfg.namespace,
+                ttl=cfg.ttl,
+                workload_manager_url=cfg.workload_manager_url,
+                router_url=cfg.router_url,
+                auth_token=cfg.auth_token,
                 session_id=session_id,
             )
             if session_reuse:
                 _SESSIONS[session_id] = client
             return client
         client = CodeInterpreterClient(
-            name=env.code_interpreter_name,
-            namespace=env.namespace,
-            ttl=env.ttl,
-            workload_manager_url=env.workload_manager_url,
-            router_url=env.router_url,
-            auth_token=env.auth_token,
+            name=cfg.code_interpreter_name,
+            namespace=cfg.namespace,
+            ttl=cfg.ttl,
+            workload_manager_url=cfg.workload_manager_url,
+            router_url=cfg.router_url,
+            auth_token=cfg.auth_token,
         )
         if session_reuse and client.session_id:
             _SESSIONS[client.session_id] = client
@@ -119,9 +126,12 @@ def create_mcp_server(
     instructions: str | None = None,
 ) -> FastMCP:
     instr = instructions or (
-        "AgentCube Code Interpreter tools. Set ROUTER_URL and WORKLOAD_MANAGER_URL on the server. "
-        "Use session_reuse=true to keep a sandbox session for multiple calls; pass session_id on later calls. "
-        "Call stop_session when finished if you used session_reuse."
+        "Run code and shell commands in an isolated AgentCube Code Interpreter sandbox. "
+        "For multi-step tasks (write file then run code, list then read, etc.), set session_reuse=true "
+        "and pass session_id from the previous JSON response on each follow-up call so the same sandbox "
+        "workspace stays available. IMPORTANT: each run_code starts a new Python process—variables do not "
+        "carry between run_code calls; only workspace files persist while the session is open. "
+        "When finished with a reused session, call stop_session with that session_id."
     )
     app = FastMCP(
         "agentcube-code-interpreter",
@@ -133,17 +143,47 @@ def create_mcp_server(
     )
     CodeInterpreterClient = _import_client()
 
-    @app.tool()
+    @app.tool(structured_output=False)
     def run_code(
-        language: str,
-        code: str,
-        session_id: Optional[str] = None,
-        session_reuse: bool = False,
-        timeout_seconds: Optional[float] = None,
+        language: Annotated[
+            str,
+            Field(
+                description="Interpreter language for CodeInterpreterClient.run_code (e.g. python, bash)."
+            ),
+        ],
+        code: Annotated[str, Field(description="Source or script body to execute in the sandbox.")],
+        session_id: Annotated[
+            Optional[str],
+            Field(
+                default=None,
+                description=(
+                    "Continue an existing sandbox: use the session_id string from a prior tool JSON response. "
+                    "Omit to start a new session."
+                ),
+            ),
+        ] = None,
+        session_reuse: Annotated[
+            bool,
+            Field(
+                default=False,
+                description=(
+                    "If false (default), the server stops the sandbox after this call—later calls cannot rely "
+                    "on files from this session. If true, the sandbox stays alive for follow-up tools; you MUST "
+                    "pass the returned session_id on the next call and call stop_session when done to free resources."
+                ),
+            ),
+        ] = False,
+        timeout_seconds: Annotated[
+            Optional[float],
+            Field(
+                default=None,
+                description="Optional execution timeout in seconds for this run_code invocation.",
+            ),
+        ] = None,
     ) -> str:
         """Execute code in an AgentCube Code Interpreter session (via Router)."""
-        env = _load_env()
-        client = _client_for_call(session_id, session_reuse, env, CodeInterpreterClient)
+        cfg = _load_server()
+        client = _client_for_call(session_id, session_reuse, cfg, CodeInterpreterClient)
         try:
             out = client.run_code(language, code, timeout=timeout_seconds)
             return _json_ok(
@@ -155,67 +195,122 @@ def create_mcp_server(
         finally:
             _cleanup_after_call(client, session_reuse)
 
-    @app.tool()
+    @app.tool(structured_output=False)
     def execute_command(
-        command: str,
-        session_id: Optional[str] = None,
-        session_reuse: bool = False,
-        timeout_seconds: Optional[float] = None,
+        command: Annotated[str, Field(description="Shell command to run inside the interpreter sandbox.")],
+        session_id: Annotated[
+            Optional[str],
+            Field(
+                default=None,
+                description="Existing session_id from a prior tool response; omit for a new session.",
+            ),
+        ] = None,
+        session_reuse: Annotated[
+            bool,
+            Field(
+                default=False,
+                description=(
+                    "False: stop sandbox after this call. True: keep sandbox for follow-up; pass session_id next "
+                    "and stop_session when finished."
+                ),
+            ),
+        ] = False,
+        timeout_seconds: Annotated[
+            Optional[float],
+            Field(default=None, description="Optional timeout in seconds for this command."),
+        ] = None,
     ) -> str:
         """Run a shell command in the Code Interpreter sandbox."""
-        env = _load_env()
-        client = _client_for_call(session_id, session_reuse, env, CodeInterpreterClient)
+        cfg = _load_server()
+        client = _client_for_call(session_id, session_reuse, cfg, CodeInterpreterClient)
         try:
             out = client.execute_command(command, timeout=timeout_seconds)
             return _json_ok({"session_id": client.session_id, "output": out})
         finally:
             _cleanup_after_call(client, session_reuse)
 
-    @app.tool()
+    @app.tool(structured_output=False)
     def write_file(
-        content: str,
-        remote_path: str,
-        session_id: Optional[str] = None,
-        session_reuse: bool = False,
+        content: Annotated[str, Field(description="File contents to write (text).")],
+        remote_path: Annotated[
+            str,
+            Field(
+                description="Path relative to the interpreter workspace (e.g. data/input.txt)."
+            ),
+        ],
+        session_id: Annotated[
+            Optional[str],
+            Field(default=None, description="Existing session_id; omit to create a new session."),
+        ] = None,
+        session_reuse: Annotated[
+            bool,
+            Field(
+                default=False,
+                description=(
+                    "Set true when more steps will read or run against this file; then pass session_id on "
+                    "follow-up tools and stop_session when done. If false, the session ends after this write."
+                ),
+            ),
+        ] = False,
     ) -> str:
         """Write text to a path inside the interpreter workspace (CodeInterpreterClient.write_file)."""
-        env = _load_env()
-        client = _client_for_call(session_id, session_reuse, env, CodeInterpreterClient)
+        cfg = _load_server()
+        client = _client_for_call(session_id, session_reuse, cfg, CodeInterpreterClient)
         try:
             client.write_file(content, remote_path)
             return _json_ok({"session_id": client.session_id, "remote_path": remote_path, "status": "ok"})
         finally:
             _cleanup_after_call(client, session_reuse)
 
-    @app.tool()
+    @app.tool(structured_output=False)
     def list_files(
-        path: str = ".",
-        session_id: Optional[str] = None,
-        session_reuse: bool = False,
+        path: Annotated[
+            str,
+            Field(
+                default=".",
+                description="Directory path inside the workspace to list (default: current/workspace root).",
+            ),
+        ] = ".",
+        session_id: Annotated[
+            Optional[str],
+            Field(default=None, description="Existing session_id; omit to create a new session."),
+        ] = None,
+        session_reuse: Annotated[
+            bool,
+            Field(
+                default=False,
+                description="True to keep the session after listing for further tools; false to tear down after.",
+            ),
+        ] = False,
     ) -> str:
         """List files in the interpreter workspace (CodeInterpreterClient.list_files)."""
-        env = _load_env()
-        client = _client_for_call(session_id, session_reuse, env, CodeInterpreterClient)
+        cfg = _load_server()
+        client = _client_for_call(session_id, session_reuse, cfg, CodeInterpreterClient)
         try:
             files = client.list_files(path)
             return _json_ok({"session_id": client.session_id, "path": path, "entries": files})
         finally:
             _cleanup_after_call(client, session_reuse)
 
-    @app.tool()
-    def stop_session(session_id: str) -> str:
+    @app.tool(structured_output=False)
+    def stop_session(
+        session_id: Annotated[
+            str,
+            Field(description="The session_id to terminate; must match a session you opened with session_reuse."),
+        ],
+    ) -> str:
         """Stop and delete a session (CodeInterpreterClient.stop); required after session_reuse."""
-        env = _load_env()
+        cfg = _load_server()
         with _SESSION_LOCK:
             client = _SESSIONS.pop(session_id, None)
         if client is None:
             c = CodeInterpreterClient(
-                name=env.code_interpreter_name,
-                namespace=env.namespace,
-                ttl=env.ttl,
-                workload_manager_url=env.workload_manager_url,
-                router_url=env.router_url,
-                auth_token=env.auth_token,
+                name=cfg.code_interpreter_name,
+                namespace=cfg.namespace,
+                ttl=cfg.ttl,
+                workload_manager_url=cfg.workload_manager_url,
+                router_url=cfg.router_url,
+                auth_token=cfg.auth_token,
                 session_id=session_id,
             )
             c.stop()

--- a/integrations/code-interpreter-mcp/agentcube_code_interpreter_mcp/server.py
+++ b/integrations/code-interpreter-mcp/agentcube_code_interpreter_mcp/server.py
@@ -7,7 +7,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 import threading
 from collections.abc import Callable
@@ -117,10 +116,6 @@ def _cleanup_after_call(client: Any, session_reuse: bool) -> None:
                 _SESSIONS.pop(sid, None)
 
 
-def _json_ok(payload: dict[str, Any]) -> str:
-    return json.dumps(payload, ensure_ascii=False)
-
-
 def _is_stale_session_error(exc: BaseException) -> bool:
     """Router returns 404 for unknown/expired session (see pkg/router session not found)."""
     if isinstance(exc, requests.HTTPError):
@@ -220,7 +215,7 @@ def create_mcp_server(
                 description="Run timeout (seconds).",
             ),
         ] = None,
-    ) -> str:
+    ) -> dict[str, Any]:
         """Run code in the sandbox."""
         cfg = _load_server()
 
@@ -232,7 +227,7 @@ def create_mcp_server(
         )
         payload: dict[str, Any] = {"session_id": sid, "output": out}
         payload.update(meta)
-        return _json_ok(payload)
+        return payload
 
     @app.tool(structured_output=False)
     def execute_command(
@@ -255,7 +250,7 @@ def create_mcp_server(
             Optional[float],
             Field(default=None, description="Timeout (seconds)."),
         ] = None,
-    ) -> str:
+    ) -> dict[str, Any]:
         """Run shell in sandbox."""
         cfg = _load_server()
 
@@ -267,7 +262,7 @@ def create_mcp_server(
         )
         payload: dict[str, Any] = {"session_id": sid, "output": out}
         payload.update(meta)
-        return _json_ok(payload)
+        return payload
 
     @app.tool(structured_output=False)
     def write_file(
@@ -289,7 +284,7 @@ def create_mcp_server(
                 description="Keep session for follow-up; pass session_id; stop_session when done.",
             ),
         ] = False,
-    ) -> str:
+    ) -> dict[str, Any]:
         """Write a file in the workspace."""
         cfg = _load_server()
 
@@ -301,7 +296,7 @@ def create_mcp_server(
         )
         payload: dict[str, Any] = {"session_id": sid, "remote_path": remote_path, "status": "ok"}
         payload.update(meta)
-        return _json_ok(payload)
+        return payload
 
     @app.tool(structured_output=False)
     def list_files(
@@ -323,7 +318,7 @@ def create_mcp_server(
                 description="Keep session for more tools; else tear down after.",
             ),
         ] = False,
-    ) -> str:
+    ) -> dict[str, Any]:
         """List workspace directory."""
         cfg = _load_server()
 
@@ -335,7 +330,7 @@ def create_mcp_server(
         )
         payload: dict[str, Any] = {"session_id": sid, "path": path, "entries": files}
         payload.update(meta)
-        return _json_ok(payload)
+        return payload
 
     @app.tool(structured_output=False)
     def stop_session(
@@ -343,7 +338,7 @@ def create_mcp_server(
             str,
             Field(description="session_id to stop (from session_reuse)."),
         ],
-    ) -> str:
+    ) -> dict[str, Any]:
         """Stop a reused session."""
         cfg = _load_server()
         with _SESSION_LOCK:
@@ -359,8 +354,8 @@ def create_mcp_server(
                 session_id=session_id,
             )
             c.stop()
-            return _json_ok({"session_id": session_id, "status": "stopped"})
+            return {"session_id": session_id, "status": "stopped"}
         client.stop()
-        return _json_ok({"session_id": session_id, "status": "stopped"})
+        return {"session_id": session_id, "status": "stopped"}
 
     return app

--- a/integrations/code-interpreter-mcp/agentcube_code_interpreter_mcp/server.py
+++ b/integrations/code-interpreter-mcp/agentcube_code_interpreter_mcp/server.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 import json
 import os
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Annotated, Any, Optional
 
+import requests
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
@@ -119,6 +121,54 @@ def _json_ok(payload: dict[str, Any]) -> str:
     return json.dumps(payload, ensure_ascii=False)
 
 
+def _is_stale_session_error(exc: BaseException) -> bool:
+    """Router returns 404 for unknown/expired session (see pkg/router session not found)."""
+    if isinstance(exc, requests.HTTPError):
+        r = exc.response
+        if r is not None and r.status_code in (404, 410):
+            return True
+    return False
+
+
+def _drop_session_cache(session_id: str) -> None:
+    with _SESSION_LOCK:
+        _SESSIONS.pop(session_id, None)
+
+
+def _call_with_session_recovery(
+    session_id: Optional[str],
+    session_reuse: bool,
+    cfg: Server,
+    CodeInterpreterClient: type,
+    op: Callable[[Any], Any],
+) -> tuple[Any, dict[str, Any], str]:
+    """Run ``op(client)``; if the caller passed ``session_id`` and Router says it is gone, open a new session once."""
+    meta: dict[str, Any] = {}
+    client = _client_for_call(session_id, session_reuse, cfg, CodeInterpreterClient)
+    try:
+        try:
+            out = op(client)
+            return out, meta, client.session_id or ""
+        except Exception as e:
+            if not session_id or not _is_stale_session_error(e):
+                raise
+            _drop_session_cache(session_id)
+            try:
+                client.stop()
+            except Exception:
+                pass
+            client = _client_for_call(None, session_reuse, cfg, CodeInterpreterClient)
+            meta["session_recovered"] = True
+            meta["previous_session_id"] = session_id
+            meta["hint"] = (
+                "Old session expired or missing; new sandbox below. "
+            )
+            out = op(client)
+            return out, meta, client.session_id or ""
+    finally:
+        _cleanup_after_call(client, session_reuse)
+
+
 def create_mcp_server(
     *,
     host: str = "127.0.0.1",
@@ -127,7 +177,8 @@ def create_mcp_server(
 ) -> FastMCP:
     instr = instructions or (
         "AgentCube sandbox. Multi-step: session_reuse=true, pass session_id from prior JSON; "
-        "each run_code is a new process—only files persist. stop_session when done."
+        "each run_code is a new process—only files persist. stop_session when done. "
+        "If a session_id is expired, the server recreates the sandbox once (workspace files are lost)."
     )
     app = FastMCP(
         "agentcube-code-interpreter",
@@ -172,17 +223,16 @@ def create_mcp_server(
     ) -> str:
         """Run code in the sandbox."""
         cfg = _load_server()
-        client = _client_for_call(session_id, session_reuse, cfg, CodeInterpreterClient)
-        try:
-            out = client.run_code(language, code, timeout=timeout_seconds)
-            return _json_ok(
-                {
-                    "session_id": client.session_id,
-                    "output": out,
-                }
-            )
-        finally:
-            _cleanup_after_call(client, session_reuse)
+
+        def _op(c: Any) -> Any:
+            return c.run_code(language, code, timeout=timeout_seconds)
+
+        out, meta, sid = _call_with_session_recovery(
+            session_id, session_reuse, cfg, CodeInterpreterClient, _op
+        )
+        payload: dict[str, Any] = {"session_id": sid, "output": out}
+        payload.update(meta)
+        return _json_ok(payload)
 
     @app.tool(structured_output=False)
     def execute_command(
@@ -208,12 +258,16 @@ def create_mcp_server(
     ) -> str:
         """Run shell in sandbox."""
         cfg = _load_server()
-        client = _client_for_call(session_id, session_reuse, cfg, CodeInterpreterClient)
-        try:
-            out = client.execute_command(command, timeout=timeout_seconds)
-            return _json_ok({"session_id": client.session_id, "output": out})
-        finally:
-            _cleanup_after_call(client, session_reuse)
+
+        def _op(c: Any) -> Any:
+            return c.execute_command(command, timeout=timeout_seconds)
+
+        out, meta, sid = _call_with_session_recovery(
+            session_id, session_reuse, cfg, CodeInterpreterClient, _op
+        )
+        payload: dict[str, Any] = {"session_id": sid, "output": out}
+        payload.update(meta)
+        return _json_ok(payload)
 
     @app.tool(structured_output=False)
     def write_file(
@@ -238,12 +292,16 @@ def create_mcp_server(
     ) -> str:
         """Write a file in the workspace."""
         cfg = _load_server()
-        client = _client_for_call(session_id, session_reuse, cfg, CodeInterpreterClient)
-        try:
-            client.write_file(content, remote_path)
-            return _json_ok({"session_id": client.session_id, "remote_path": remote_path, "status": "ok"})
-        finally:
-            _cleanup_after_call(client, session_reuse)
+
+        def _op(c: Any) -> None:
+            c.write_file(content, remote_path)
+
+        _, meta, sid = _call_with_session_recovery(
+            session_id, session_reuse, cfg, CodeInterpreterClient, _op
+        )
+        payload: dict[str, Any] = {"session_id": sid, "remote_path": remote_path, "status": "ok"}
+        payload.update(meta)
+        return _json_ok(payload)
 
     @app.tool(structured_output=False)
     def list_files(
@@ -268,12 +326,16 @@ def create_mcp_server(
     ) -> str:
         """List workspace directory."""
         cfg = _load_server()
-        client = _client_for_call(session_id, session_reuse, cfg, CodeInterpreterClient)
-        try:
-            files = client.list_files(path)
-            return _json_ok({"session_id": client.session_id, "path": path, "entries": files})
-        finally:
-            _cleanup_after_call(client, session_reuse)
+
+        def _op(c: Any) -> Any:
+            return c.list_files(path)
+
+        files, meta, sid = _call_with_session_recovery(
+            session_id, session_reuse, cfg, CodeInterpreterClient, _op
+        )
+        payload: dict[str, Any] = {"session_id": sid, "path": path, "entries": files}
+        payload.update(meta)
+        return _json_ok(payload)
 
     @app.tool(structured_output=False)
     def stop_session(

--- a/integrations/code-interpreter-mcp/agentcube_code_interpreter_mcp/server.py
+++ b/integrations/code-interpreter-mcp/agentcube_code_interpreter_mcp/server.py
@@ -1,0 +1,226 @@
+# Copyright The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""FastMCP server backed by AgentCube CodeInterpreterClient."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+_SESSION_LOCK = threading.RLock()
+_SESSIONS: dict[str, Any] = {}
+
+
+@dataclass(frozen=True)
+class ServerEnv:
+    router_url: str
+    workload_manager_url: str
+    namespace: str
+    code_interpreter_name: str
+    auth_token: Optional[str]
+    ttl: int
+
+
+def _load_env() -> ServerEnv:
+    router = os.environ.get("ROUTER_URL", "").strip()
+    wm = os.environ.get("WORKLOAD_MANAGER_URL", "").strip()
+    if not router:
+        raise RuntimeError("ROUTER_URL is required")
+    if not wm:
+        raise RuntimeError("WORKLOAD_MANAGER_URL is required")
+    token = os.environ.get("API_TOKEN") or os.environ.get("AGENTCUBE_API_TOKEN") or None
+    if token is not None:
+        token = token.strip() or None
+    return ServerEnv(
+        router_url=router,
+        workload_manager_url=wm,
+        namespace=os.environ.get("AGENTCUBE_NAMESPACE", "default").strip() or "default",
+        code_interpreter_name=os.environ.get("CODE_INTERPRETER_NAME", "my-interpreter").strip()
+        or "my-interpreter",
+        auth_token=token,
+        ttl=int(os.environ.get("CODE_INTERPRETER_SESSION_TTL", "3600")),
+    )
+
+
+def _import_client():
+    try:
+        from agentcube import CodeInterpreterClient
+    except ImportError as e:  # pragma: no cover - runtime guard
+        raise RuntimeError(
+            "agentcube SDK is not installed. Install with: pip install -e /path/to/sdk-python"
+        ) from e
+    return CodeInterpreterClient
+
+
+def _client_for_call(
+    session_id: Optional[str],
+    session_reuse: bool,
+    env: ServerEnv,
+    CodeInterpreterClient: type,
+):
+    with _SESSION_LOCK:
+        if session_id:
+            cached = _SESSIONS.get(session_id)
+            if cached is not None:
+                return cached
+            client = CodeInterpreterClient(
+                name=env.code_interpreter_name,
+                namespace=env.namespace,
+                ttl=env.ttl,
+                workload_manager_url=env.workload_manager_url,
+                router_url=env.router_url,
+                auth_token=env.auth_token,
+                session_id=session_id,
+            )
+            if session_reuse:
+                _SESSIONS[session_id] = client
+            return client
+        client = CodeInterpreterClient(
+            name=env.code_interpreter_name,
+            namespace=env.namespace,
+            ttl=env.ttl,
+            workload_manager_url=env.workload_manager_url,
+            router_url=env.router_url,
+            auth_token=env.auth_token,
+        )
+        if session_reuse and client.session_id:
+            _SESSIONS[client.session_id] = client
+        return client
+
+
+def _cleanup_after_call(client: Any, session_reuse: bool) -> None:
+    if session_reuse:
+        return
+    sid = getattr(client, "session_id", None)
+    try:
+        client.stop()
+    finally:
+        if sid:
+            with _SESSION_LOCK:
+                _SESSIONS.pop(sid, None)
+
+
+def _json_ok(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def create_mcp_server(
+    *,
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    instructions: str | None = None,
+) -> FastMCP:
+    instr = instructions or (
+        "AgentCube Code Interpreter tools. Set ROUTER_URL and WORKLOAD_MANAGER_URL on the server. "
+        "Use session_reuse=true to keep a sandbox session for multiple calls; pass session_id on later calls. "
+        "Call stop_session when finished if you used session_reuse."
+    )
+    app = FastMCP(
+        "agentcube-code-interpreter",
+        instructions=instr,
+        host=host,
+        port=port,
+        stateless_http=True,
+        json_response=True,
+    )
+    CodeInterpreterClient = _import_client()
+
+    @app.tool()
+    def run_code(
+        language: str,
+        code: str,
+        session_id: Optional[str] = None,
+        session_reuse: bool = False,
+        timeout_seconds: Optional[float] = None,
+    ) -> str:
+        """Execute code in an AgentCube Code Interpreter session (via Router)."""
+        env = _load_env()
+        client = _client_for_call(session_id, session_reuse, env, CodeInterpreterClient)
+        try:
+            out = client.run_code(language, code, timeout=timeout_seconds)
+            return _json_ok(
+                {
+                    "session_id": client.session_id,
+                    "output": out,
+                }
+            )
+        finally:
+            _cleanup_after_call(client, session_reuse)
+
+    @app.tool()
+    def execute_command(
+        command: str,
+        session_id: Optional[str] = None,
+        session_reuse: bool = False,
+        timeout_seconds: Optional[float] = None,
+    ) -> str:
+        """Run a shell command in the Code Interpreter sandbox."""
+        env = _load_env()
+        client = _client_for_call(session_id, session_reuse, env, CodeInterpreterClient)
+        try:
+            out = client.execute_command(command, timeout=timeout_seconds)
+            return _json_ok({"session_id": client.session_id, "output": out})
+        finally:
+            _cleanup_after_call(client, session_reuse)
+
+    @app.tool()
+    def write_file(
+        content: str,
+        remote_path: str,
+        session_id: Optional[str] = None,
+        session_reuse: bool = False,
+    ) -> str:
+        """Write text to a path inside the interpreter workspace (CodeInterpreterClient.write_file)."""
+        env = _load_env()
+        client = _client_for_call(session_id, session_reuse, env, CodeInterpreterClient)
+        try:
+            client.write_file(content, remote_path)
+            return _json_ok({"session_id": client.session_id, "remote_path": remote_path, "status": "ok"})
+        finally:
+            _cleanup_after_call(client, session_reuse)
+
+    @app.tool()
+    def list_files(
+        path: str = ".",
+        session_id: Optional[str] = None,
+        session_reuse: bool = False,
+    ) -> str:
+        """List files in the interpreter workspace (CodeInterpreterClient.list_files)."""
+        env = _load_env()
+        client = _client_for_call(session_id, session_reuse, env, CodeInterpreterClient)
+        try:
+            files = client.list_files(path)
+            return _json_ok({"session_id": client.session_id, "path": path, "entries": files})
+        finally:
+            _cleanup_after_call(client, session_reuse)
+
+    @app.tool()
+    def stop_session(session_id: str) -> str:
+        """Stop and delete a session (CodeInterpreterClient.stop); required after session_reuse."""
+        env = _load_env()
+        with _SESSION_LOCK:
+            client = _SESSIONS.pop(session_id, None)
+        if client is None:
+            c = CodeInterpreterClient(
+                name=env.code_interpreter_name,
+                namespace=env.namespace,
+                ttl=env.ttl,
+                workload_manager_url=env.workload_manager_url,
+                router_url=env.router_url,
+                auth_token=env.auth_token,
+                session_id=session_id,
+            )
+            c.stop()
+            return _json_ok({"session_id": session_id, "status": "stopped"})
+        client.stop()
+        return _json_ok({"session_id": session_id, "status": "stopped"})
+
+    return app

--- a/integrations/code-interpreter-mcp/deployment.yaml
+++ b/integrations/code-interpreter-mcp/deployment.yaml
@@ -1,0 +1,71 @@
+# Copyright The Volcano Authors.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Example: deploy MCP server in-cluster. Adjust URLs and secrets for your environment.
+apiVersion: v1
+kind: Service
+metadata:
+  name: agentcube-code-interpreter-mcp
+  namespace: agentcube
+  labels:
+    app: agentcube-code-interpreter-mcp
+spec:
+  selector:
+    app: agentcube-code-interpreter-mcp
+  ports:
+    - name: mcp
+      port: 8000
+      targetPort: 8000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agentcube-code-interpreter-mcp
+  namespace: agentcube
+  labels:
+    app: agentcube-code-interpreter-mcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: agentcube-code-interpreter-mcp
+  template:
+    metadata:
+      labels:
+        app: agentcube-code-interpreter-mcp
+    spec:
+      containers:
+        - name: mcp
+          image: agentcube-code-interpreter-mcp:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+              name: mcp
+          env:
+            # Data plane — Router Service in the same namespace
+            - name: ROUTER_URL
+              value: "http://agentcube-router.agentcube.svc.cluster.local:8080"
+            # Control plane — Workload Manager Service
+            - name: WORKLOAD_MANAGER_URL
+              value: "http://workloadmanager.agentcube.svc.cluster.local:8080"
+            - name: AGENTCUBE_NAMESPACE
+              value: "agentcube"
+            - name: CODE_INTERPRETER_NAME
+              value: "e2e-code-interpreter"
+            # Optional: mount projected token or use CSI; placeholder for in-cluster auth
+            # - name: API_TOKEN
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: agentcube-mcp-token
+            #       key: token
+          readinessProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 20

--- a/integrations/code-interpreter-mcp/deployment.yaml
+++ b/integrations/code-interpreter-mcp/deployment.yaml
@@ -26,6 +26,8 @@ metadata:
   labels:
     app: agentcube-code-interpreter-mcp
 spec:
+  # Session reuse caches CodeInterpreterClient in this process memory (_SESSIONS).
+  # Do not scale above 1 replica unless the gateway pins all MCP traffic to one Pod.
   replicas: 1
   selector:
     matchLabels:

--- a/integrations/code-interpreter-mcp/pyproject.toml
+++ b/integrations/code-interpreter-mcp/pyproject.toml
@@ -17,6 +17,7 @@ requires-python = ">=3.10"
 dependencies = [
     "mcp>=1.8.0",
     "pydantic>=2.0.0",
+    "requests>=2.28.0",
     "uvicorn>=0.30.0",
 ]
 

--- a/integrations/code-interpreter-mcp/pyproject.toml
+++ b/integrations/code-interpreter-mcp/pyproject.toml
@@ -16,6 +16,7 @@ license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "mcp>=1.8.0",
+    "pydantic>=2.0.0",
     "uvicorn>=0.30.0",
 ]
 

--- a/integrations/code-interpreter-mcp/pyproject.toml
+++ b/integrations/code-interpreter-mcp/pyproject.toml
@@ -1,0 +1,27 @@
+# Copyright The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "agentcube-code-interpreter-mcp"
+version = "0.1.0"
+description = "MCP server exposing AgentCube Code Interpreter (Router + Workload Manager)"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.10"
+dependencies = [
+    "mcp>=1.8.0",
+    "uvicorn>=0.30.0",
+]
+
+[project.scripts]
+agentcube-code-interpreter-mcp = "agentcube_code_interpreter_mcp.__main__:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["agentcube_code_interpreter_mcp*"]

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -36,7 +36,7 @@ The `run_e2e.sh` script performs the following steps:
 4. Loads images into Kind cluster
 5. Deploys Redis, WorkloadManager, and Router
 6. Creates test resources (AgentRuntime, CodeInterpreter)
-7. Runs Go tests and Python SDK tests
+7. Runs Go tests, Python SDK tests, MCP tests (local HTTP, stdio, and in-cluster Deployment when setup is not skipped)
 8. Cleans up resources
 
 ## Prerequisites
@@ -78,6 +78,25 @@ E2E_SKIP_SETUP=true ./test/e2e/run_e2e.sh
 | `test_case2_code_execution_in_session` | Stateless execution verification (variables not preserved) |
 | `test_case3_file_based_workflow_fibonacci_json` | File upload, execution, and download workflow |
 
+### Code Interpreter MCP (`test_mcp_code_interpreter.py`)
+
+| Test | Description |
+|------|-------------|
+| `test_mcp_protocol_initialize_ping_list_tools` | MCP `initialize`, notification path, `ping`, `tools/list`; asserts tools `run_code`, `execute_command`, `write_file`, `list_files`, `stop_session` |
+| `test_mcp_execute_command` | `execute_command`: `echo` output |
+| `test_mcp_stateless_execution_nameerror` | Two `run_code` on same session (SDK case2); second expects `isError` + NameError-like text |
+| `test_mcp_write_list_run_code_file_workflow` | `write_file` → `list_files` → `run_code` read file; `session_reuse` + `stop_session` (light SDK case3 + reuse) |
+
+Minimal **`run_code`** smoke (SDK case1 style) lives in **`test_mcp_code_interpreter_stdio.py`** and **`test_mcp_code_interpreter_k8s.py`** to avoid duplicating the same check three times.
+
+**`test_mcp_code_interpreter_stdio.py`** — MCP **stdio**: `stdio_client` spawns `python -m agentcube_code_interpreter_mcp --transport stdio`, then `initialize` / `list_tools` / `run_code` against live Router/WM (same env as other Python E2E).
+
+**`test_mcp_code_interpreter_k8s.py`** — MCP **in-cluster**: `run_e2e.sh` builds the MCP image, loads it into Kind, applies `integrations/code-interpreter-mcp/deployment.yaml`, injects `API_TOKEN`, port-forwards `svc/agentcube-code-interpreter-mcp`, sets **`MCP_K8S_MCP_URL`**, then runs streamable-http client tests against the Pod.
+
+When **`E2E_SKIP_SETUP=true`**, the in-cluster MCP build/load/deploy step is **skipped** (image may not exist in Kind).
+
+Local subprocess MCP tests use **Streamable HTTP** at `/mcp` on `127.0.0.1:19245` by default (`MCP_E2E_HOST` / `MCP_E2E_PORT`).
+
 ## Environment Variables
 
 | Variable | Default | Description |
@@ -89,6 +108,8 @@ E2E_SKIP_SETUP=true ./test/e2e/run_e2e.sh
 | `E2E_VENV_DIR` | `/tmp/agentcube-e2e-venv` | Python virtual environment path |
 | `WORKLOAD_MANAGER_LOCAL_PORT` | `8080` | Local port for WorkloadManager |
 | `ROUTER_LOCAL_PORT` | `8081` | Local port for Router |
+| `MCP_K8S_LOCAL_PORT` | `19446` | Local port for port-forward to in-cluster MCP Service |
+| `MCP_K8S_MCP_URL` | *(set by script)* | e.g. `http://127.0.0.1:19446/mcp` — only required for `test_mcp_code_interpreter_k8s.py` when run alone |
 
 ## Test Resources
 

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -13,6 +13,10 @@ PICOD_IMAGE=${PICOD_IMAGE:-picod:latest}
 REDIS_IMAGE=${REDIS_IMAGE:-redis:7-alpine}
 AGENTCUBE_NAMESPACE=${AGENTCUBE_NAMESPACE:-agentcube}
 E2E_VENV_DIR=${E2E_VENV_DIR:-/tmp/agentcube-e2e-venv}
+MCP_K8S_LOCAL_PORT=${MCP_K8S_LOCAL_PORT:-19446}
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+REPO_ROOT="$(cd "$_SCRIPT_DIR/../.." && pwd)"
 
 # Images that need to be pre-pulled and loaded into kind cluster
 # Based on agent-sandbox manifest analysis, only these images are needed:
@@ -42,6 +46,13 @@ cleanup() {
         echo "Stopping router port forward (PID: $ROUTER_PID)..."
         kill "$ROUTER_PID" 2>/dev/null || true
     fi
+    if [ -n "${MCP_K8S_PF_PID:-}" ]; then
+        echo "Stopping MCP in-cluster port forward (PID: $MCP_K8S_PF_PID)..."
+        kill "$MCP_K8S_PF_PID" 2>/dev/null || true
+    fi
+
+    # Best-effort: remove MCP Deployment so the next run starts clean
+    kubectl delete deployment agentcube-code-interpreter-mcp -n "${AGENTCUBE_NAMESPACE:-agentcube}" --ignore-not-found=true 2>/dev/null || true
 
     # Kill any remaining kubectl port-forward processes
     echo "Killing any remaining kubectl port-forward processes..."
@@ -51,8 +62,8 @@ cleanup() {
     sleep 2
 
     # Force kill any remaining processes on our ports
-    echo "Force killing any processes using ports 8080-8081..."
-    for port in 8080 8081; do
+    echo "Force killing any processes using ports 8080-8081 and MCP_K8S_LOCAL_PORT..."
+    for port in 8080 8081 "${MCP_K8S_LOCAL_PORT:-19446}"; do
         # Try lsof first (most Linux systems)
         if command -v lsof >/dev/null 2>&1 && lsof -i :$port >/dev/null 2>&1; then
             echo "Port $port is still in use, force killing with lsof..."
@@ -134,6 +145,9 @@ collect_component_logs() {
     
     # 2. Collect router logs
     collect_pod_logs "app=agentcube-router" "router" "${artifacts_dir}"
+
+    # 2b. MCP server (in-cluster E2E)
+    collect_pod_logs "app=agentcube-code-interpreter-mcp" "code-interpreter-mcp" "${artifacts_dir}"
     
     # 3. Collect Sandbox Pods logs (per-container: agentd, picod, etc.)
     echo "Collecting sandbox pods logs (agentd/picod per container)..."
@@ -375,7 +389,7 @@ step "Pre-cleanup"
 # Clean up any leftover processes before starting
 echo "Performing pre-run cleanup..."
 pkill -f "kubectl port-forward" 2>/dev/null || true
-for port in 8080 8081; do
+for port in 8080 8081 "${MCP_K8S_LOCAL_PORT:-19446}" 19245; do
     if command -v lsof > /dev/null 2>&1 && lsof -i :$port > /dev/null 2>&1; then
         lsof -ti :$port | xargs kill -9 2>/dev/null || true
     elif command -v netstat > /dev/null 2>&1 && netstat -tulpn 2>/dev/null | grep ":$port " > /dev/null; then
@@ -441,6 +455,7 @@ pip install --upgrade pip
 # Install agentcube SDK in development mode
 # We are currently in project root, sdk-python is at ./sdk-python
 pip install -e ./sdk-python
+pip install -e ./integrations/code-interpreter-mcp
 
 # Check if agentcube package is available after installation
 require_python
@@ -458,6 +473,46 @@ cd "$(dirname "$0")"
 
 if ! WORKLOAD_MANAGER_URL="http://localhost:${WORKLOAD_MANAGER_LOCAL_PORT}" ROUTER_URL="http://localhost:${ROUTER_LOCAL_PORT}" API_TOKEN=$API_TOKEN AGENTCUBE_NAMESPACE="${AGENTCUBE_NAMESPACE}" "$E2E_VENV_DIR/bin/python" test_codeinterpreter.py; then
     TEST_FAILED=1
+fi
+
+echo "Running Python Code Interpreter MCP tests (streamable-http, local subprocess)..."
+if ! WORKLOAD_MANAGER_URL="http://localhost:${WORKLOAD_MANAGER_LOCAL_PORT}" ROUTER_URL="http://localhost:${ROUTER_LOCAL_PORT}" API_TOKEN=$API_TOKEN AGENTCUBE_NAMESPACE="${AGENTCUBE_NAMESPACE}" "$E2E_VENV_DIR/bin/python" test_mcp_code_interpreter.py; then
+    TEST_FAILED=1
+fi
+
+echo "Running Python Code Interpreter MCP stdio tests..."
+if ! WORKLOAD_MANAGER_URL="http://localhost:${WORKLOAD_MANAGER_LOCAL_PORT}" ROUTER_URL="http://localhost:${ROUTER_LOCAL_PORT}" API_TOKEN=$API_TOKEN AGENTCUBE_NAMESPACE="${AGENTCUBE_NAMESPACE}" "$E2E_VENV_DIR/bin/python" test_mcp_code_interpreter_stdio.py; then
+    TEST_FAILED=1
+fi
+
+if [ "${E2E_SKIP_SETUP}" = "true" ]; then
+    echo "Skipping MCP in-cluster Deployment E2E (E2E_SKIP_SETUP=true — image may not be loaded in Kind)."
+else
+    step "Building and deploying MCP server into Kind for in-cluster E2E..."
+    cd "$REPO_ROOT"
+    docker build -f integrations/code-interpreter-mcp/Dockerfile -t agentcube-code-interpreter-mcp:latest .
+    kind load docker-image agentcube-code-interpreter-mcp:latest --name "${E2E_CLUSTER_NAME}"
+    kubectl apply -f integrations/code-interpreter-mcp/deployment.yaml
+    kubectl -n "${AGENTCUBE_NAMESPACE}" rollout status deployment/agentcube-code-interpreter-mcp --timeout=300s
+    kubectl -n "${AGENTCUBE_NAMESPACE}" set env deployment/agentcube-code-interpreter-mcp "API_TOKEN=${API_TOKEN}"
+    kubectl -n "${AGENTCUBE_NAMESPACE}" rollout status deployment/agentcube-code-interpreter-mcp --timeout=300s
+
+    echo "Starting MCP in-cluster port-forward (localhost:${MCP_K8S_LOCAL_PORT} -> svc/agentcube-code-interpreter-mcp)..."
+    kubectl port-forward -n "${AGENTCUBE_NAMESPACE}" "svc/agentcube-code-interpreter-mcp" "${MCP_K8S_LOCAL_PORT}:8000" >/tmp/mcp_k8s_port_forward.log 2>&1 &
+    MCP_K8S_PF_PID=$!
+    sleep 2
+    if ! kill -0 "$MCP_K8S_PF_PID" 2>/dev/null; then
+        echo "Failed to start MCP port-forward. Check /tmp/mcp_k8s_port_forward.log" >&2
+        cat /tmp/mcp_k8s_port_forward.log >&2 || true
+        TEST_FAILED=1
+    else
+        echo "Running Python Code Interpreter MCP in-cluster (K8s Pod) tests..."
+        cd "$_SCRIPT_DIR"
+        export MCP_K8S_MCP_URL="http://127.0.0.1:${MCP_K8S_LOCAL_PORT}/mcp"
+        if ! "$E2E_VENV_DIR/bin/python" test_mcp_code_interpreter_k8s.py; then
+            TEST_FAILED=1
+        fi
+    fi
 fi
 
 # Collect logs if tests failed

--- a/test/e2e/test_mcp_code_interpreter.py
+++ b/test/e2e/test_mcp_code_interpreter.py
@@ -28,6 +28,7 @@ import os
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 import unittest
 from contextlib import asynccontextmanager
@@ -40,6 +41,8 @@ EXPECTED_MCP_TOOLS = frozenset(
         "execute_command",
         "write_file",
         "list_files",
+        "upload_file",
+        "download_file",
         "stop_session",
     }
 )
@@ -311,6 +314,66 @@ class TestMCPCodeInterpreterE2E(unittest.TestCase):
                 self.assertFalse(st.isError, _tool_result_text(st))
                 d_stop = json.loads(_tool_result_text(st))
                 self.assertEqual(d_stop.get("status"), "stopped")
+
+        _run_async(body())
+
+    def test_mcp_upload_download_roundtrip(self):
+        """upload_file (local temp) -> download_file; paths are on the MCP server host (E2E subprocess)."""
+
+        async def body():
+            payload_bytes = f"upload-dl-{int(time.time())}\n".encode("utf-8")
+            remote = f"mcp_roundtrip_{int(time.time())}.txt"
+            sid: str | None = None
+            src_path: str | None = None
+            out_path: str | None = None
+            async with _mcp_client_session(self.host, self.port) as (session, _):
+                try:
+                    with tempfile.NamedTemporaryFile(delete=False) as src:
+                        src.write(payload_bytes)
+                        src.flush()
+                        src_path = src.name
+                    assert src_path is not None
+                    out_path = f"{src_path}.downloaded"
+
+                    u = await session.call_tool(
+                        "upload_file",
+                        {
+                            "local_path": src_path,
+                            "remote_path": remote,
+                            "session_reuse": True,
+                        },
+                    )
+                    self.assertFalse(u.isError, _tool_result_text(u))
+                    sid = json.loads(_tool_result_text(u))["session_id"]
+
+                    d = await session.call_tool(
+                        "download_file",
+                        {
+                            "remote_path": remote,
+                            "local_path": out_path,
+                            "session_id": sid,
+                            "session_reuse": True,
+                        },
+                    )
+                    self.assertFalse(d.isError, _tool_result_text(d))
+
+                    with open(out_path, "rb") as f:
+                        self.assertEqual(f.read(), payload_bytes)
+                    print(f"[MCP E2E] upload_file -> download_file roundtrip ok remote={remote!r}")
+                finally:
+                    if src_path:
+                        try:
+                            os.unlink(src_path)
+                        except OSError:
+                            pass
+                    if out_path:
+                        try:
+                            os.unlink(out_path)
+                        except OSError:
+                            pass
+                    if sid:
+                        st = await session.call_tool("stop_session", {"session_id": sid})
+                        self.assertFalse(st.isError, _tool_result_text(st))
 
         _run_async(body())
 

--- a/test/e2e/test_mcp_code_interpreter.py
+++ b/test/e2e/test_mcp_code_interpreter.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+# Copyright The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""E2E: AgentCube Code Interpreter MCP server (streamable-http) against live Router/WM.
+
+Mirrors ``test_codeinterpreter.py`` themes: stateless runs, file write/list/read (session reuse + ``stop_session``).
+Also exercises MCP lifecycle: initialize, Initialized notification path, ping, tools/list and schemas.
+Simple ``run_code`` smoke is covered by ``test_mcp_code_interpreter_stdio.py`` and ``test_mcp_code_interpreter_k8s.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import unittest
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator
+
+# Must match tools registered in integrations/code-interpreter-mcp/server.py
+EXPECTED_MCP_TOOLS = frozenset(
+    {
+        "run_code",
+        "execute_command",
+        "write_file",
+        "list_files",
+        "stop_session",
+    }
+)
+
+
+def _wait_tcp(host: str, port: int, timeout_s: float = 45.0) -> None:
+    deadline = time.monotonic() + timeout_s
+    last_err: OSError | None = None
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=1.0):
+                return
+        except OSError as e:
+            last_err = e
+            time.sleep(0.2)
+    raise RuntimeError(f"timeout waiting for {host}:{port}: {last_err}")
+
+
+def _tool_result_text(result: Any) -> str:
+    parts: list[str] = []
+    for block in getattr(result, "content", []) or []:
+        t = getattr(block, "text", None)
+        if isinstance(t, str):
+            parts.append(t)
+    return "\n".join(parts)
+
+
+@asynccontextmanager
+async def _mcp_client_session(
+    host: str,
+    port: int,
+    *,
+    request_timeout: float = 120.0,
+) -> AsyncIterator[tuple[Any, Any]]:
+    """MCP Streamable HTTP client session; closes cleanly on exit."""
+    import httpx
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamable_http_client
+
+    url = f"http://{host}:{port}/mcp"
+    async with httpx.AsyncClient(timeout=request_timeout) as http_client:
+        async with streamable_http_client(url, http_client=http_client) as (
+            read_stream,
+            write_stream,
+            _,
+        ):
+            async with ClientSession(read_stream, write_stream) as session:
+                init_result = await session.initialize()
+                yield session, init_result
+
+
+def _run_async(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+class TestMCPCodeInterpreterE2E(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.host = os.environ.get("MCP_E2E_HOST", "127.0.0.1")
+        cls.port = int(os.environ.get("MCP_E2E_PORT", "19245"))
+        cls.router = os.environ["ROUTER_URL"]
+        cls.wm = os.environ["WORKLOAD_MANAGER_URL"]
+        cls.token = os.environ.get("API_TOKEN", "")
+        cls.ns = os.environ.get("AGENTCUBE_NAMESPACE", "agentcube")
+
+        print(
+            "\n[MCP E2E] environment: "
+            f"namespace={cls.ns}, router={cls.router}, workload_manager={cls.wm}, "
+            f"mcp_listen=http://{cls.host}:{cls.port}/mcp\n"
+        )
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "ROUTER_URL": cls.router,
+                "WORKLOAD_MANAGER_URL": cls.wm,
+                "AGENTCUBE_NAMESPACE": cls.ns,
+                "CODE_INTERPRETER_NAME": "e2e-code-interpreter",
+                "MCP_TRANSPORT": "streamable-http",
+                "MCP_HOST": cls.host,
+                "MCP_PORT": str(cls.port),
+            }
+        )
+        if cls.token:
+            env["API_TOKEN"] = cls.token
+
+        cls.proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "agentcube_code_interpreter_mcp",
+                "--transport",
+                "streamable-http",
+                "--host",
+                cls.host,
+                "--port",
+                str(cls.port),
+            ],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            _wait_tcp(cls.host, cls.port, timeout_s=60.0)
+        except Exception as e:
+            cls.proc.kill()
+            raise RuntimeError(
+                f"MCP server failed to bind {cls.host}:{cls.port} (process exit code {cls.proc.poll()})"
+            ) from e
+        print(f"[MCP E2E] subprocess MCP server started (pid={cls.proc.pid})\n")
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "proc", None) is not None:
+            cls.proc.terminate()
+            try:
+                cls.proc.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                cls.proc.kill()
+            print("[MCP E2E] MCP server subprocess stopped\n")
+
+    def test_mcp_protocol_initialize_ping_list_tools(self):
+        """MCP: initialize, ping, tools/list; assert full tool surface and inputSchema."""
+
+        async def body():
+            async with _mcp_client_session(self.host, self.port) as (session, init_result):
+                self.assertIsNotNone(init_result.protocolVersion, "initialize must return protocolVersion")
+                print(f"[MCP E2E] initialize protocolVersion={init_result.protocolVersion!r}")
+                si = init_result.serverInfo
+                if si is not None:
+                    print(f"[MCP E2E] serverInfo.name={getattr(si, 'name', None)!r}")
+
+                ping = await session.send_ping()
+                self.assertIsNotNone(ping)
+                print("[MCP E2E] ping ok")
+
+                tools_resp = await session.list_tools()
+                names = {t.name for t in tools_resp.tools}
+                self.assertEqual(
+                    names,
+                    EXPECTED_MCP_TOOLS,
+                    f"list_tools must expose exactly {EXPECTED_MCP_TOOLS}, got {names}",
+                )
+                for t in tools_resp.tools:
+                    self.assertTrue(
+                        (t.description or "").strip(),
+                        f"tool {t.name!r} must have a non-empty description",
+                    )
+                    schema = getattr(t, "inputSchema", None) or {}
+                    self.assertEqual(
+                        schema.get("type"),
+                        "object",
+                        f"tool {t.name!r} inputSchema.type must be object",
+                    )
+                    props = schema.get("properties")
+                    if not isinstance(props, dict):
+                        self.fail(f"tool {t.name!r} inputSchema.properties must be dict, got {props!r}")
+                    print(f"[MCP E2E] tool {t.name!r} input properties: {list(props.keys())}")
+
+        _run_async(body())
+
+    def test_mcp_execute_command(self):
+        """Covers execute_command tool."""
+
+        async def body():
+            async with _mcp_client_session(self.host, self.port) as (session, _):
+                res = await session.call_tool(
+                    "execute_command",
+                    {
+                        "command": "echo mcp-cmd-ok",
+                        "session_reuse": False,
+                    },
+                )
+                self.assertFalse(res.isError, _tool_result_text(res))
+                data = json.loads(_tool_result_text(res))
+                self.assertIn("mcp-cmd-ok", data.get("output", ""), data)
+                print(f"[MCP E2E] execute_command ok: {data!r}")
+
+        _run_async(body())
+
+    def test_mcp_stateless_execution_nameerror(self):
+        """SDK case2 equivalent: two run_code calls on same session; second fails (isError)."""
+
+        async def body():
+            async with _mcp_client_session(self.host, self.port) as (session, _):
+                r1 = await session.call_tool(
+                    "run_code",
+                    {
+                        "language": "python",
+                        "code": "x = 10\nprint('defined')",
+                        "session_reuse": True,
+                    },
+                )
+                self.assertFalse(r1.isError, _tool_result_text(r1))
+                sid = json.loads(_tool_result_text(r1))["session_id"]
+                print(f"[MCP E2E] stateless step1 session_id={sid!r}")
+
+                r2 = await session.call_tool(
+                    "run_code",
+                    {
+                        "language": "python",
+                        "code": "print(x)",
+                        "session_id": sid,
+                        "session_reuse": True,
+                    },
+                )
+                self.assertTrue(r2.isError, "stateless print(x) must surface as MCP tool error")
+                err_text = _tool_result_text(r2)
+                self.assertTrue(
+                    "NameError" in err_text or "name 'x' is not defined" in err_text or "not defined" in err_text,
+                    err_text,
+                )
+                print(f"[MCP E2E] stateless step2 error as expected: {err_text[:200]!r}...")
+
+                r3 = await session.call_tool("stop_session", {"session_id": sid})
+                self.assertFalse(r3.isError, _tool_result_text(r3))
+
+        _run_async(body())
+
+    def test_mcp_write_list_run_code_file_workflow(self):
+        """SDK case3 light: write_file -> list_files -> run_code reads file; cross-tool session_reuse + stop_session."""
+
+        async def body():
+            marker = f"mcp-list-{int(time.time())}"
+            async with _mcp_client_session(self.host, self.port) as (session, _):
+                w = await session.call_tool(
+                    "write_file",
+                    {
+                        "content": marker,
+                        "remote_path": "mcp_marker.txt",
+                        "session_reuse": True,
+                    },
+                )
+                self.assertFalse(w.isError, _tool_result_text(w))
+                sid = json.loads(_tool_result_text(w))["session_id"]
+
+                lst = await session.call_tool(
+                    "list_files",
+                    {"path": ".", "session_id": sid, "session_reuse": True},
+                )
+                self.assertFalse(lst.isError, _tool_result_text(lst))
+                payload = json.loads(_tool_result_text(lst))
+                files = payload.get("entries") or []
+                names = []
+                for item in files:
+                    if isinstance(item, dict):
+                        names.append(item.get("name") or item.get("path") or "")
+                    else:
+                        names.append(str(item))
+                joined = " ".join(names)
+                self.assertIn("mcp_marker.txt", joined, payload)
+                print(f"[MCP E2E] list_files saw mcp_marker.txt in {joined!r}")
+
+                r = await session.call_tool(
+                    "run_code",
+                    {
+                        "language": "python",
+                        "code": "print(open('mcp_marker.txt').read())",
+                        "session_id": sid,
+                        "session_reuse": True,
+                    },
+                )
+                self.assertFalse(r.isError, _tool_result_text(r))
+                out = json.loads(_tool_result_text(r)).get("output", "")
+                self.assertIn(marker, out, out)
+                print(f"[MCP E2E] read marker via run_code ok: {out!r}")
+
+                st = await session.call_tool("stop_session", {"session_id": sid})
+                self.assertFalse(st.isError, _tool_result_text(st))
+                d_stop = json.loads(_tool_result_text(st))
+                self.assertEqual(d_stop.get("status"), "stopped")
+
+        _run_async(body())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/e2e/test_mcp_code_interpreter.py
+++ b/test/e2e/test_mcp_code_interpreter.py
@@ -3,6 +3,15 @@
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """E2E: AgentCube Code Interpreter MCP server (streamable-http) against live Router/WM.
 

--- a/test/e2e/test_mcp_code_interpreter_k8s.py
+++ b/test/e2e/test_mcp_code_interpreter_k8s.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# Copyright The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""E2E: MCP server running as a Pod in Kubernetes (streamable-http via port-forward).
+
+run_e2e.sh sets MCP_K8S_MCP_URL (e.g. http://127.0.0.1:19446/mcp) after deploying the MCP Deployment.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import unittest
+from typing import Any
+
+
+def _tool_result_text(result: Any) -> str:
+    parts: list[str] = []
+    for block in getattr(result, "content", []) or []:
+        t = getattr(block, "text", None)
+        if isinstance(t, str):
+            parts.append(t)
+    return "\n".join(parts)
+
+
+def _run_async(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+class TestMCPCodeInterpreterK8sDeploymentE2E(unittest.TestCase):
+    def test_in_cluster_mcp_http_roundtrip(self):
+        url = os.environ.get("MCP_K8S_MCP_URL", "").strip()
+        if not url:
+            raise unittest.SkipTest("MCP_K8S_MCP_URL not set (in-cluster MCP E2E not started)")
+
+        async def body():
+            import httpx
+            from mcp import ClientSession
+            from mcp.client.streamable_http import streamable_http_client
+
+            async with httpx.AsyncClient(timeout=120.0) as http_client:
+                async with streamable_http_client(url, http_client=http_client) as (
+                    read_stream,
+                    write_stream,
+                    _,
+                ):
+                    async with ClientSession(read_stream, write_stream) as session:
+                        await session.initialize()
+                        print(f"[MCP K8s E2E] initialize ok url={url!r}")
+
+                        tools = await session.list_tools()
+                        names = {t.name for t in tools.tools}
+                        self.assertIn("run_code", names)
+                        self.assertIn("stop_session", names)
+
+                        res = await session.call_tool(
+                            "run_code",
+                            {
+                                "language": "python",
+                                "code": "print(7-2)",
+                                "session_reuse": False,
+                            },
+                        )
+                        self.assertFalse(res.isError, _tool_result_text(res))
+                        data = json.loads(_tool_result_text(res))
+                        self.assertIn("5", (data.get("output") or ""), data)
+                        print(f"[MCP K8s E2E] run_code via in-cluster pod ok output={data.get('output')!r}")
+
+        _run_async(body())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/e2e/test_mcp_code_interpreter_k8s.py
+++ b/test/e2e/test_mcp_code_interpreter_k8s.py
@@ -3,6 +3,15 @@
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """E2E: MCP server running as a Pod in Kubernetes (streamable-http via port-forward).
 

--- a/test/e2e/test_mcp_code_interpreter_stdio.py
+++ b/test/e2e/test_mcp_code_interpreter_stdio.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# Copyright The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""E2E: MCP stdio transport — stdio_client spawns agentcube_code_interpreter_mcp (stdio)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import unittest
+from typing import Any
+
+
+def _tool_result_text(result: Any) -> str:
+    parts: list[str] = []
+    for block in getattr(result, "content", []) or []:
+        t = getattr(block, "text", None)
+        if isinstance(t, str):
+            parts.append(t)
+    return "\n".join(parts)
+
+
+def _run_async(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+class TestMCPCodeInterpreterStdioE2E(unittest.TestCase):
+    """Requires ROUTER_URL, WORKLOAD_MANAGER_URL (same as other CodeInterpreter E2E)."""
+
+    def test_stdio_initialize_list_tools_run_code(self):
+        router = os.environ.get("ROUTER_URL")
+        wm = os.environ.get("WORKLOAD_MANAGER_URL")
+        if not router or not wm:
+            raise unittest.SkipTest("ROUTER_URL and WORKLOAD_MANAGER_URL are required")
+
+        ns = os.environ.get("AGENTCUBE_NAMESPACE", "agentcube")
+        token = os.environ.get("API_TOKEN", "")
+        env: dict[str, str] = {
+            "ROUTER_URL": router,
+            "WORKLOAD_MANAGER_URL": wm,
+            "AGENTCUBE_NAMESPACE": ns,
+            "CODE_INTERPRETER_NAME": "e2e-code-interpreter",
+        }
+        if token:
+            env["API_TOKEN"] = token
+
+        async def body():
+            from mcp import ClientSession
+            from mcp.client.stdio import StdioServerParameters, stdio_client
+
+            params = StdioServerParameters(
+                command=sys.executable,
+                args=["-m", "agentcube_code_interpreter_mcp", "--transport", "stdio"],
+                env=env,
+            )
+            async with stdio_client(params) as (read_stream, write_stream):
+                async with ClientSession(read_stream, write_stream) as session:
+                    init = await session.initialize()
+                    self.assertIsNotNone(init.protocolVersion)
+                    print(f"[MCP stdio E2E] initialize ok protocolVersion={init.protocolVersion!r}")
+
+                    tools = await session.list_tools()
+                    names = {t.name for t in tools.tools}
+                    self.assertIn("run_code", names)
+                    self.assertIn("write_file", names)
+                    print(f"[MCP stdio E2E] list_tools ok count={len(tools.tools)}")
+
+                    res = await session.call_tool(
+                        "run_code",
+                        {
+                            "language": "python",
+                            "code": "print(3+1)",
+                            "session_reuse": False,
+                        },
+                    )
+                    self.assertFalse(res.isError, _tool_result_text(res))
+                    data = json.loads(_tool_result_text(res))
+                    self.assertIn("4", (data.get("output") or ""), data)
+                    print(f"[MCP stdio E2E] run_code ok output={data.get('output')!r}")
+
+        _run_async(body())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/e2e/test_mcp_code_interpreter_stdio.py
+++ b/test/e2e/test_mcp_code_interpreter_stdio.py
@@ -3,6 +3,15 @@
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """E2E: MCP stdio transport — stdio_client spawns agentcube_code_interpreter_mcp (stdio)."""
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

* Adds an AgentCube Code Interpreter MCP server (integrations/code-interpreter-mcp/) built with the official Python MCP SDK (FastMCP) so clients can use standard MCP (initialize, tools/list, tools/call) instead of hand-rolling HTTP against Router / Workload Manager.
* Exposes tools aligned with CodeInterpreterClient: run_code, execute_command, write_file, list_files, and stop_session, with optional session_id / session_reuse for multi-step sandboxes.
* Supports two ways to run it:
Local / IDE: stdio (e.g. Cursor mcp.json) and streamable-http for debugging or HTTP clients.
Kubernetes: Dockerfile + deployment.yaml (in-cluster ROUTER_URL / WORKLOAD_MANAGER_URL, optional API_TOKEN via kubectl set env in E2E).
* E2E (test/e2e/ + run_e2e.sh):
Streamable HTTP against a local subprocess MCP (full protocol checks, execute_command, stateless NameError, file workflow).
stdio smoke (stdio_client spawns the MCP module).
In-cluster smoke: build/load image into Kind, apply Deployment, inject token, port-forward Service, hit /mcp (skipped when E2E_SKIP_SETUP=true).
* Docs: English integrations/code-interpreter-mcp/README.md, and test/e2e/README.md updates for the new flows.


**Which issue(s) this PR fixes**:
Fixes https://github.com/volcano-sh/agentcube/issues/284

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
