### PR TITLE
[BUG] wrap underlying errors with %w

### DIFF
--- a/pkg/picod/auth.go
+++ b/pkg/picod/auth.go
@@ -70,7 +70,7 @@ func (am *AuthManager) LoadPublicKeyFromEnv() error {
 
 	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
-		return fmt.Errorf("failed to parse public key: %v", err)
+		return fmt.Errorf("failed to parse public key: %w", err)
 	}
 
 	rsaPub, ok := pub.(*rsa.PublicKey)

--- a/pkg/store/store_valkey.go
+++ b/pkg/store/store_valkey.go
@@ -113,7 +113,7 @@ func (vs *valkeyStore) loadSandboxesBySessionIDs(ctx context.Context, sessionIDs
 	// MGet should in same slot
 	stingSliceResults, err := vs.cli.Do(ctx, vs.cli.B().Mget().Key(sessionIDKeys...).Build()).AsStrSlice()
 	if err != nil {
-		return nil, fmt.Errorf("loadSandboxesBySessionIDs: Valkey MGet sandboxes failed: %v", err)
+		return nil, fmt.Errorf("loadSandboxesBySessionIDs: Valkey MGet sandboxes failed: %w", err)
 	}
 
 	if len(stingSliceResults) > len(sessionIDKeys) {


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
This PR wraps two underlying errors with `%w` instead of formatting them with `%v`, preserving error context for callers that use `errors.Is` or `errors.As`.



**Special notes for your reviewer**:
`go test ./pkg/store` passes. `go test ./pkg/picod` was attempted, but fails on this Windows setup due to missing Unix commands like `sh`/`sleep` and symlink privilege restrictions.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
