### PR TITLE
feat(cli): add env support in agent_metadata.yaml

### DIFF
--- a/cmd/cli/agentcube/runtime/publish_runtime.py
+++ b/cmd/cli/agentcube/runtime/publish_runtime.py
@@ -150,6 +150,11 @@ class PublishRuntime:
                 "Please ensure 'readiness_probe_path' and 'readiness_probe_port' are set in agent_metadata.yaml."
             )
 
+        # Merge user-defined env from metadata with any env_vars from options
+        env_vars = dict(metadata.env) if metadata.env else {}
+        if options.get('env_vars'):
+            env_vars.update(options['env_vars'])
+
         # Step 3: Deploy AgentRuntime CR
         try:
             k8s_info = self.agentcube_provider.deploy_agent_runtime(
@@ -157,7 +162,7 @@ class PublishRuntime:
                 image_url=image_url,
                 port=metadata.port,
                 entrypoint=metadata.entrypoint,
-                env_vars=options.get('env_vars', None),
+                env_vars=env_vars or None,
                 workload_manager_url=metadata.workload_manager_url,
                 router_url=metadata.router_url,
                 readiness_probe_path=metadata.readiness_probe_path,
@@ -229,6 +234,11 @@ class PublishRuntime:
         if not image_url:
             raise ValueError("Image URL must be provided or configured in metadata.")
 
+        # Merge user-defined env from metadata with any env_vars from options
+        env_vars = dict(metadata.env) if metadata.env else {}
+        if options.get('env_vars'):
+            env_vars.update(options['env_vars'])
+
         # Step 3: Deploy to K8s
         k8s_info = None
         try:
@@ -239,7 +249,7 @@ class PublishRuntime:
                 entrypoint=metadata.entrypoint,
                 replicas=options.get('replicas', 1),
                 node_port=options.get('node_port', None),
-                env_vars=options.get('env_vars', None)
+                env_vars=env_vars or None
             )
 
             # Step 4: Update metadata with K8s deployment information (after creation, before readiness check)

--- a/cmd/cli/agentcube/services/metadata_service.py
+++ b/cmd/cli/agentcube/services/metadata_service.py
@@ -69,6 +69,11 @@ class AgentMetadata(BaseModel):
     agent_id: Optional[str] = Field(None, description="Agent ID assigned by AgentCube")
     session_id: Optional[str] = Field(None, description="The session ID for the agent")
 
+    # User-defined environment variables injected into sandbox pods
+    env: Optional[Dict[str, str]] = Field(
+        None, description="Extra env vars to inject into the agent container"
+    )
+
     # Kubernetes deployment fields (filled when using K8s provider)
     k8s_deployment: Optional[Dict[str, Any]] = Field(None, description="Kubernetes deployment information")
 

