### PR TITLE
fix: use idiomatic Go boolean check in store_redis.go

### DIFF
--- a/pkg/store/store_redis.go
+++ b/pkg/store/store_redis.go
@@ -207,8 +207,8 @@ func (rs *redisStore) UpdateSandbox(ctx context.Context, sandboxRedis *types.San
 		return fmt.Errorf("UpdateSandbox: redis SETXX %s: %w", sessionKey, err)
 	}
 
-	if ok == false {
-		return fmt.Errorf("UpdateSandbox: redis SETXX %s, key not exists", sessionKey)
+	if !ok {
+		return fmt.Errorf("UpdateSandbox: redis SETXX %s, key does not exist", sessionKey)
 	}
 	return nil
 }

--- a/pkg/store/store_redis_test.go
+++ b/pkg/store/store_redis_test.go
@@ -122,7 +122,7 @@ func TestRedisStore_UpdateSandbox(t *testing.T) {
 	}
 	err := c.UpdateSandbox(ctx, sandboxStoreStruct)
 	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "key not exists")
+	assert.Contains(t, err.Error(), "key does not exist")
 }
 
 func TestGetSandboxBySessionIDNotFound(t *testing.T) {


### PR DESCRIPTION

**Description**:
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Replaces `if ok == false` with `if !ok` in `store_redis.go`. The Go Code Review Comments wiki and `golint`/`revive` linters recommend against comparing boolean values to `true`/`false` explicitly. The idiomatic Go form uses the negation operator directly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
