### PR TITLE
test: fail TestAgentRuntimeSessionTTL on missing session ID

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -723,12 +723,12 @@ func TestAgentRuntimeSessionTTL(t *testing.T) {
 		},
 	}
 
-	_, sessionID, err := env.invokeAgentRuntime(namespace, runtimeName, "", req)
+	resp, sessionID, err := env.invokeAgentRuntime(namespace, runtimeName, "", req)
 	if err != nil {
 		t.Fatalf("Failed to create session: %v", err)
 	}
 	if sessionID == "" {
-		t.Skip("Session ID not returned, skipping TTL test")
+		t.Fatalf("Session ID not returned in invocation response; cannot exercise TTL behavior. Response: %+v", resp)
 	}
 
 	t.Logf("Created session %s for TTL test", sessionID)


### PR DESCRIPTION
## Summary

- `TestAgentRuntimeSessionTTL` was silently skipping via `t.Skip` when the invocation response lacked a session ID, letting CI pass green without actually testing TTL behavior.
- Replaced the `t.Skip` with `t.Fatalf` that logs the full invocation response so the root cause is immediately visible.

Fixes #198

## Test plan

- The test will now fail loudly if the runtime does not return a session ID, surfacing TTL regressions instead of hiding them.
- When a session ID is returned, behavior is unchanged -- TTL expiration is exercised as before.