### PR TITLE
fix: clarify ambiguous DDL comment in garbage collector

### DIFF
--- a/pkg/workloadmanager/garbage_collection.go
+++ b/pkg/workloadmanager/garbage_collection.go
@@ -104,7 +104,7 @@ func (gc *garbageCollector) once() {
 		}
 	}
 
-	// List sandboxes reach DDL
+	// List sandboxes that have reached their expiry deadline
 	expiredSandboxes, err := gc.storeClient.ListExpiredSandboxes(ctx, now, gcCandidateLimit)
 	if err != nil {
 		klog.Errorf("garbage collector error listing expired sandboxes: %v", err)


### PR DESCRIPTION

**Description**:

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
The comment `// List sandboxes reach DDL` in `garbage_collection.go` is ambiguous — "DDL" commonly refers to Data Definition Language in database contexts, which is misleading here. This PR replaces it with `// List sandboxes that have reached their expiry deadline` which accurately describes the function's behavior of finding sandboxes past their max TTL.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
