### PR TITLE
fix: propagate ctx into waitForCacheSync to respect caller cancellation

### DIFF
--- a/pkg/workloadmanager/informers.go
+++ b/pkg/workloadmanager/informers.go
@@ -83,12 +83,21 @@ func (ifm *Informers) run(stopCh <-chan struct{}) {
 
 func (ifm *Informers) waitForCacheSync(ctx context.Context) error {
 	if !cache.WaitForCacheSync(ctx.Done(), ifm.AgentRuntimeInformer.HasSynced) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		return fmt.Errorf("timed out waiting for %v caches to sync", AgentRuntimeGVR)
 	}
 	if !cache.WaitForCacheSync(ctx.Done(), ifm.CodeInterpreterInformer.HasSynced) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		return fmt.Errorf("timed out waiting for %v caches to sync", CodeInterpreterGVR)
 	}
 	if !cache.WaitForCacheSync(ctx.Done(), ifm.PodInformer.HasSynced) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		return fmt.Errorf("timed out waiting for pod informer cache to sync")
 	}
 	return nil

--- a/pkg/workloadmanager/informers.go
+++ b/pkg/workloadmanager/informers.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -48,16 +49,11 @@ var (
 	}
 )
 
-// informerStarter is the subset of SharedInformerFactory used by Informers.
-type informerStarter interface {
-	Start(stopCh <-chan struct{})
-}
-
 type Informers struct {
 	AgentRuntimeInformer    cache.SharedIndexInformer
 	CodeInterpreterInformer cache.SharedIndexInformer
 	PodInformer             cache.SharedIndexInformer
-	informerFactory         informerStarter
+	informerFactory         informers.SharedInformerFactory
 }
 
 func NewInformers(k8sClient *K8sClient) *Informers {

--- a/pkg/workloadmanager/informers.go
+++ b/pkg/workloadmanager/informers.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -49,11 +48,16 @@ var (
 	}
 )
 
