### PR TITLE
fix: register sandbox rollback defer before workload create to plug placeholder leak

### DIFF
--- a/pkg/workloadmanager/handlers.go
+++ b/pkg/workloadmanager/handlers.go
@@ -220,6 +220,7 @@ func (s *Server) createSandbox(ctx context.Context, dynamicClient dynamic.Interf
 	// preventing the runtime from retaining the timer until it fires.
 	timer := time.NewTimer(2 * time.Minute) // consistent with router settings
 
+
 	var createdSandbox *sandboxv1alpha1.Sandbox
 	select {
 	case result := <-resultChan:

--- a/pkg/workloadmanager/handlers.go
+++ b/pkg/workloadmanager/handlers.go
@@ -220,7 +220,6 @@ func (s *Server) createSandbox(ctx context.Context, dynamicClient dynamic.Interf
 	// preventing the runtime from retaining the timer until it fires.
 	timer := time.NewTimer(2 * time.Minute) // consistent with router settings
 
-
 	var createdSandbox *sandboxv1alpha1.Sandbox
 	select {
 	case result := <-resultChan:

--- a/pkg/workloadmanager/handlers_test.go
+++ b/pkg/workloadmanager/handlers_test.go
@@ -44,10 +44,11 @@ import (
 
 type fakeStore struct {
 	store.Store
-	storeErr    error
-	updateErr   error
-	storeCalls  int
-	updateCalls int
+	storeErr           error
+	updateErr          error
+	storeCalls         int
+	updateCalls        int
+	deleteSessionCalls int
 }
 
 func (f *fakeStore) Ping(_ context.Context) error { return nil }
@@ -62,7 +63,10 @@ func (f *fakeStore) UpdateSandbox(_ context.Context, _ *types.SandboxInfo) error
 	f.updateCalls++
 	return f.updateErr
 }
-func (f *fakeStore) DeleteSandboxBySessionID(_ context.Context, _ string) error { return nil }
+func (f *fakeStore) DeleteSandboxBySessionID(_ context.Context, _ string) error {
+	f.deleteSessionCalls++
+	return nil
+}
 func (f *fakeStore) ListExpiredSandboxes(_ context.Context, _ time.Time, _ int64) ([]*types.SandboxInfo, error) {
 	return nil, nil
 }
@@ -102,20 +106,21 @@ func makeEntry() *sandboxEntry {
 
 func TestServerCreateSandbox(t *testing.T) {
 	type testCase struct {
-		name              string
-		sandboxClaim      bool
-		storeErr          error
-		createSandboxErr  error
-		createClaimErr    error
-		podIPErr          error
-		readyErr          error
-		updateErr         error
-		sendResult        bool
-		expectErr         bool
-		expectCreateCalls int
-		expectClaimCalls  int
-		expectDeleteCalls int
-		expectUpdateCalls int
+		name                   string
+		sandboxClaim           bool
+		storeErr               error
+		createSandboxErr       error
+		createClaimErr         error
+		podIPErr               error
+		readyErr               error
+		updateErr              error
+		sendResult             bool
+		expectErr              bool
+		expectCreateCalls      int
+		expectClaimCalls       int
+		expectDeleteCalls      int
+		expectStoreDeleteCalls int
+		expectUpdateCalls      int
 	}
 	tests := []testCase{
 		{
@@ -137,44 +142,49 @@ func TestServerCreateSandbox(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name:              "sandbox creation fails",
-			createSandboxErr:  errors.New("create sandbox failed"),
-			expectErr:         true,
-			expectCreateCalls: 1,
-			expectDeleteCalls: 1,
+			name:                   "sandbox creation fails triggers rollback",
+			createSandboxErr:       errors.New("create sandbox failed"),
+			expectErr:              true,
+			expectCreateCalls:      1,
+			expectDeleteCalls:      1,
+			expectStoreDeleteCalls: 1,
 		},
 		{
-			name:              "sandbox claim creation fails",
-			sandboxClaim:      true,
-			createClaimErr:    errors.New("create claim failed"),
-			expectErr:         true,
-			expectClaimCalls:  1,
-			expectDeleteCalls: 1,
+			name:                   "sandbox claim creation fails triggers rollback",
+			sandboxClaim:           true,
+			createClaimErr:         errors.New("create claim failed"),
+			expectErr:              true,
+			expectClaimCalls:       1,
+			expectDeleteCalls:      1,
+			expectStoreDeleteCalls: 1,
 		},
 		{
-			name:              "pod ip lookup fails triggers rollback",
-			podIPErr:          errors.New("pod ip missing"),
-			sendResult:        true,
-			expectErr:         true,
-			expectCreateCalls: 1,
-			expectDeleteCalls: 1,
+			name:                   "pod ip lookup fails triggers rollback",
+			podIPErr:               errors.New("pod ip missing"),
+			sendResult:             true,
+			expectErr:              true,
+			expectCreateCalls:      1,
+			expectDeleteCalls:      1,
+			expectStoreDeleteCalls: 1,
 		},
 		{
-			name:              "entrypoint readiness failure triggers rollback",
-			readyErr:          errors.New("connection refused"),
-			sendResult:        true,
-			expectErr:         true,
-			expectCreateCalls: 1,
-			expectDeleteCalls: 1,
+			name:                   "entrypoint readiness failure triggers rollback",
+			readyErr:               errors.New("connection refused"),
+			sendResult:             true,
+			expectErr:              true,
+			expectCreateCalls:      1,
+			expectDeleteCalls:      1,
+			expectStoreDeleteCalls: 1,
 		},
 		{
-			name:              "update store fails triggers rollback",
-			updateErr:         errors.New("update failed"),
-			sendResult:        true,
-			expectErr:         true,
-			expectCreateCalls: 1,
-			expectUpdateCalls: 1,
-			expectDeleteCalls: 1,
+			name:                   "update store fails triggers rollback",
+			updateErr:              errors.New("update failed"),
+			sendResult:             true,
+			expectErr:              true,
+			expectCreateCalls:      1,
+			expectUpdateCalls:      1,
+			expectDeleteCalls:      1,
+			expectStoreDeleteCalls: 1,
 		},
 	}
 
@@ -242,6 +252,8 @@ func TestServerCreateSandbox(t *testing.T) {
 				claim = &extensionsv1alpha1.SandboxClaim{ObjectMeta: metav1.ObjectMeta{Name: sb.Name, Namespace: sb.Namespace}}
 			}
 
+
+
 			resp, err := server.createSandbox(context.Background(), nil, sb, claim, makeEntry(), resultChan)
 
 			require.Equal(t, tt.expectCreateCalls, createCalls, "createSandbox call count")
@@ -249,6 +261,7 @@ func TestServerCreateSandbox(t *testing.T) {
 			require.Equal(t, tt.expectDeleteCalls, deleteCalls, "delete call count")
 			require.Equal(t, 1, fakeStoreInst.storeCalls, "StoreSandbox call count")
 			require.Equal(t, tt.expectUpdateCalls, fakeStoreInst.updateCalls, "UpdateSandbox call count")
+			require.Equal(t, tt.expectStoreDeleteCalls, fakeStoreInst.deleteSessionCalls, "DeleteSandboxBySessionID call count")
 
 			if tt.expectErr {
 				require.Error(t, err)

--- a/pkg/workloadmanager/handlers_test.go
+++ b/pkg/workloadmanager/handlers_test.go
@@ -44,10 +44,11 @@ import (
 
 type fakeStore struct {
 	store.Store
-	storeErr    error
-	updateErr   error
-	storeCalls  int
-	updateCalls int
+	storeErr           error
+	updateErr          error
+	storeCalls         int
+	updateCalls        int
+	deleteSessionCalls int
 }
 
 func (f *fakeStore) Ping(_ context.Context) error { return nil }
@@ -62,7 +63,10 @@ func (f *fakeStore) UpdateSandbox(_ context.Context, _ *types.SandboxInfo) error
 	f.updateCalls++
 	return f.updateErr
 }
-func (f *fakeStore) DeleteSandboxBySessionID(_ context.Context, _ string) error { return nil }
+func (f *fakeStore) DeleteSandboxBySessionID(_ context.Context, _ string) error {
+	f.deleteSessionCalls++
+	return nil
+}
 func (f *fakeStore) ListExpiredSandboxes(_ context.Context, _ time.Time, _ int64) ([]*types.SandboxInfo, error) {
 	return nil, nil
 }
@@ -102,20 +106,21 @@ func makeEntry() *sandboxEntry {
 
 func TestServerCreateSandbox(t *testing.T) {
 	type testCase struct {
-		name              string
-		sandboxClaim      bool
-		storeErr          error
-		createSandboxErr  error
-		createClaimErr    error
-		podIPErr          error
-		readyErr          error
-		updateErr         error
-		sendResult        bool
-		expectErr         bool
-		expectCreateCalls int
-		expectClaimCalls  int
-		expectDeleteCalls int
-		expectUpdateCalls int
+		name                   string
+		sandboxClaim           bool
+		storeErr               error
+		createSandboxErr       error
+		createClaimErr         error
+		podIPErr               error
+		readyErr               error
+		updateErr              error
+		sendResult             bool
+		expectErr              bool
+		expectCreateCalls      int
+		expectClaimCalls       int
+		expectDeleteCalls      int
+		expectStoreDeleteCalls int
+		expectUpdateCalls      int
 	}
 	tests := []testCase{
 		{
@@ -137,44 +142,49 @@ func TestServerCreateSandbox(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name:              "sandbox creation fails",
-			createSandboxErr:  errors.New("create sandbox failed"),
-			expectErr:         true,
-			expectCreateCalls: 1,
-			expectDeleteCalls: 1,
+			name:                   "sandbox creation fails triggers rollback",
+			createSandboxErr:       errors.New("create sandbox failed"),
+			expectErr:              true,
+			expectCreateCalls:      1,
+			expectDeleteCalls:      1,
+			expectStoreDeleteCalls: 1,
 		},
 		{
-			name:              "sandbox claim creation fails",
-			sandboxClaim:      true,
-			createClaimErr:    errors.New("create claim failed"),
-			expectErr:         true,
-			expectClaimCalls:  1,
-			expectDeleteCalls: 1,
+			name:                   "sandbox claim creation fails triggers rollback",
+			sandboxClaim:           true,
+			createClaimErr:         errors.New("create claim failed"),
+			expectErr:              true,
+			expectClaimCalls:       1,
+			expectDeleteCalls:      1,
+			expectStoreDeleteCalls: 1,
 		},
 		{
-			name:              "pod ip lookup fails triggers rollback",
-			podIPErr:          errors.New("pod ip missing"),
-			sendResult:        true,
-			expectErr:         true,
-			expectCreateCalls: 1,
-			expectDeleteCalls: 1,
+			name:                   "pod ip lookup fails triggers rollback",
+			podIPErr:               errors.New("pod ip missing"),
+			sendResult:             true,
+			expectErr:              true,
+			expectCreateCalls:      1,
+			expectDeleteCalls:      1,
+			expectStoreDeleteCalls: 1,
 		},
 		{
-			name:              "entrypoint readiness failure triggers rollback",
-			readyErr:          errors.New("connection refused"),
-			sendResult:        true,
-			expectErr:         true,
-			expectCreateCalls: 1,
-			expectDeleteCalls: 1,
+			name:                   "entrypoint readiness failure triggers rollback",
+			readyErr:               errors.New("connection refused"),
+			sendResult:             true,
+			expectErr:              true,
+			expectCreateCalls:      1,
+			expectDeleteCalls:      1,
+			expectStoreDeleteCalls: 1,
 		},
 		{
-			name:              "update store fails triggers rollback",
-			updateErr:         errors.New("update failed"),
-			sendResult:        true,
-			expectErr:         true,
-			expectCreateCalls: 1,
-			expectUpdateCalls: 1,
-			expectDeleteCalls: 1,
+			name:                   "update store fails triggers rollback",
+			updateErr:              errors.New("update failed"),
+			sendResult:             true,
+			expectErr:              true,
+			expectCreateCalls:      1,
+			expectUpdateCalls:      1,
+			expectDeleteCalls:      1,
+			expectStoreDeleteCalls: 1,
 		},
 	}
 
@@ -249,6 +259,7 @@ func TestServerCreateSandbox(t *testing.T) {
 			require.Equal(t, tt.expectDeleteCalls, deleteCalls, "delete call count")
 			require.Equal(t, 1, fakeStoreInst.storeCalls, "StoreSandbox call count")
 			require.Equal(t, tt.expectUpdateCalls, fakeStoreInst.updateCalls, "UpdateSandbox call count")
+			require.Equal(t, tt.expectStoreDeleteCalls, fakeStoreInst.deleteSessionCalls, "DeleteSandboxBySessionID call count")
 
 			if tt.expectErr {
 				require.Error(t, err)


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it


The existing TestServerCreateSandbox test cases for failure paths (sandbox creation fails, sandbox claim creation fails, etc.) were not asserting that the store placeholder gets cleaned up during rollback. fakeStore.DeleteSandboxBySessionID was a silent no-op , so even if rollbackSandboxCreation stopped calling DeleteSandboxBySessionID, no test would catch
  it.
  
  This PR closes that gap:

  - Adds a deleteSessionCalls counter to fakeStore so DeleteSandboxBySessionID calls are tracked
  - Adds expectStoreDeleteCalls to the test case struct and asserts it is 1 for every error path that triggers rollback
  - Patches deleteSandboxClaim in the test setup to prevent a nil-client panic when the claim rollback path runs during the claim-failure case
  - Renames the two affected test cases to make the expected rollback behavior explicit in the name                                                                                      

The store placeholder fails case correctly remains at zero, since the defer is registered only after StoreSandbox succeeds.                                                            

### Does this PR introduce a user-facing change?

```release-note
NONE
```