### PR TITLE
test: add coverage for buildSandboxObject and buildSandboxClaimObject

### DIFF
--- a/pkg/workloadmanager/workload_builder_test.go
+++ b/pkg/workloadmanager/workload_builder_test.go
@@ -19,6 +19,8 @@ package workloadmanager
 import (
 	"testing"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // TestBuildSandboxObject_DoesNotMutateCallerLabels verifies that buildSandboxObject
@@ -101,4 +103,108 @@ func TestBuildSandboxObject_NilLabels(t *testing.T) {
 	if podLabels[SandboxNameLabelKey] != "sandbox-xyz" {
 		t.Errorf("expected %s=sandbox-xyz, got %q", SandboxNameLabelKey, podLabels[SandboxNameLabelKey])
 	}
+}
+
+// TestBuildSandboxObject_WorkloadNameLabel verifies that the WorkloadNameLabelKey
+// label is correctly set on the Sandbox object metadata from the workloadName param.
+// This covers the bug where CodeInterpreter sandboxes were missing this label.
+func TestBuildSandboxObject_WorkloadNameLabel(t *testing.T) {
+	tests := []struct {
+		name         string
+		workloadName string
+		wantLabel    string
+	}{
+		{
+			name:         "workloadName is set",
+			workloadName: "my-code-interpreter",
+			wantLabel:    "my-code-interpreter",
+		},
+		{
+			name:         "workloadName is empty",
+			workloadName: "",
+			wantLabel:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := &buildSandboxParams{
+				namespace:    "default",
+				workloadName: tt.workloadName,
+				sandboxName:  "sandbox-wl-test",
+				sessionID:    "session-wl-test",
+				ttl:          time.Hour,
+				idleTimeout:  15 * time.Minute,
+			}
+			sandbox := buildSandboxObject(params)
+
+			got := sandbox.ObjectMeta.Labels[WorkloadNameLabelKey]
+			if got != tt.wantLabel {
+				t.Errorf("expected %s=%q, got %q", WorkloadNameLabelKey, tt.wantLabel, got)
+			}
+		})
+	}
+}
+
+// TestBuildSandboxClaimObject verifies that buildSandboxClaimObject correctly
+// populates all fields including labels, annotations, and owner references.
+func TestBuildSandboxClaimObject(t *testing.T) {
+	t.Run("with owner reference", func(t *testing.T) {
+		ownerRef := &metav1.OwnerReference{
+			APIVersion: "runtime.agentcube.volcano.sh/v1alpha1",
+			Kind:       "CodeInterpreter",
+			Name:       "my-ci",
+			UID:        "test-uid-123",
+		}
+		params := &buildSandboxClaimParams{
+			namespace:           "test-ns",
+			name:                "claim-abc",
+			sandboxTemplateName: "my-ci",
+			sessionID:           "session-claim-test",
+			idleTimeout:         10 * time.Minute,
+			ownerReference:      ownerRef,
+		}
+		claim := buildSandboxClaimObject(params)
+
+		if claim.Namespace != "test-ns" {
+			t.Errorf("expected namespace test-ns, got %q", claim.Namespace)
+		}
+		if claim.Name != "claim-abc" {
+			t.Errorf("expected name claim-abc, got %q", claim.Name)
+		}
+		if claim.Spec.TemplateRef.Name != "my-ci" {
+			t.Errorf("expected templateRef name my-ci, got %q", claim.Spec.TemplateRef.Name)
+		}
+		if claim.Labels[SessionIdLabelKey] != "session-claim-test" {
+			t.Errorf("expected label %s=session-claim-test, got %q", SessionIdLabelKey, claim.Labels[SessionIdLabelKey])
+		}
+		if claim.Annotations[IdleTimeoutAnnotationKey] != "10m0s" {
+			t.Errorf("expected annotation %s=10m0s, got %q", IdleTimeoutAnnotationKey, claim.Annotations[IdleTimeoutAnnotationKey])
+		}
+		if len(claim.OwnerReferences) != 1 {
+			t.Fatalf("expected 1 owner reference, got %d", len(claim.OwnerReferences))
+		}
+		if claim.OwnerReferences[0].Name != "my-ci" {
+			t.Errorf("expected owner ref name my-ci, got %q", claim.OwnerReferences[0].Name)
+		}
+	})
+
+	t.Run("without owner reference", func(t *testing.T) {
+		params := &buildSandboxClaimParams{
+			namespace:           "default",
+			name:                "claim-no-owner",
+			sandboxTemplateName: "template-1",
+			sessionID:           "session-no-owner",
+			idleTimeout:         0,
+		}
+		claim := buildSandboxClaimObject(params)
+
+		if len(claim.OwnerReferences) != 0 {
+			t.Errorf("expected 0 owner references, got %d", len(claim.OwnerReferences))
+		}
+		if claim.Annotations[IdleTimeoutAnnotationKey] != DefaultSandboxIdleTimeout.String() {
+			t.Errorf("expected default idle timeout annotation %s, got %q",
+				DefaultSandboxIdleTimeout.String(), claim.Annotations[IdleTimeoutAnnotationKey])
+		}
+	})
 }


### PR DESCRIPTION
**Description**:
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:
Adds two new test functions to improve test coverage for the workload builder package:
- `TestBuildSandboxObject_WorkloadNameLabel`: Verifies that `WorkloadNameLabelKey` is correctly propagated from `params.workloadName` to the Sandbox object metadata labels.
- `TestBuildSandboxClaimObject`: Verifies `buildSandboxClaimObject` correctly populates all fields including namespace, name, templateRef, session labels, idle timeout annotations, and owner references (covers both with and without owner reference scenarios).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
