### PR TITLE
fix: abort sandbox create when request context is cancelled

### DIFF
--- a/pkg/workloadmanager/handlers.go
+++ b/pkg/workloadmanager/handlers.go
@@ -172,8 +172,8 @@ func (s *Server) createSandbox(ctx context.Context, dynamicClient dynamic.Interf
 	}()
 
 	var createdSandbox *sandboxv1alpha1.Sandbox
-	// Use an explicit timer so it is stopped as soon as the channel receives or
-	// ctx cancels, instead of leaking until time.After fires.
+	// Explicit timer + deferred Stop so the runtime timer is released on
+	// function return rather than lingering until the 2m deadline fires.
 	timer := time.NewTimer(2 * time.Minute) // consistent with router settings
 	defer timer.Stop()
 	select {

--- a/pkg/workloadmanager/handlers.go
+++ b/pkg/workloadmanager/handlers.go
@@ -173,8 +173,8 @@ func (s *Server) createSandbox(ctx context.Context, dynamicClient dynamic.Interf
 
 	var createdSandbox *sandboxv1alpha1.Sandbox
 	// Explicit timer + deferred Stop so the runtime timer is released on
-	// function return rather than lingering until the 2m deadline fires.
-	timer := time.NewTimer(2 * time.Minute) // consistent with router settings
+	// function return rather than lingering until the deadline fires.
+	timer := time.NewTimer(sandboxCreateTimeout)
 	defer timer.Stop()
 	select {
 	case result := <-resultChan:

--- a/pkg/workloadmanager/handlers.go
+++ b/pkg/workloadmanager/handlers.go
@@ -172,11 +172,18 @@ func (s *Server) createSandbox(ctx context.Context, dynamicClient dynamic.Interf
 	}()
 
 	var createdSandbox *sandboxv1alpha1.Sandbox
+	// Use an explicit timer so it is stopped as soon as the channel receives or
+	// ctx cancels, instead of leaking until time.After fires.
+	timer := time.NewTimer(2 * time.Minute) // consistent with router settings
+	defer timer.Stop()
 	select {
 	case result := <-resultChan:
 		createdSandbox = result.Sandbox
 		klog.V(2).Infof("sandbox %s/%s reported ready, verifying entrypoints", createdSandbox.Namespace, createdSandbox.Name)
-	case <-time.After(2 * time.Minute): // consistent with router settings
+	case <-ctx.Done():
+		klog.Warningf("sandbox %s/%s create aborted: %v", sandbox.Namespace, sandbox.Name, ctx.Err())
+		return nil, fmt.Errorf("sandbox creation aborted: %w", ctx.Err())
+	case <-timer.C:
 		klog.Warningf("sandbox %s/%s create timed out", sandbox.Namespace, sandbox.Name)
 		return nil, fmt.Errorf("sandbox creation timed out")
 	}

--- a/pkg/workloadmanager/handlers_test.go
+++ b/pkg/workloadmanager/handlers_test.go
@@ -259,6 +259,43 @@ func TestServerCreateSandbox(t *testing.T) {
 	}
 }
 
+// TestServerCreateSandbox_ContextCancelled verifies that createSandbox aborts
+// promptly when the caller's context is cancelled while waiting for the
+// sandbox to reach Running state, and that the rollback defer still runs.
+func TestServerCreateSandbox_ContextCancelled(t *testing.T) {
+	store := &fakeStore{}
+	server := &Server{storeClient: store, k8sClient: &K8sClient{}}
+
+	// Empty channel — Reconcile will never notify in this test.
+	resultChan := make(chan SandboxStatusUpdate, 1)
+	sb := readySandbox()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(createSandbox, func(_ context.Context, _ dynamic.Interface, sandbox *sandboxv1alpha1.Sandbox) (*SandboxInfo, error) {
+		return &SandboxInfo{Name: sandbox.Name, Namespace: sandbox.Namespace}, nil
+	})
+	deleteCalls := 0
+	patches.ApplyFunc(deleteSandbox, func(_ context.Context, _ dynamic.Interface, _, _ string) error {
+		deleteCalls++
+		return nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel before the call so the select picks ctx.Done() immediately.
+
+	start := time.Now()
+	resp, err := server.createSandbox(ctx, nil, sb, nil, makeEntry(), resultChan)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Less(t, elapsed, time.Second, "createSandbox should abort immediately on ctx cancel, not wait for the 2m timer")
+	require.Equal(t, 1, deleteCalls, "rollback defer should still delete the sandbox on ctx cancel")
+}
+
 func newFakeServer() *Server {
 	return &Server{
 		config:            &Config{SandboxReadyProbeTimeout: 5 * time.Millisecond, SandboxReadyProbeInterval: time.Millisecond},

--- a/pkg/workloadmanager/handlers_test.go
+++ b/pkg/workloadmanager/handlers_test.go
@@ -259,14 +259,20 @@ func TestServerCreateSandbox(t *testing.T) {
 	}
 }
 
-// TestServerCreateSandbox_ContextCancelled verifies that createSandbox aborts
-// promptly when the caller's context is cancelled while waiting for the
-// sandbox to reach Running state, and that the rollback defer still runs.
-func TestServerCreateSandbox_ContextCancelled(t *testing.T) {
+// TestServerCreateSandbox_ContextCanceled verifies that createSandbox aborts
+// promptly when the caller's context is canceled while blocked in the
+// wait-for-Running select, and that the rollback defer still runs.
+//
+// The context is canceled from a timer (not before the call) so the function
+// actually reaches the select with a live ctx — otherwise an upstream
+// ctx-honoring call could return first and the test would pass without
+// exercising the regression being fixed.
+func TestServerCreateSandbox_ContextCanceled(t *testing.T) {
 	store := &fakeStore{}
 	server := &Server{storeClient: store, k8sClient: &K8sClient{}}
 
-	// Empty channel — Reconcile will never notify in this test.
+	// Empty channel — Reconcile will never notify, forcing the select to
+	// block until ctx cancels or the 2m timer fires.
 	resultChan := make(chan SandboxStatusUpdate, 1)
 	sb := readySandbox()
 
@@ -283,7 +289,9 @@ func TestServerCreateSandbox_ContextCancelled(t *testing.T) {
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // Cancel before the call so the select picks ctx.Done() immediately.
+	defer cancel()
+	// Cancel after createSandbox has had time to reach the select.
+	time.AfterFunc(20*time.Millisecond, cancel)
 
 	start := time.Now()
 	resp, err := server.createSandbox(ctx, nil, sb, nil, makeEntry(), resultChan)
@@ -292,7 +300,7 @@ func TestServerCreateSandbox_ContextCancelled(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, resp)
 	require.ErrorIs(t, err, context.Canceled)
-	require.Less(t, elapsed, time.Second, "createSandbox should abort immediately on ctx cancel, not wait for the 2m timer")
+	require.Less(t, elapsed, time.Second, "createSandbox should abort on ctx cancel, not wait for the 2m timer")
 	require.Equal(t, 1, deleteCalls, "rollback defer should still delete the sandbox on ctx cancel")
 }
 

--- a/pkg/workloadmanager/handlers_test.go
+++ b/pkg/workloadmanager/handlers_test.go
@@ -304,6 +304,44 @@ func TestServerCreateSandbox_ContextCanceled(t *testing.T) {
 	require.Equal(t, 1, deleteCalls, "rollback defer should still delete the sandbox on ctx cancel")
 }
 
+// TestServerCreateSandbox_Timeout verifies that createSandbox returns a
+// timeout error and triggers rollback when the readiness deadline elapses
+// before a Running notification arrives. The package-level deadline is
+// shrunk so the test runs in milliseconds.
+func TestServerCreateSandbox_Timeout(t *testing.T) {
+	oldTimeout := sandboxCreateTimeout
+	sandboxCreateTimeout = 20 * time.Millisecond
+	defer func() { sandboxCreateTimeout = oldTimeout }()
+
+	store := &fakeStore{}
+	server := &Server{storeClient: store, k8sClient: &K8sClient{}}
+
+	resultChan := make(chan SandboxStatusUpdate, 1) // never written
+	sb := readySandbox()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(createSandbox, func(_ context.Context, _ dynamic.Interface, sandbox *sandboxv1alpha1.Sandbox) (*SandboxInfo, error) {
+		return &SandboxInfo{Name: sandbox.Name, Namespace: sandbox.Namespace}, nil
+	})
+	deleteCalls := 0
+	patches.ApplyFunc(deleteSandbox, func(_ context.Context, _ dynamic.Interface, _, _ string) error {
+		deleteCalls++
+		return nil
+	})
+
+	start := time.Now()
+	resp, err := server.createSandbox(context.Background(), nil, sb, nil, makeEntry(), resultChan)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "sandbox creation timed out")
+	require.Less(t, elapsed, time.Second, "createSandbox should return shortly after the shortened deadline")
+	require.Equal(t, 1, deleteCalls, "rollback defer should delete the sandbox when the deadline fires")
+}
+
 func newFakeServer() *Server {
 	return &Server{
 		config:            &Config{SandboxReadyProbeTimeout: 5 * time.Millisecond, SandboxReadyProbeInterval: time.Millisecond},

--- a/pkg/workloadmanager/sandbox_helper.go
+++ b/pkg/workloadmanager/sandbox_helper.go
@@ -35,6 +35,11 @@ const (
 	defaultSandboxReadyDialTimeout   = 1 * time.Second
 )
 
+// sandboxCreateTimeout is the deadline for a sandbox to reach the Running
+// state before createSandbox bails. Declared as a var (not const) so tests
+// can override it. Keep in sync with the router settings.
+var sandboxCreateTimeout = 2 * time.Minute
+
 var sandboxEntrypointDial = func(ctx context.Context, endpoint string, timeout time.Duration) error {
 	dialer := &net.Dialer{Timeout: timeout}
 	conn, err := dialer.DialContext(ctx, "tcp", endpoint)


### PR DESCRIPTION
## Summary

`createSandbox` waits for the Sandbox to reach Running state via a `select` on a notification channel and a 2-minute timer. The select had no `ctx.Done()` case, so when the HTTP client disconnects (tab closed, curl Ctrl+C, upstream proxy timeout < 2m), the handler keeps blocking for the full 2 minutes — holding a goroutine, a watcher-map entry in `SandboxReconciler`, and the about-to-be-rolled-back K8s objects the entire time.

Fix the select to observe context cancellation and swap `time.After` for an explicit timer + `Stop()` so the timer doesn't leak when the select exits early.

## Changes

- Add `case <-ctx.Done():` to the wait-for-Running `select` in [`pkg/workloadmanager/handlers.go`](pkg/workloadmanager/handlers.go). Returns `ctx.Err()` wrapped so the existing `sandboxRollback` defer still tears down the placeholder, claim, and sandbox.
- Replace `time.After(2 * time.Minute)` with `time.NewTimer` + `defer timer.Stop()` to free the timer when the channel receives or `ctx` cancels.
- Add `TestServerCreateSandbox_ContextCancelled` that cancels the context before invoking `createSandbox` and asserts it returns with `context.Canceled` in well under 1 second, and that the rollback (`deleteSandbox`) still runs.

## Test plan

- [x] `go test ./pkg/workloadmanager/... -count=1`
- [x] `go vet ./pkg/workloadmanager/...`
- [x] `go build ./...`
- [x] New test `TestServerCreateSandbox_ContextCancelled` aborts in <1s with `context.Canceled`, confirms rollback fired

