### PR TITLE
cleanup: remove unused GetCodeInterpreter method

### DIFF
--- a/pkg/workloadmanager/codeinterpreter_controller.go
+++ b/pkg/workloadmanager/codeinterpreter_controller.go
@@ -334,27 +334,29 @@ func (r *CodeInterpreterReconciler) podTemplateEqual(a, b sandboxv1alpha1.PodTem
 	return reflect.DeepEqual(a.Spec, b.Spec)
 }
 
-// GetCodeInterpreter retrieves a CodeInterpreter from the cache by namespace and name.
-// The cache uses Kubernetes informer cache which is automatically maintained by controller-runtime
-// and stays synchronized with the Kubernetes API server through watch mechanism.
+// GetCodeInterpreter retrieves a CodeInterpreter by namespace and name via the
+// reconciler's embedded client. In production the client is cache-backed (see
+// controller-runtime manager.GetClient), so reads hit the informer cache and
+// stay synchronized with the Kubernetes API server through watches.
 //
-// Returns nil if the CodeInterpreter is not found in the cache.
 // The returned object is a deep copy to prevent external modifications.
+// Callers can use apierrors.IsNotFound(err) to distinguish a missing resource
+// from other errors such as context cancellation or transient API failures.
 //
 // Example usage:
 //
-//	ci := reconciler.GetCodeInterpreter(ctx, "my-codeinterpreter", "default")
-func (r *CodeInterpreterReconciler) GetCodeInterpreter(ctx context.Context, name, namespace string) *runtimev1alpha1.CodeInterpreter {
+//	ci, err := reconciler.GetCodeInterpreter(ctx, "my-codeinterpreter", "default")
+func (r *CodeInterpreterReconciler) GetCodeInterpreter(ctx context.Context, name, namespace string) (*runtimev1alpha1.CodeInterpreter, error) {
 	if r.Client == nil {
-		return nil
+		return nil, fmt.Errorf("reconciler client is not initialized")
 	}
 
 	ci := &runtimev1alpha1.CodeInterpreter{}
 	key := types.NamespacedName{Namespace: namespace, Name: name}
 	if err := r.Get(ctx, key, ci); err != nil {
-		return nil
+		return nil, err
 	}
-	return ci.DeepCopy()
+	return ci.DeepCopy(), nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/workloadmanager/codeinterpreter_controller.go
+++ b/pkg/workloadmanager/codeinterpreter_controller.go
@@ -44,7 +44,6 @@ import (
 type CodeInterpreterReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
-	mgr    ctrl.Manager
 }
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -338,8 +337,6 @@ func (r *CodeInterpreterReconciler) podTemplateEqual(a, b sandboxv1alpha1.PodTem
 // GenerationChangedPredicate filters out status-only update events so that
 // the controller is not re-enqueued by its own status writes.
 func (r *CodeInterpreterReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	r.mgr = mgr
-
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&runtimev1alpha1.CodeInterpreter{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)

--- a/pkg/workloadmanager/codeinterpreter_controller.go
+++ b/pkg/workloadmanager/codeinterpreter_controller.go
@@ -343,15 +343,15 @@ func (r *CodeInterpreterReconciler) podTemplateEqual(a, b sandboxv1alpha1.PodTem
 //
 // Example usage:
 //
-//	ci := reconciler.GetCodeInterpreter("my-codeinterpreter", "default")
-func (r *CodeInterpreterReconciler) GetCodeInterpreter(name, namespace string) *runtimev1alpha1.CodeInterpreter {
-	if r.mgr == nil {
+//	ci := reconciler.GetCodeInterpreter(ctx, "my-codeinterpreter", "default")
+func (r *CodeInterpreterReconciler) GetCodeInterpreter(ctx context.Context, name, namespace string) *runtimev1alpha1.CodeInterpreter {
+	if r.Client == nil {
 		return nil
 	}
 
 	ci := &runtimev1alpha1.CodeInterpreter{}
 	key := types.NamespacedName{Namespace: namespace, Name: name}
-	if err := r.mgr.GetCache().Get(context.Background(), key, ci); err != nil {
+	if err := r.Get(ctx, key, ci); err != nil {
 		return nil
 	}
 	return ci.DeepCopy()

--- a/pkg/workloadmanager/codeinterpreter_controller.go
+++ b/pkg/workloadmanager/codeinterpreter_controller.go
@@ -334,31 +334,6 @@ func (r *CodeInterpreterReconciler) podTemplateEqual(a, b sandboxv1alpha1.PodTem
 	return reflect.DeepEqual(a.Spec, b.Spec)
 }
 
-// GetCodeInterpreter retrieves a CodeInterpreter by namespace and name via the
-// reconciler's embedded client. In production the client is cache-backed (see
-// controller-runtime manager.GetClient), so reads hit the informer cache and
-// stay synchronized with the Kubernetes API server through watches.
-//
-// The returned object is a deep copy to prevent external modifications.
-// Callers can use apierrors.IsNotFound(err) to distinguish a missing resource
-// from other errors such as context cancellation or transient API failures.
-//
-// Example usage:
-//
-//	ci, err := reconciler.GetCodeInterpreter(ctx, "my-codeinterpreter", "default")
-func (r *CodeInterpreterReconciler) GetCodeInterpreter(ctx context.Context, name, namespace string) (*runtimev1alpha1.CodeInterpreter, error) {
-	if r.Client == nil {
-		return nil, fmt.Errorf("reconciler client is not initialized")
-	}
-
-	ci := &runtimev1alpha1.CodeInterpreter{}
-	key := types.NamespacedName{Namespace: namespace, Name: name}
-	if err := r.Get(ctx, key, ci); err != nil {
-		return nil, err
-	}
-	return ci.DeepCopy(), nil
-}
-
 // SetupWithManager sets up the controller with the Manager.
 // GenerationChangedPredicate filters out status-only update events so that
 // the controller is not re-enqueued by its own status writes.

--- a/pkg/workloadmanager/codeinterpreter_controller_test.go
+++ b/pkg/workloadmanager/codeinterpreter_controller_test.go
@@ -22,8 +22,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	runtimev1alpha1 "github.com/volcano-sh/agentcube/pkg/apis/runtime/v1alpha1"
@@ -37,18 +35,10 @@ func setupTestReconciler() *CodeInterpreterReconciler {
 	_ = corev1.AddToScheme(scheme)
 
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
-	// Create a minimal manager for testing
-	cfg := &rest.Config{
-		Host: "https://test",
-	}
-	mgr, _ := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme,
-	})
 
 	return &CodeInterpreterReconciler{
 		Client: client,
 		Scheme: scheme,
-		mgr:    mgr,
 	}
 }
 

--- a/pkg/workloadmanager/codeinterpreter_controller_test.go
+++ b/pkg/workloadmanager/codeinterpreter_controller_test.go
@@ -17,13 +17,10 @@ limitations under the License.
 package workloadmanager
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -195,62 +192,3 @@ func TestConvertToPodTemplate_AuthMode(t *testing.T) {
 // Note: TestConvertToPodTemplate_EmptyCommandAndArgs and
 // TestConvertToPodTemplate_NilCommandAndArgs removed - they only verified that
 // empty/nil values are preserved, which is trivial field copying behavior.
-
-func newTestCodeInterpreter(name, namespace string) *runtimev1alpha1.CodeInterpreter {
-	return &runtimev1alpha1.CodeInterpreter{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Labels:    map[string]string{"env": "test"},
-		},
-	}
-}
-
-func TestGetCodeInterpreter_Found(t *testing.T) {
-	r := setupTestReconciler()
-	ci := newTestCodeInterpreter("my-ci", "default")
-	assert.NoError(t, r.Create(context.Background(), ci))
-
-	got, err := r.GetCodeInterpreter(context.Background(), "my-ci", "default")
-	assert.NoError(t, err)
-	assert.NotNil(t, got)
-	assert.Equal(t, "my-ci", got.Name)
-	assert.Equal(t, "default", got.Namespace)
-}
-
-func TestGetCodeInterpreter_NotFound(t *testing.T) {
-	r := setupTestReconciler()
-
-	got, err := r.GetCodeInterpreter(context.Background(), "missing", "default")
-	assert.Nil(t, got)
-	assert.Error(t, err)
-	assert.True(t, apierrors.IsNotFound(err), "expected NotFound error, got %v", err)
-}
-
-func TestGetCodeInterpreter_NilClient(t *testing.T) {
-	r := &CodeInterpreterReconciler{}
-
-	got, err := r.GetCodeInterpreter(context.Background(), "my-ci", "default")
-	assert.Nil(t, got)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "client is not initialized")
-}
-
-func TestGetCodeInterpreter_ReturnsDeepCopy(t *testing.T) {
-	r := setupTestReconciler()
-	ci := newTestCodeInterpreter("my-ci", "default")
-	assert.NoError(t, r.Create(context.Background(), ci))
-
-	got, err := r.GetCodeInterpreter(context.Background(), "my-ci", "default")
-	assert.NoError(t, err)
-	assert.NotNil(t, got)
-
-	// Mutate the returned copy.
-	got.Labels["env"] = "mutated"
-
-	// A second call should return the original unmodified value.
-	got2, err := r.GetCodeInterpreter(context.Background(), "my-ci", "default")
-	assert.NoError(t, err)
-	assert.NotNil(t, got2)
-	assert.Equal(t, "test", got2.Labels["env"])
-}

--- a/pkg/workloadmanager/codeinterpreter_controller_test.go
+++ b/pkg/workloadmanager/codeinterpreter_controller_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package workloadmanager
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -192,3 +194,66 @@ func TestConvertToPodTemplate_AuthMode(t *testing.T) {
 // Note: TestConvertToPodTemplate_EmptyCommandAndArgs and
 // TestConvertToPodTemplate_NilCommandAndArgs removed - they only verified that
 // empty/nil values are preserved, which is trivial field copying behavior.
+
+func newTestCodeInterpreter(name, namespace string) *runtimev1alpha1.CodeInterpreter {
+	return &runtimev1alpha1.CodeInterpreter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"env": "test"},
+		},
+	}
+}
+
+func setupReconcilerWithFakeClient() *CodeInterpreterReconciler {
+	scheme := runtime.NewScheme()
+	_ = runtimev1alpha1.AddToScheme(scheme)
+	_ = sandboxv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	return &CodeInterpreterReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+		Scheme: scheme,
+	}
+}
+
+func TestGetCodeInterpreter_Found(t *testing.T) {
+	r := setupReconcilerWithFakeClient()
+	ci := newTestCodeInterpreter("my-ci", "default")
+	assert.NoError(t, r.Create(context.Background(), ci))
+
+	got := r.GetCodeInterpreter(context.Background(), "my-ci", "default")
+	assert.NotNil(t, got)
+	assert.Equal(t, "my-ci", got.Name)
+	assert.Equal(t, "default", got.Namespace)
+}
+
+func TestGetCodeInterpreter_NotFound(t *testing.T) {
+	r := setupReconcilerWithFakeClient()
+
+	got := r.GetCodeInterpreter(context.Background(), "missing", "default")
+	assert.Nil(t, got)
+}
+
+func TestGetCodeInterpreter_NilClient(t *testing.T) {
+	r := &CodeInterpreterReconciler{}
+
+	got := r.GetCodeInterpreter(context.Background(), "my-ci", "default")
+	assert.Nil(t, got)
+}
+
+func TestGetCodeInterpreter_ReturnsDeepCopy(t *testing.T) {
+	r := setupReconcilerWithFakeClient()
+	ci := newTestCodeInterpreter("my-ci", "default")
+	assert.NoError(t, r.Create(context.Background(), ci))
+
+	got := r.GetCodeInterpreter(context.Background(), "my-ci", "default")
+	assert.NotNil(t, got)
+
+	// Mutate the returned copy.
+	got.Labels["env"] = "mutated"
+
+	// A second call should return the original unmodified value.
+	got2 := r.GetCodeInterpreter(context.Background(), "my-ci", "default")
+	assert.NotNil(t, got2)
+	assert.Equal(t, "test", got2.Labels["env"])
+}

--- a/pkg/workloadmanager/codeinterpreter_controller_test.go
+++ b/pkg/workloadmanager/codeinterpreter_controller_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
@@ -205,55 +206,51 @@ func newTestCodeInterpreter(name, namespace string) *runtimev1alpha1.CodeInterpr
 	}
 }
 
-func setupReconcilerWithFakeClient() *CodeInterpreterReconciler {
-	scheme := runtime.NewScheme()
-	_ = runtimev1alpha1.AddToScheme(scheme)
-	_ = sandboxv1alpha1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	return &CodeInterpreterReconciler{
-		Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
-		Scheme: scheme,
-	}
-}
-
 func TestGetCodeInterpreter_Found(t *testing.T) {
-	r := setupReconcilerWithFakeClient()
+	r := setupTestReconciler()
 	ci := newTestCodeInterpreter("my-ci", "default")
 	assert.NoError(t, r.Create(context.Background(), ci))
 
-	got := r.GetCodeInterpreter(context.Background(), "my-ci", "default")
+	got, err := r.GetCodeInterpreter(context.Background(), "my-ci", "default")
+	assert.NoError(t, err)
 	assert.NotNil(t, got)
 	assert.Equal(t, "my-ci", got.Name)
 	assert.Equal(t, "default", got.Namespace)
 }
 
 func TestGetCodeInterpreter_NotFound(t *testing.T) {
-	r := setupReconcilerWithFakeClient()
+	r := setupTestReconciler()
 
-	got := r.GetCodeInterpreter(context.Background(), "missing", "default")
+	got, err := r.GetCodeInterpreter(context.Background(), "missing", "default")
 	assert.Nil(t, got)
+	assert.Error(t, err)
+	assert.True(t, apierrors.IsNotFound(err), "expected NotFound error, got %v", err)
 }
 
 func TestGetCodeInterpreter_NilClient(t *testing.T) {
 	r := &CodeInterpreterReconciler{}
 
-	got := r.GetCodeInterpreter(context.Background(), "my-ci", "default")
+	got, err := r.GetCodeInterpreter(context.Background(), "my-ci", "default")
 	assert.Nil(t, got)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "client is not initialized")
 }
 
 func TestGetCodeInterpreter_ReturnsDeepCopy(t *testing.T) {
-	r := setupReconcilerWithFakeClient()
+	r := setupTestReconciler()
 	ci := newTestCodeInterpreter("my-ci", "default")
 	assert.NoError(t, r.Create(context.Background(), ci))
 
-	got := r.GetCodeInterpreter(context.Background(), "my-ci", "default")
+	got, err := r.GetCodeInterpreter(context.Background(), "my-ci", "default")
+	assert.NoError(t, err)
 	assert.NotNil(t, got)
 
 	// Mutate the returned copy.
 	got.Labels["env"] = "mutated"
 
 	// A second call should return the original unmodified value.
-	got2 := r.GetCodeInterpreter(context.Background(), "my-ci", "default")
+	got2, err := r.GetCodeInterpreter(context.Background(), "my-ci", "default")
+	assert.NoError(t, err)
 	assert.NotNil(t, got2)
 	assert.Equal(t, "test", got2.Labels["env"])
 }


