### PR TITLE
fix(sdk-python): correct router port and bootstrap session race

### DIFF
--- a/sdk-python/agentcube/clients/agent_runtime_data_plane.py
+++ b/sdk-python/agentcube/clients/agent_runtime_data_plane.py
@@ -56,14 +56,19 @@ class AgentRuntimeDataPlaneClient:
             self.base_url,
             timeout=(self.connect_timeout, self.timeout),
         )
-        resp.raise_for_status()
-
         session_id = resp.headers.get(self.SESSION_HEADER)
-        if not session_id:
-            raise ValueError(
-                f"Missing required response header: {self.SESSION_HEADER}"
-            )
-        return session_id
+        if session_id:
+            if resp.status_code >= 400:
+                self.logger.warning(
+                    f"Bootstrap request returned status {resp.status_code}, "
+                    f"but session ID was found: {session_id}"
+                )
+            return session_id
+        resp.raise_for_status()
+        raise ValueError(
+            f"Missing required response header: {self.SESSION_HEADER} "
+            f"(Status: {resp.status_code}, Response: {resp.text[:100]})"
+        )
 
     def invoke(
         self,

--- a/sdk-python/agentcube/clients/agent_runtime_data_plane.py
+++ b/sdk-python/agentcube/clients/agent_runtime_data_plane.py
@@ -59,15 +59,19 @@ class AgentRuntimeDataPlaneClient:
         session_id = resp.headers.get(self.SESSION_HEADER)
         if session_id:
             if resp.status_code >= 400:
-                self.logger.warning(
+                self.logger.debug(
                     f"Bootstrap request returned status {resp.status_code}, "
                     f"but session ID was found: {session_id}"
                 )
             return session_id
         resp.raise_for_status()
+        content_type = resp.headers.get("Content-Type")
+        content_length = resp.headers.get("Content-Length")
         raise ValueError(
             f"Missing required response header: {self.SESSION_HEADER} "
-            f"(Status: {resp.status_code}, Response: {resp.text[:100]})"
+            f"(status: {resp.status_code}, "
+            f"content-type: {content_type}, "
+            f"content-length: {content_length})"
         )
 
     def invoke(

--- a/sdk-python/examples/agent_runtime_usage.py
+++ b/sdk-python/examples/agent_runtime_usage.py
@@ -17,7 +17,7 @@ from agentcube import AgentRuntimeClient
 # first time: it will create a new pod
 agent_client_v1 = AgentRuntimeClient(
     agent_name="my-agent",
-    router_url="http://localhost:18081",
+    router_url="http://localhost:8081",
     namespace="default",
     verbose=True,
 )
@@ -31,7 +31,7 @@ print(result_v1)
 # second time: it will try to reuse the pod created before
 agent_client_v2 = AgentRuntimeClient(
     agent_name="my-agent",
-    router_url="http://localhost:18081",
+    router_url="http://localhost:8081",
     namespace="default",
     session_id=agent_client_v1.session_id,
     verbose=True,

--- a/sdk-python/tests/test_agent_runtime.py
+++ b/sdk-python/tests/test_agent_runtime.py
@@ -111,6 +111,26 @@ class TestAgentRuntimeDataPlaneClient(unittest.TestCase):
         self.assertEqual(client.bootstrap_session_id(), "abc")
 
     @patch("agentcube.clients.agent_runtime_data_plane.create_session")
+    def test_bootstrap_session_id_returns_header_on_non_2xx(self, mock_create_session):
+        sess = Mock()
+        resp = Mock()
+        resp.status_code = 404
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError(response=resp)
+        resp.headers = {"x-agentcube-session-id": "session-from-404"}
+        sess.get.return_value = resp
+        mock_create_session.return_value = sess
+
+        from agentcube.clients.agent_runtime_data_plane import AgentRuntimeDataPlaneClient
+
+        client = AgentRuntimeDataPlaneClient(
+            router_url="http://router",
+            namespace="default",
+            agent_name="agent-a",
+        )
+        self.assertEqual(client.bootstrap_session_id(), "session-from-404")
+        resp.raise_for_status.assert_not_called()
+
+    @patch("agentcube.clients.agent_runtime_data_plane.create_session")
     def test_invoke_sends_session_header(self, mock_create_session):
         sess = Mock()
         resp = Mock()

--- a/sdk-python/tests/test_agent_runtime.py
+++ b/sdk-python/tests/test_agent_runtime.py
@@ -95,6 +95,7 @@ class TestAgentRuntimeDataPlaneClient(unittest.TestCase):
     def test_bootstrap_session_id_extracts_header(self, mock_create_session):
         sess = Mock()
         resp = Mock()
+        resp.status_code = 200
         resp.raise_for_status.return_value = None
         resp.headers = {"x-agentcube-session-id": "abc"}
         sess.get.return_value = resp


### PR DESCRIPTION
## Summary
Two fixes found while running the getting-started examples end-to-end.

### Fix 1 — Wrong port in example
`agent_runtime_usage.py` hardcoded port `18081` but the documented
`kubectl port-forward` command maps the router to `8081`. This caused
`Connection refused` for anyone following the getting-started guide.

### Fix 2 — Bootstrap session race on non-2xx agent responses
`bootstrap_session_id()` called `raise_for_status()` before reading
the session header. The AgentCube Router injects `x-agentcube-session-id`
even when the upstream agent returns a non-2xx response (e.g. `404`
for `GET /` on agents that only handle `POST`). This caused the client
to crash before it could read the valid session ID.

**Fix**: Read the header first. Only surface the HTTP error if the
header is absent.

## Testing
Verified end-to-end with `kind` cluster using the getting-started guide.