--- a/cmd/cli/tests/__init__.py
+++ b/cmd/cli/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/cmd/cli/tests/test_env_support.py
+++ b/cmd/cli/tests/test_env_support.py
@@ -1,0 +1,261 @@
+# Copyright The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for env support in agent_metadata.yaml.
+
+Verifies that the `env` field is correctly parsed from metadata,
+persisted on save, and forwarded to pod containers during publish.
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from agentcube.services.metadata_service import AgentMetadata, MetadataService
+
+
+# ---------------------------------------------------------------------------
+# AgentMetadata model tests
+# ---------------------------------------------------------------------------
+
+class TestAgentMetadataEnvField:
+    """Test that the env field is accepted and validated on the model."""
+
+    def test_env_field_default_is_none(self):
+        meta = AgentMetadata(agent_name="a", entrypoint="python main.py")
+        assert meta.env is None
+
+    def test_env_field_accepts_dict(self):
+        meta = AgentMetadata(
+            agent_name="a",
+            entrypoint="python main.py",
+            env={"LLM_BASE_URL": "http://llm", "LLM_API_KEY": "secret"},
+        )
+        assert meta.env == {"LLM_BASE_URL": "http://llm", "LLM_API_KEY": "secret"}
+
+    def test_env_field_empty_dict(self):
+        meta = AgentMetadata(
+            agent_name="a",
+            entrypoint="python main.py",
+            env={},
+        )
+        assert meta.env == {}
+
+
+# ---------------------------------------------------------------------------
+# MetadataService round-trip tests
+# ---------------------------------------------------------------------------
+
+class TestMetadataServiceEnvRoundTrip:
+    """Test load/save preserves the env field."""
+
+    def _write_yaml(self, path: Path, data: dict):
+        with open(path, "w") as f:
+            yaml.dump(data, f)
+
+    def test_load_metadata_with_env(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ws = Path(tmpdir)
+            self._write_yaml(ws / "agent_metadata.yaml", {
+                "agent_name": "test-agent",
+                "entrypoint": "python main.py",
+                "env": {"FOO": "bar", "BAZ": "qux"},
+            })
+            svc = MetadataService()
+            meta = svc.load_metadata(ws)
+            assert meta.env == {"FOO": "bar", "BAZ": "qux"}
+
+    def test_load_metadata_without_env(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ws = Path(tmpdir)
+            self._write_yaml(ws / "agent_metadata.yaml", {
+                "agent_name": "test-agent",
+                "entrypoint": "python main.py",
+            })
+            svc = MetadataService()
+            meta = svc.load_metadata(ws)
+            assert meta.env is None
+
+    def test_save_and_reload_preserves_env(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ws = Path(tmpdir)
+            meta = AgentMetadata(
+                agent_name="test-agent",
+                entrypoint="python main.py",
+                env={"KEY": "value"},
+            )
+            svc = MetadataService()
+            svc.save_metadata(ws, meta)
+
+            reloaded = svc.load_metadata(ws)
+            assert reloaded.env == {"KEY": "value"}
+
+    def test_save_without_env_omits_field(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ws = Path(tmpdir)
+            meta = AgentMetadata(
+                agent_name="test-agent",
+                entrypoint="python main.py",
+            )
+            svc = MetadataService()
+            svc.save_metadata(ws, meta)
+
+            with open(ws / "agent_metadata.yaml") as f:
+                raw = yaml.safe_load(f)
+            assert "env" not in raw
+
+
+# ---------------------------------------------------------------------------
+# PublishRuntime env forwarding tests
+# ---------------------------------------------------------------------------
+
+class TestPublishRuntimeEnvForwarding:
+    """Test that env from metadata is forwarded to providers."""
+
+    def _make_metadata(self, env=None):
+        return AgentMetadata(
+            agent_name="test-agent",
+            entrypoint="python main.py",
+            port=8080,
+            build_mode="local",
+            version="0.0.1",
+            registry_url="registry.example.com/test",
+            workload_manager_url="http://wm:8080",
+            router_url="http://router:8080",
+            readiness_probe_path="/health",
+            readiness_probe_port=8080,
+            agent_endpoint="http://localhost:8080",
+            image={"repository_url": "registry.example.com/test:latest"},
+            env=env,
+        )
+
+    @patch("agentcube.runtime.publish_runtime.AgentCubeProvider")
+    @patch("agentcube.runtime.publish_runtime.DockerService")
+    @patch("agentcube.runtime.publish_runtime.MetadataService")
+    def test_env_forwarded_to_agentcube_provider(
+        self, MockMetaSvc, MockDockerSvc, MockACProvider
+    ):
+        from agentcube.runtime.publish_runtime import PublishRuntime
+
+        env = {"LLM_BASE_URL": "http://llm", "LLM_API_KEY": "sk-123"}
+        meta = self._make_metadata(env=env)
+
+        mock_meta_svc = MockMetaSvc.return_value
+        mock_meta_svc.load_metadata.return_value = meta
+
+        mock_docker = MockDockerSvc.return_value
+        mock_docker.push_image.return_value = {"pushed_image": "registry.example.com/test:latest"}
+
+        mock_provider = MagicMock()
+        mock_provider.deploy_agent_runtime.return_value = {
+            "deployment_name": "test-agent",
+            "namespace": "default",
+            "status": "deployed",
+            "type": "AgentRuntime",
+        }
+        MockACProvider.return_value = mock_provider
+
+        runtime = PublishRuntime(verbose=False, provider="agentcube")
+        runtime.metadata_service = mock_meta_svc
+        runtime.docker_service = mock_docker
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime.publish(Path(tmpdir), provider="agentcube")
+
+        call_kwargs = mock_provider.deploy_agent_runtime.call_args
+        passed_env = call_kwargs.kwargs.get("env_vars") or call_kwargs[1].get("env_vars")
+        assert passed_env is not None
+        assert "LLM_BASE_URL" in passed_env
+        assert passed_env["LLM_BASE_URL"] == "http://llm"
+        assert passed_env["LLM_API_KEY"] == "sk-123"
+
+    @patch("agentcube.runtime.publish_runtime.KubernetesProvider")
+    @patch("agentcube.runtime.publish_runtime.DockerService")
+    @patch("agentcube.runtime.publish_runtime.MetadataService")
+    def test_env_forwarded_to_k8s_provider(
+        self, MockMetaSvc, MockDockerSvc, MockK8sProvider
+    ):
+        from agentcube.runtime.publish_runtime import PublishRuntime
+
+        env = {"DB_HOST": "db.internal"}
+        meta = self._make_metadata(env=env)
+
+        mock_meta_svc = MockMetaSvc.return_value
+        mock_meta_svc.load_metadata.return_value = meta
+
+        mock_docker = MockDockerSvc.return_value
+        mock_docker.push_image.return_value = {"pushed_image": "registry.example.com/test:latest"}
+
+        mock_provider = MagicMock()
+        mock_provider.deploy_agent.return_value = {
+            "deployment_name": "test-agent",
+            "service_name": "test-agent",
+            "namespace": "default",
+            "replicas": 1,
+            "container_port": 8080,
+            "node_port": 30080,
+            "service_url": "http://localhost:30080",
+        }
+        mock_provider.wait_for_deployment_ready.return_value = None
+        MockK8sProvider.return_value = mock_provider
+
+        runtime = PublishRuntime(verbose=False, provider="k8s")
+        runtime.metadata_service = mock_meta_svc
+        runtime.docker_service = mock_docker
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime.publish(Path(tmpdir), provider="k8s")
+
+        call_kwargs = mock_provider.deploy_agent.call_args
+        passed_env = call_kwargs.kwargs.get("env_vars") or call_kwargs[1].get("env_vars")
+        assert passed_env is not None
+        assert "DB_HOST" in passed_env
+        assert passed_env["DB_HOST"] == "db.internal"
+
+    @patch("agentcube.runtime.publish_runtime.AgentCubeProvider")
+    @patch("agentcube.runtime.publish_runtime.DockerService")
+    @patch("agentcube.runtime.publish_runtime.MetadataService")
+    def test_no_env_passes_none(self, MockMetaSvc, MockDockerSvc, MockACProvider):
+        from agentcube.runtime.publish_runtime import PublishRuntime
+
+        meta = self._make_metadata(env=None)
+
+        mock_meta_svc = MockMetaSvc.return_value
+        mock_meta_svc.load_metadata.return_value = meta
+
+        mock_docker = MockDockerSvc.return_value
+        mock_docker.push_image.return_value = {"pushed_image": "registry.example.com/test:latest"}
+
+        mock_provider = MagicMock()
+        mock_provider.deploy_agent_runtime.return_value = {
+            "deployment_name": "test-agent",
+            "namespace": "default",
+            "status": "deployed",
+            "type": "AgentRuntime",
+        }
+        MockACProvider.return_value = mock_provider
+
+        runtime = PublishRuntime(verbose=False, provider="agentcube")
+        runtime.metadata_service = mock_meta_svc
+        runtime.docker_service = mock_docker
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime.publish(Path(tmpdir), provider="agentcube")
+
+        call_kwargs = mock_provider.deploy_agent_runtime.call_args
+        passed_env = call_kwargs.kwargs.get("env_vars") or call_kwargs[1].get("env_vars")
+        assert passed_env is None


### PR DESCRIPTION
## Summary

Adds first-class `env` support to `agent_metadata.yaml` so users can declare extra environment variables that get injected into sandbox pod containers during publish.

Right now the only way to get custom env vars (like `LLM_BASE_URL`, `LLM_API_KEY`) into a deployed agent is to manually patch the CRD after `kubectl agentcube publish`, and that gets overwritten on the next publish. This change lets you put them straight in the metadata file:

```yaml
agent_name: my-agent
entrypoint: python main.py
port: 8080
env:
  LLM_BASE_URL: https://api.example.com
  LLM_API_KEY: sk-xxx
```

### What changed

- **`metadata_service.py`** -- added `env: Optional[Dict[str, str]]` field to `AgentMetadata` model. Defaults to `None`, excluded from saved YAML when absent.
- **`publish_runtime.py`** -- both `_publish_cr_to_k8s` (AgentRuntime CR) and `_publish_k8s` (standard Deployment) now read `metadata.env` and merge it into the `env_vars` dict before passing to providers. Programmatic `env_vars` from options still override metadata values.
- **`tests/test_env_support.py`** -- 10 unit tests covering model validation, YAML round-trip, and env forwarding to both providers.

Fixes #222

## Test plan

- [x] `AgentMetadata` accepts `env` dict, defaults to `None`
- [x] YAML load/save round-trips `env` correctly
- [x] Saving metadata without `env` omits the field from YAML
- [x] `env` from metadata forwarded to AgentCube provider
- [x] `env` from metadata forwarded to K8s provider
- [x] No `env` passes `None` to providers (no regression)
- [x] All 10 tests pass locally