### PR DESCRIPTION




## Summary



As discussed during review, I verified that `CodeInterpreterReconciler.GetCodeInterpreter` has no production call sites — it was only referenced by its own tests.

This method originally wrapped `mgr.GetCache().Get(...)` with a hardcoded `context.Background()`, and the initial goal of this PR was to fix that context propagation issue. However, since the method is effectively dead code, the cleaner approach is to remove it entirely rather than evolve an unused API.

If a cache-backed CodeInterpreter lookup helper is needed in the future, it can be introduced alongside a real caller to properly define its interface (context usage, error handling, etc.).

## Changes

- Removed `GetCodeInterpreter` from `pkg/workloadmanager/codeinterpreter_controller.go`
- Removed associated tests:
  - `TestGetCodeInterpreter_Found`
  - `TestGetCodeInterpreter_NotFound`
  - `TestGetCodeInterpreter_NilClient`
  - `TestGetCodeInterpreter_ReturnsDeepCopy`
- Removed helper `newTestCodeInterpreter`
- Cleaned up unused imports (`context`, `apierrors`, `metav1`) from the test file

## Test Plan

- [x] `go vet ./pkg/workloadmanager/...`
- [x] `go test ./pkg/workloadmanager/... -count=1`
- [x] `go build ./...`
- [x] Confirmed zero remaining references to `GetCodeInterpreter` in the repo
