### PR TITLE
fix: add missing workloadName for CodeInterpreter sandboxes

### DIFF
--- a/pkg/workloadmanager/workload_builder.go
+++ b/pkg/workloadmanager/workload_builder.go
@@ -425,6 +425,7 @@ func buildSandboxByCodeInterpreter(namespace string, codeInterpreterName string,
 	buildParams := &buildSandboxParams{
 		sandboxName:    sandboxName,
 		namespace:      namespace,
+		workloadName:   codeInterpreterName,
 		sessionID:      sessionID,
 		podSpec:        podSpec,
 		podLabels:      codeInterpreterObj.Spec.Template.Labels,


### PR DESCRIPTION
## What this PR does

In `buildSandboxByCodeInterpreter`, the `buildSandboxParams` never sets the
`workloadName` field, causing the `WorkloadNameLabelKey` label to be empty
on all CodeInterpreter Sandbox objects.

The AgentRuntime path (`buildSandboxByAgentRuntime`) correctly sets
`workloadName` at line 274:

```go
buildParams := &buildSandboxParams{
    namespace:    namespace,
    workloadName: name,  //  present here
    ...
}
```

But the CodeInterpreter path at line 425 does not:
```
buildParams := &buildSandboxParams{
    sandboxName: sandboxName,
    namespace:   namespace,
    // workloadName is MISSING 
    ...
}
```
### Impact
CodeInterpreter sandboxes are missing the runtime.agentcube.io/workload-name label
This affects label-based queries and debugging for CodeInterpreter workloads
### Fix
Added workloadName: codeInterpreterName to match the AgentRuntime pattern.