### PR TITLE
fix: use idiomatic Go boolean checks in store_valkey.go

### DIFF
--- a/pkg/store/store_valkey.go
+++ b/pkg/store/store_valkey.go
@@ -79,7 +79,7 @@ func makeValkeyOptions() (*valkey.ClientOption, error) {
 	valkeyDisableCache := os.Getenv("VALKEY_DISABLE_CACHE")
 	if valkeyDisableCache != "" {
 		disableCache, err := strconv.ParseBool(valkeyDisableCache)
-		if err == nil && disableCache == true {
+		if err == nil && disableCache {
 			valkeyClientOptions.DisableCache = true
 			klog.Info("valkeyClientOptions DisableCache is set to true")
 		}
@@ -87,7 +87,7 @@ func makeValkeyOptions() (*valkey.ClientOption, error) {
 	valkeyForceSingle := os.Getenv("VALKEY_FORCE_SINGLE")
 	if valkeyForceSingle != "" {
 		forceSingleCache, err := strconv.ParseBool(valkeyForceSingle)
-		if err == nil && forceSingleCache == true {
+		if err == nil && forceSingleCache {
 			valkeyClientOptions.ForceSingleClient = true
 			klog.Info("valkeyClientOptions ForceSingleClient is set to true")
 		}


### PR DESCRIPTION

**Description**:
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Replaces explicit boolean comparisons with idiomatic Go style in `store_valkey.go`:
- `if err == nil && disableCache == true` → `if err == nil && disableCache`
- `if err == nil && forceSingleCache == true` → `if err == nil && forceSingleCache`

The Go Code Review Comments wiki and `golint`/`revive` linters recommend against comparing boolean values to `true`/`false` explicitly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