+// informerStarter is the subset of SharedInformerFactory used by Informers.
+type informerStarter interface {
+	Start(stopCh <-chan struct{})
+}
+
 type Informers struct {
 	AgentRuntimeInformer    cache.SharedIndexInformer
 	CodeInterpreterInformer cache.SharedIndexInformer
 	PodInformer             cache.SharedIndexInformer
-	informerFactory         informers.SharedInformerFactory
+	informerFactory         informerStarter
 }
 
 func NewInformers(k8sClient *K8sClient) *Informers {

--- a/pkg/workloadmanager/informers.go
+++ b/pkg/workloadmanager/informers.go
@@ -84,19 +84,19 @@ func (ifm *Informers) run(stopCh <-chan struct{}) {
 func (ifm *Informers) waitForCacheSync(ctx context.Context) error {
 	if !cache.WaitForCacheSync(ctx.Done(), ifm.AgentRuntimeInformer.HasSynced) {
 		if err := ctx.Err(); err != nil {
-			return err
+			return fmt.Errorf("timed out waiting for %v caches to sync: %w", AgentRuntimeGVR, err)
 		}
 		return fmt.Errorf("timed out waiting for %v caches to sync", AgentRuntimeGVR)
 	}
 	if !cache.WaitForCacheSync(ctx.Done(), ifm.CodeInterpreterInformer.HasSynced) {
 		if err := ctx.Err(); err != nil {
-			return err
+			return fmt.Errorf("timed out waiting for %v caches to sync: %w", CodeInterpreterGVR, err)
 		}
 		return fmt.Errorf("timed out waiting for %v caches to sync", CodeInterpreterGVR)
 	}
 	if !cache.WaitForCacheSync(ctx.Done(), ifm.PodInformer.HasSynced) {
 		if err := ctx.Err(); err != nil {
-			return err
+			return fmt.Errorf("timed out waiting for pod informer cache to sync: %w", err)
 		}
 		return fmt.Errorf("timed out waiting for pod informer cache to sync")
 	}

--- a/pkg/workloadmanager/informers.go
+++ b/pkg/workloadmanager/informers.go
@@ -67,7 +67,7 @@ func NewInformers(k8sClient *K8sClient) *Informers {
 
 func (ifm *Informers) RunAndWaitForCacheSync(ctx context.Context) error {
 	ifm.run(ctx.Done())
-	ctxTimeout, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctxTimeout, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
 	if err := ifm.waitForCacheSync(ctxTimeout); err != nil {
 		return fmt.Errorf("failed to wait for caches to sync: %w", err)

--- a/pkg/workloadmanager/informers_test.go
+++ b/pkg/workloadmanager/informers_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloadmanager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+// neverSyncedInformer is a cache.SharedIndexInformer whose HasSynced always returns false.
+type neverSyncedInformer struct {
+	cache.SharedIndexInformer
+}
+
+func (n *neverSyncedInformer) HasSynced() bool { return false }
+
+func TestRunAndWaitForCacheSync_RespectsContextCancellation(t *testing.T) {
+	ifm := &Informers{
+		AgentRuntimeInformer:    &neverSyncedInformer{},
+		CodeInterpreterInformer: &neverSyncedInformer{},
+		PodInformer:             &neverSyncedInformer{},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		// waitForCacheSync calls run internally via RunAndWaitForCacheSync,
+		// but run needs a real informerFactory. Call waitForCacheSync directly
+		// to isolate the context-propagation behaviour.
+		ctxTimeout, cancelTimeout := context.WithTimeout(ctx, 1*time.Minute)
+		defer cancelTimeout()
+		done <- ifm.waitForCacheSync(ctxTimeout)
+	}()
+
+	// Cancel the parent context well before the 1-minute timeout.
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected error when context is cancelled, got nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("waitForCacheSync did not respect context cancellation within 2s")
+	}
+}

--- a/pkg/workloadmanager/informers_test.go
+++ b/pkg/workloadmanager/informers_test.go
@@ -29,25 +29,27 @@ type neverSyncedInformer struct {
 	cache.SharedIndexInformer
 }
 
-func (n *neverSyncedInformer) HasSynced() bool { return false }
+func (n *neverSyncedInformer) HasSynced() bool                    { return false }
+func (n *neverSyncedInformer) Run(stopCh <-chan struct{})          { <-stopCh }
+
+// noopInformerStarter satisfies informerStarter with a no-op Start.
+type noopInformerStarter struct{}
+
+func (noopInformerStarter) Start(_ <-chan struct{}) {}
 
 func TestRunAndWaitForCacheSync_RespectsContextCancellation(t *testing.T) {
 	ifm := &Informers{
 		AgentRuntimeInformer:    &neverSyncedInformer{},
 		CodeInterpreterInformer: &neverSyncedInformer{},
 		PodInformer:             &neverSyncedInformer{},
+		informerFactory:         noopInformerStarter{},
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 
 	done := make(chan error, 1)
 	go func() {
-		// waitForCacheSync calls run internally via RunAndWaitForCacheSync,
-		// but run needs a real informerFactory. Call waitForCacheSync directly
-		// to isolate the context-propagation behaviour.
-		ctxTimeout, cancelTimeout := context.WithTimeout(ctx, 1*time.Minute)
-		defer cancelTimeout()
-		done <- ifm.waitForCacheSync(ctxTimeout)
+		done <- ifm.RunAndWaitForCacheSync(ctx)
 	}()
 
 	// Cancel the parent context well before the 1-minute timeout.
@@ -56,9 +58,9 @@ func TestRunAndWaitForCacheSync_RespectsContextCancellation(t *testing.T) {
 	select {
 	case err := <-done:
 		if err == nil {
-			t.Fatal("expected error when context is cancelled, got nil")
+			t.Fatal("expected error when context is canceled, got nil")
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("waitForCacheSync did not respect context cancellation within 2s")
+		t.Fatal("RunAndWaitForCacheSync did not respect context cancellation within 2s")
 	}
 }

--- a/pkg/workloadmanager/informers_test.go
+++ b/pkg/workloadmanager/informers_test.go
@@ -31,7 +31,7 @@ type neverSyncedInformer struct {
 	cache.SharedIndexInformer
 }
 
-func (n *neverSyncedInformer) HasSynced() bool           { return false }
+func (n *neverSyncedInformer) HasSynced() bool { return false }
 func (n *neverSyncedInformer) Run(stopCh <-chan struct{}) { <-stopCh }
 
 func TestRunAndWaitForCacheSync_RespectsContextCancellation(t *testing.T) {

--- a/pkg/workloadmanager/informers_test.go
+++ b/pkg/workloadmanager/informers_test.go
@@ -32,36 +32,84 @@ type neverSyncedInformer struct {
 	cache.SharedIndexInformer
 }
 
-func (n *neverSyncedInformer) HasSynced() bool { return false }
+func (n *neverSyncedInformer) HasSynced() bool           { return false }
 func (n *neverSyncedInformer) Run(stopCh <-chan struct{}) { <-stopCh }
 
-func TestRunAndWaitForCacheSync_RespectsContextCancellation(t *testing.T) {
-	fakeClient := fake.NewSimpleClientset()
-	factory := informers.NewSharedInformerFactory(fakeClient, 0)
+// alwaysSyncedInformer is a cache.SharedIndexInformer whose HasSynced always returns true.
+type alwaysSyncedInformer struct {
+	cache.SharedIndexInformer
+}
 
+func (a *alwaysSyncedInformer) HasSynced() bool           { return true }
+func (a *alwaysSyncedInformer) Run(stopCh <-chan struct{}) { <-stopCh }
+
+// runCanceled starts RunAndWaitForCacheSync in a goroutine, cancels the context
+// immediately, and returns the error. Fails the test if it takes more than 2s.
+func runCanceled(t *testing.T, ifm *Informers) error {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- ifm.RunAndWaitForCacheSync(ctx) }()
+	cancel()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunAndWaitForCacheSync did not respect context cancellation within 2s")
+		return nil
+	}
+}
+
+func TestRunAndWaitForCacheSync_AgentRuntimeInformerCanceled(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
 	ifm := &Informers{
 		AgentRuntimeInformer:    &neverSyncedInformer{},
 		CodeInterpreterInformer: &neverSyncedInformer{},
 		PodInformer:             &neverSyncedInformer{},
-		informerFactory:         factory,
+		informerFactory:         informers.NewSharedInformerFactory(fakeClient, 0),
 	}
+	if err := runCanceled(t, ifm); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
 
-	ctx, cancel := context.WithCancel(context.Background())
+func TestRunAndWaitForCacheSync_CodeInterpreterInformerCanceled(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	ifm := &Informers{
+		AgentRuntimeInformer:    &alwaysSyncedInformer{},
+		CodeInterpreterInformer: &neverSyncedInformer{},
+		PodInformer:             &neverSyncedInformer{},
+		informerFactory:         informers.NewSharedInformerFactory(fakeClient, 0),
+	}
+	if err := runCanceled(t, ifm); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
 
-	done := make(chan error, 1)
-	go func() {
-		done <- ifm.RunAndWaitForCacheSync(ctx)
-	}()
+func TestRunAndWaitForCacheSync_PodInformerCanceled(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	ifm := &Informers{
+		AgentRuntimeInformer:    &alwaysSyncedInformer{},
+		CodeInterpreterInformer: &alwaysSyncedInformer{},
+		PodInformer:             &neverSyncedInformer{},
+		informerFactory:         informers.NewSharedInformerFactory(fakeClient, 0),
+	}
+	if err := runCanceled(t, ifm); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
 
-	// Cancel the parent context well before the 1-minute timeout.
-	cancel()
-
-	select {
-	case err := <-done:
-		if !errors.Is(err, context.Canceled) {
-			t.Fatalf("expected context.Canceled, got %v", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("RunAndWaitForCacheSync did not respect context cancellation within 2s")
+func TestRunAndWaitForCacheSync_AllSynced(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	ifm := &Informers{
+		AgentRuntimeInformer:    &alwaysSyncedInformer{},
+		CodeInterpreterInformer: &alwaysSyncedInformer{},
+		PodInformer:             &alwaysSyncedInformer{},
+		informerFactory:         informers.NewSharedInformerFactory(fakeClient, 0),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := ifm.RunAndWaitForCacheSync(ctx); err != nil {
+		t.Fatalf("expected no error when all informers are synced, got %v", err)
 	}
 }

--- a/pkg/workloadmanager/informers_test.go
+++ b/pkg/workloadmanager/informers_test.go
@@ -18,6 +18,7 @@ package workloadmanager
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -57,8 +58,8 @@ func TestRunAndWaitForCacheSync_RespectsContextCancellation(t *testing.T) {
 
 	select {
 	case err := <-done:
-		if err == nil {
-			t.Fatal("expected error when context is canceled, got nil")
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("RunAndWaitForCacheSync did not respect context cancellation within 2s")

--- a/pkg/workloadmanager/informers_test.go
+++ b/pkg/workloadmanager/informers_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -29,20 +31,18 @@ type neverSyncedInformer struct {
 	cache.SharedIndexInformer
 }
 
-func (n *neverSyncedInformer) HasSynced() bool                    { return false }
-func (n *neverSyncedInformer) Run(stopCh <-chan struct{})          { <-stopCh }
-
-// noopInformerStarter satisfies informerStarter with a no-op Start.
-type noopInformerStarter struct{}
-
-func (noopInformerStarter) Start(_ <-chan struct{}) {}
+func (n *neverSyncedInformer) HasSynced() bool           { return false }
+func (n *neverSyncedInformer) Run(stopCh <-chan struct{}) { <-stopCh }
 
 func TestRunAndWaitForCacheSync_RespectsContextCancellation(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(fakeClient, 0)
+
 	ifm := &Informers{
 		AgentRuntimeInformer:    &neverSyncedInformer{},
 		CodeInterpreterInformer: &neverSyncedInformer{},
 		PodInformer:             &neverSyncedInformer{},
-		informerFactory:         noopInformerStarter{},
+		informerFactory:         factory,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/workloadmanager/informers_test.go
+++ b/pkg/workloadmanager/informers_test.go
@@ -60,52 +60,62 @@ func runCanceled(t *testing.T, ifm *Informers) error {
 	}
 }
 
-func TestRunAndWaitForCacheSync_AgentRuntimeInformerCanceled(t *testing.T) {
-	fakeClient := fake.NewSimpleClientset()
-	ifm := &Informers{
-		AgentRuntimeInformer:    &neverSyncedInformer{},
-		CodeInterpreterInformer: &neverSyncedInformer{},
-		PodInformer:             &neverSyncedInformer{},
-		informerFactory:         informers.NewSharedInformerFactory(fakeClient, 0),
-	}
-	if err := runCanceled(t, ifm); !errors.Is(err, context.Canceled) {
-		t.Fatalf("expected context.Canceled, got %v", err)
-	}
+func newFactory() informers.SharedInformerFactory {
+	return informers.NewSharedInformerFactory(fake.NewSimpleClientset(), 0)
 }
 
-func TestRunAndWaitForCacheSync_CodeInterpreterInformerCanceled(t *testing.T) {
-	fakeClient := fake.NewSimpleClientset()
-	ifm := &Informers{
-		AgentRuntimeInformer:    &alwaysSyncedInformer{},
-		CodeInterpreterInformer: &neverSyncedInformer{},
-		PodInformer:             &neverSyncedInformer{},
-		informerFactory:         informers.NewSharedInformerFactory(fakeClient, 0),
-	}
-	if err := runCanceled(t, ifm); !errors.Is(err, context.Canceled) {
-		t.Fatalf("expected context.Canceled, got %v", err)
-	}
-}
+func TestRunAndWaitForCacheSync_ContextCancellation(t *testing.T) {
+	never := func() cache.SharedIndexInformer { return &neverSyncedInformer{} }
+	always := func() cache.SharedIndexInformer { return &alwaysSyncedInformer{} }
 
-func TestRunAndWaitForCacheSync_PodInformerCanceled(t *testing.T) {
-	fakeClient := fake.NewSimpleClientset()
-	ifm := &Informers{
-		AgentRuntimeInformer:    &alwaysSyncedInformer{},
-		CodeInterpreterInformer: &alwaysSyncedInformer{},
-		PodInformer:             &neverSyncedInformer{},
-		informerFactory:         informers.NewSharedInformerFactory(fakeClient, 0),
+	tests := []struct {
+		name                    string
+		agentRuntime            cache.SharedIndexInformer
+		codeInterpreter         cache.SharedIndexInformer
+		pod                     cache.SharedIndexInformer
+	}{
+		{
+			name:            "AgentRuntimeInformer never syncs",
+			agentRuntime:    never(),
+			codeInterpreter: never(),
+			pod:             never(),
+		},
+		{
+			name:            "CodeInterpreterInformer never syncs",
+			agentRuntime:    always(),
+			codeInterpreter: never(),
+			pod:             never(),
+		},
+		{
+			name:            "PodInformer never syncs",
+			agentRuntime:    always(),
+			codeInterpreter: always(),
+			pod:             never(),
+		},
 	}
-	if err := runCanceled(t, ifm); !errors.Is(err, context.Canceled) {
-		t.Fatalf("expected context.Canceled, got %v", err)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ifm := &Informers{
+				AgentRuntimeInformer:    tc.agentRuntime,
+				CodeInterpreterInformer: tc.codeInterpreter,
+				PodInformer:             tc.pod,
+				informerFactory:         newFactory(),
+			}
+			err := runCanceled(t, ifm)
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("expected context.Canceled, got %v", err)
+			}
+		})
 	}
 }
 
 func TestRunAndWaitForCacheSync_AllSynced(t *testing.T) {
-	fakeClient := fake.NewSimpleClientset()
 	ifm := &Informers{
 		AgentRuntimeInformer:    &alwaysSyncedInformer{},
 		CodeInterpreterInformer: &alwaysSyncedInformer{},
 		PodInformer:             &alwaysSyncedInformer{},
-		informerFactory:         informers.NewSharedInformerFactory(fakeClient, 0),
+		informerFactory:         newFactory(),
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()


### PR DESCRIPTION
## Summary

- Fix RunAndWaitForCacheSync to respect the provided context for timeout handling instead of using context.Background()
- Ensures cache sync wait exits early when the parent context is cancelled (e.g., during graceful shutdown)

## What

RunAndWaitForCacheSync accepted a ctx (context.Context) parameter but incorrectly derived its timeout from context.Background():

// before
ctxTimeout, cancel := context.WithTimeout(context.Background(), 1*time.Minute)

// after
ctxTimeout, cancel := context.WithTimeout(ctx, 1*time.Minute)

## Why

Cancelling the parent context (for example, on SIGTERM during graceful shutdown) had no effect on the cache-sync wait. The function would block for the full 1-minute timeout regardless.

The same ctx was already correctly passed to ifm.run(ctx.Done()) earlier, making this inconsistency evident. This change ensures consistent and expected context propagation.

## Changes

- Updated RunAndWaitForCacheSync to derive timeout from the passed ctx
- Preserves existing timeout behavior while allowing early cancellation
- Aligns context usage with ifm.run(ctx.Done())

## Test Plan

- [x] Added TestRunAndWaitForCacheSync_RespectsContextCancellation in informers_test.go

### Test Details

- Uses a neverSyncedInformer stub (HasSynced always returns false) to keep sync pending
- Cancels the parent context immediately
- Asserts the function returns within 2 seconds (well before the 1-minute timeout)

## Impact

- Improves graceful shutdown behavior
- Prevents unnecessary blocking during termination
- No breaking changes (backward compatible)

