### PR TITLE
fix(router): enforce session-to-route binding validation

### DIFF
--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -57,6 +57,11 @@ func NewSessionNotFoundError(sessionID string) error {
 	return apierrors.NewNotFound(sessionResource, sessionID)
 }
 
+func NewSessionTargetMismatchError(sessionID, namespace, name, kind string) error {
+	target := fmt.Sprintf("%s/%s", namespace, name)
+	return apierrors.NewConflict(sessionResource, sessionID, fmt.Errorf("session target mismatch: %s (%s)", target, kind))
+}
+
 func workloadResource(kind string) schema.GroupResource {
 	switch kind {
 	case types.CodeInterpreterKind:

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -19,6 +19,7 @@ package api
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -60,6 +61,24 @@ func NewSessionNotFoundError(sessionID string) error {
 func NewSessionTargetMismatchError(sessionID, namespace, name, kind string) error {
 	target := fmt.Sprintf("%s/%s", namespace, name)
 	return apierrors.NewConflict(sessionResource, sessionID, fmt.Errorf("session target mismatch: %s (%s)", target, kind))
+}
+
+func IsSessionTargetMismatch(err error) bool {
+	if !apierrors.IsConflict(err) {
+		return false
+	}
+	statusErr, ok := err.(apierrors.APIStatus)
+	if !ok {
+		return false
+	}
+	status := statusErr.Status()
+	if status.Details == nil {
+		return false
+	}
+	if status.Details.Group != sessionResource.Group || status.Details.Kind != sessionResource.Resource {
+		return false
+	}
+	return strings.Contains(status.Message, "session target mismatch")
 }
 
 func workloadResource(kind string) schema.GroupResource {

--- a/pkg/api/errors_test.go
+++ b/pkg/api/errors_test.go
@@ -46,6 +46,17 @@ func TestNewSessionNotFoundError(t *testing.T) {
 	assert.Equal(t, sessionID, status.Details.Name)
 }
 
+func TestIsSessionTargetMismatch(t *testing.T) {
+	mismatchErr := NewSessionTargetMismatchError("session-1", "default", "agent", types.AgentRuntimeKind)
+	assert.True(t, IsSessionTargetMismatch(mismatchErr))
+
+	notFoundErr := NewSessionNotFoundError("session-2")
+	assert.False(t, IsSessionTargetMismatch(notFoundErr))
+
+	wrappedErr := NewInternalError(errors.New("boom"))
+	assert.False(t, IsSessionTargetMismatch(wrappedErr))
+}
+
 func TestWorkloadResource(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/common/types/sandbox.go
+++ b/pkg/common/types/sandbox.go
@@ -28,6 +28,8 @@ type SandboxInfo struct {
 	SandboxID        string              `json:"sandboxId"`
 	SandboxNamespace string              `json:"sandboxNamespace"`
 	Name             string              `json:"name"`
+	WorkloadKind     string              `json:"workloadKind,omitempty"`
+	WorkloadName     string              `json:"workloadName,omitempty"`
 	EntryPoints      []SandboxEntryPoint `json:"entryPoints"`
 	SessionID        string              `json:"sessionId"`
 	CreatedAt        time.Time           `json:"createdAt"`

--- a/pkg/router/handlers.go
+++ b/pkg/router/handlers.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/volcano-sh/agentcube/pkg/api"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 
@@ -96,6 +97,10 @@ func (s *Server) handleGetSandboxError(c *gin.Context, err error) {
 		}
 		if code == http.StatusInternalServerError {
 			message = "internal server error"
+		}
+		if api.IsSessionTargetMismatch(err) {
+			c.JSON(code, gin.H{"error": message, "code": "SESSION_TARGET_MISMATCH"})
+			return
 		}
 		c.JSON(code, gin.H{"error": message})
 		return

--- a/pkg/router/handlers_test.go
+++ b/pkg/router/handlers_test.go
@@ -195,6 +195,11 @@ func TestHandleInvoke_ErrorPaths(t *testing.T) {
 			expectedCode: http.StatusNotFound,
 		},
 		{
+			name:         "session target mismatch",
+			err:          api.NewSessionTargetMismatchError("session-1", "default", "test-agent", types.AgentRuntimeKind),
+			expectedCode: http.StatusConflict,
+		},
+		{
 			name:         "agent runtime not found",
 			err:          api.NewSandboxTemplateNotFoundError("default", "test-agent", types.AgentRuntimeKind),
 			expectedCode: http.StatusNotFound,

--- a/pkg/router/handlers_test.go
+++ b/pkg/router/handlers_test.go
@@ -18,6 +18,7 @@ package router
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -180,9 +181,10 @@ func TestHandleInvoke_ErrorPaths(t *testing.T) {
 	defer teardownEnv()
 
 	tests := []struct {
-		name         string
-		err          error
-		expectedCode int
+		name             string
+		err              error
+		expectedCode     int
+		expectedBodyCode string
 	}{
 		{
 			name:         "session manager generic error",
@@ -195,9 +197,10 @@ func TestHandleInvoke_ErrorPaths(t *testing.T) {
 			expectedCode: http.StatusNotFound,
 		},
 		{
-			name:         "session target mismatch",
-			err:          api.NewSessionTargetMismatchError("session-1", "default", "test-agent", types.AgentRuntimeKind),
-			expectedCode: http.StatusConflict,
+			name:             "session target mismatch",
+			err:              api.NewSessionTargetMismatchError("session-1", "default", "test-agent", types.AgentRuntimeKind),
+			expectedCode:     http.StatusConflict,
+			expectedBodyCode: "SESSION_TARGET_MISMATCH",
 		},
 		{
 			name:         "agent runtime not found",
@@ -232,6 +235,15 @@ func TestHandleInvoke_ErrorPaths(t *testing.T) {
 
 			if w.Code != tt.expectedCode {
 				t.Fatalf("expected status %d, got %d", tt.expectedCode, w.Code)
+			}
+			if tt.expectedBodyCode != "" {
+				var resp map[string]interface{}
+				if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if resp["code"] != tt.expectedBodyCode {
+					t.Fatalf("expected code %q, got %v", tt.expectedBodyCode, resp["code"])
+				}
 			}
 			t.Logf("Response body: %s", w.Body.String())
 		})

--- a/pkg/router/session_manager.go
+++ b/pkg/router/session_manager.go
@@ -109,7 +109,27 @@ func (m *manager) GetSandboxBySession(ctx context.Context, sessionID string, nam
 		return nil, fmt.Errorf("failed to get sandbox from store: %w", err)
 	}
 
+	if !sessionTargetMatches(sandbox, namespace, name, kind) {
+		return nil, api.NewSessionTargetMismatchError(sessionID, namespace, name, kind)
+	}
+
 	return sandbox, nil
+}
+
+func sessionTargetMatches(sandbox *types.SandboxInfo, namespace, name, kind string) bool {
+	if sandbox == nil {
+		return false
+	}
+	if sandbox.Kind != "" && sandbox.Kind != kind {
+		return false
+	}
+	if sandbox.Name != "" && sandbox.Name != name {
+		return false
+	}
+	if sandbox.SandboxNamespace != "" && sandbox.SandboxNamespace != namespace {
+		return false
+	}
+	return true
 }
 
 // createSandbox creates a new sandbox by calling the external workload manager API.

--- a/pkg/router/session_manager.go
+++ b/pkg/router/session_manager.go
@@ -131,11 +131,11 @@ func sessionTargetMatches(sandbox *types.SandboxInfo, sessionID, namespace, name
 		missingFields = append(missingFields, "sandboxNamespace")
 	}
 	if len(missingFields) > 0 {
-		klog.V(2).InfoS("Session target metadata missing", "sessionID", sessionID, "requestedNamespace", namespace, "requestedName", name, "requestedKind", kind, "missingFields", strings.Join(missingFields, ","))
+		klog.Warningf("Session target metadata missing for sessionID=%s: missing fields [%s] (requested namespace=%s name=%s kind=%s)", sessionID, strings.Join(missingFields, ","), namespace, name, kind)
 		return false
 	}
 	if sandbox.WorkloadKind != kind || sandbox.WorkloadName != name || sandbox.SandboxNamespace != namespace {
-		klog.V(2).InfoS("Session target mismatch", "sessionID", sessionID, "requestedNamespace", namespace, "requestedName", name, "requestedKind", kind, "actualNamespace", sandbox.SandboxNamespace, "actualWorkloadName", sandbox.WorkloadName, "actualWorkloadKind", sandbox.WorkloadKind)
+		klog.Warningf("Session target mismatch for sessionID=%s: requested namespace=%s name=%s kind=%s but session belongs to namespace=%s name=%s kind=%s", sessionID, namespace, name, kind, sandbox.SandboxNamespace, sandbox.WorkloadName, sandbox.WorkloadKind)
 		return false
 	}
 	return true

--- a/pkg/router/session_manager.go
+++ b/pkg/router/session_manager.go
@@ -109,24 +109,27 @@ func (m *manager) GetSandboxBySession(ctx context.Context, sessionID string, nam
 		return nil, fmt.Errorf("failed to get sandbox from store: %w", err)
 	}
 
-	if !sessionTargetMatches(sandbox, namespace, name, kind) {
+	if !sessionTargetMatches(sandbox, sessionID, namespace, name, kind) {
 		return nil, api.NewSessionTargetMismatchError(sessionID, namespace, name, kind)
 	}
 
 	return sandbox, nil
 }
 
-func sessionTargetMatches(sandbox *types.SandboxInfo, namespace, name, kind string) bool {
+func sessionTargetMatches(sandbox *types.SandboxInfo, sessionID, namespace, name, kind string) bool {
 	if sandbox == nil {
 		return false
 	}
 	if sandbox.Kind != "" && sandbox.Kind != kind {
+		klog.V(2).InfoS("Session target mismatch", "sessionID", sessionID, "requestedNamespace", namespace, "requestedName", name, "requestedKind", kind, "actualNamespace", sandbox.SandboxNamespace, "actualName", sandbox.Name, "actualKind", sandbox.Kind)
 		return false
 	}
 	if sandbox.Name != "" && sandbox.Name != name {
+		klog.V(2).InfoS("Session target mismatch", "sessionID", sessionID, "requestedNamespace", namespace, "requestedName", name, "requestedKind", kind, "actualNamespace", sandbox.SandboxNamespace, "actualName", sandbox.Name, "actualKind", sandbox.Kind)
 		return false
 	}
 	if sandbox.SandboxNamespace != "" && sandbox.SandboxNamespace != namespace {
+		klog.V(2).InfoS("Session target mismatch", "sessionID", sessionID, "requestedNamespace", namespace, "requestedName", name, "requestedKind", kind, "actualNamespace", sandbox.SandboxNamespace, "actualName", sandbox.Name, "actualKind", sandbox.Kind)
 		return false
 	}
 	return true
@@ -203,12 +206,17 @@ func (m *manager) createSandbox(ctx context.Context, namespace string, name stri
 		return nil, api.NewInternalError(fmt.Errorf("response with empty session id from workload manager"))
 	}
 
-	// Construct Sandbox Info from response
+	// Construct Sandbox Info from response, storing the requested target metadata
+	// to enable proper session reuse validation. The ephemeral sandbox name (res.SandboxName)
+	// is not stored here to avoid the "fail-open" vulnerability where a session could be
+	// incorrectly reused for a different workload.
 	sandbox := &types.SandboxInfo{
-		SandboxID:   res.SandboxID,
-		Name:        res.SandboxName,
-		SessionID:   res.SessionID,
-		EntryPoints: res.EntryPoints,
+		SandboxID:        res.SandboxID,
+		Name:             name,
+		SandboxNamespace: namespace,
+		Kind:             kind,
+		SessionID:        res.SessionID,
+		EntryPoints:      res.EntryPoints,
 	}
 
 	return sandbox, nil

--- a/pkg/router/session_manager.go
+++ b/pkg/router/session_manager.go
@@ -120,16 +120,22 @@ func sessionTargetMatches(sandbox *types.SandboxInfo, sessionID, namespace, name
 	if sandbox == nil {
 		return false
 	}
-	if sandbox.Kind != "" && sandbox.Kind != kind {
-		klog.V(2).InfoS("Session target mismatch", "sessionID", sessionID, "requestedNamespace", namespace, "requestedName", name, "requestedKind", kind, "actualNamespace", sandbox.SandboxNamespace, "actualName", sandbox.Name, "actualKind", sandbox.Kind)
+	missingFields := make([]string, 0, 3)
+	if sandbox.WorkloadKind == "" {
+		missingFields = append(missingFields, "workloadKind")
+	}
+	if sandbox.WorkloadName == "" {
+		missingFields = append(missingFields, "workloadName")
+	}
+	if sandbox.SandboxNamespace == "" {
+		missingFields = append(missingFields, "sandboxNamespace")
+	}
+	if len(missingFields) > 0 {
+		klog.V(2).InfoS("Session target metadata missing", "sessionID", sessionID, "requestedNamespace", namespace, "requestedName", name, "requestedKind", kind, "missingFields", strings.Join(missingFields, ","))
 		return false
 	}
-	if sandbox.Name != "" && sandbox.Name != name {
-		klog.V(2).InfoS("Session target mismatch", "sessionID", sessionID, "requestedNamespace", namespace, "requestedName", name, "requestedKind", kind, "actualNamespace", sandbox.SandboxNamespace, "actualName", sandbox.Name, "actualKind", sandbox.Kind)
-		return false
-	}
-	if sandbox.SandboxNamespace != "" && sandbox.SandboxNamespace != namespace {
-		klog.V(2).InfoS("Session target mismatch", "sessionID", sessionID, "requestedNamespace", namespace, "requestedName", name, "requestedKind", kind, "actualNamespace", sandbox.SandboxNamespace, "actualName", sandbox.Name, "actualKind", sandbox.Kind)
+	if sandbox.WorkloadKind != kind || sandbox.WorkloadName != name || sandbox.SandboxNamespace != namespace {
+		klog.V(2).InfoS("Session target mismatch", "sessionID", sessionID, "requestedNamespace", namespace, "requestedName", name, "requestedKind", kind, "actualNamespace", sandbox.SandboxNamespace, "actualWorkloadName", sandbox.WorkloadName, "actualWorkloadKind", sandbox.WorkloadKind)
 		return false
 	}
 	return true
@@ -215,6 +221,8 @@ func (m *manager) createSandbox(ctx context.Context, namespace string, name stri
 		Name:             name,
 		SandboxNamespace: namespace,
 		Kind:             kind,
+		WorkloadKind:     kind,
+		WorkloadName:     name,
 		SessionID:        res.SessionID,
 		EntryPoints:      res.EntryPoints,
 	}

--- a/pkg/router/session_manager_test.go
+++ b/pkg/router/session_manager_test.go
@@ -103,7 +103,8 @@ func (f *fakeStoreClient) Close() error {
 func TestGetSandboxBySession_Success(t *testing.T) {
 	sb := &types.SandboxInfo{
 		SandboxID: "sandbox-1",
-		Name:      "sandbox-1",
+		Name:      "test",
+		SandboxNamespace: "default",
 		EntryPoints: []types.SandboxEntryPoint{
 			{Endpoint: "10.0.0.1:9000"},
 		},
@@ -151,6 +152,63 @@ func TestGetSandboxBySession_NotFound(t *testing.T) {
 	}
 	if !apierrors.IsNotFound(err) {
 		t.Fatalf("expected not found error, got %v", err)
+	}
+}
+
+func TestGetSandboxBySession_TargetMismatch(t *testing.T) {
+	r := &fakeStoreClient{
+		sandbox: &types.SandboxInfo{
+			SessionID:        "sess-1",
+			Kind:             types.AgentRuntimeKind,
+			SandboxNamespace: "default",
+			Name:             "other-runtime",
+		},
+	}
+	m := &manager{
+		storeClient: r,
+	}
+
+	_, err := m.GetSandboxBySession(context.Background(), "sess-1", "default", "test-runtime", types.AgentRuntimeKind)
+	if err == nil {
+		t.Fatalf("expected conflict error for target mismatch")
+	}
+	if !apierrors.IsConflict(err) {
+		t.Fatalf("expected conflict error, got %v", err)
+	}
+}
+
+func TestGetSandboxBySession_TargetMatch(t *testing.T) {
+	r := &fakeStoreClient{
+		sandbox: &types.SandboxInfo{
+			SessionID:        "sess-1",
+			Kind:             types.AgentRuntimeKind,
+			SandboxNamespace: "default",
+			Name:             "test-runtime",
+		},
+	}
+	m := &manager{
+		storeClient: r,
+	}
+
+	_, err := m.GetSandboxBySession(context.Background(), "sess-1", "default", "test-runtime", types.AgentRuntimeKind)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestGetSandboxBySession_TargetMatch_EmptyFields(t *testing.T) {
+	r := &fakeStoreClient{
+		sandbox: &types.SandboxInfo{
+			SessionID: "sess-1",
+		},
+	}
+	m := &manager{
+		storeClient: r,
+	}
+
+	_, err := m.GetSandboxBySession(context.Background(), "sess-1", "default", "test-runtime", types.AgentRuntimeKind)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
 	}
 }
 

--- a/pkg/router/session_manager_test.go
+++ b/pkg/router/session_manager_test.go
@@ -102,8 +102,8 @@ func (f *fakeStoreClient) Close() error {
 
 func TestGetSandboxBySession_Success(t *testing.T) {
 	sb := &types.SandboxInfo{
-		SandboxID: "sandbox-1",
-		Name:      "test",
+		SandboxID:        "sandbox-1",
+		Name:             "test",
 		SandboxNamespace: "default",
 		EntryPoints: []types.SandboxEntryPoint{
 			{Endpoint: "10.0.0.1:9000"},

--- a/pkg/router/session_manager_test.go
+++ b/pkg/router/session_manager_test.go
@@ -105,6 +105,8 @@ func TestGetSandboxBySession_Success(t *testing.T) {
 		SandboxID:        "sandbox-1",
 		Name:             "test",
 		SandboxNamespace: "default",
+		WorkloadKind:     types.AgentRuntimeKind,
+		WorkloadName:     "test",
 		EntryPoints: []types.SandboxEntryPoint{
 			{Endpoint: "10.0.0.1:9000"},
 		},
@@ -159,9 +161,9 @@ func TestGetSandboxBySession_TargetMismatch(t *testing.T) {
 	r := &fakeStoreClient{
 		sandbox: &types.SandboxInfo{
 			SessionID:        "sess-1",
-			Kind:             types.AgentRuntimeKind,
+			WorkloadKind:     types.AgentRuntimeKind,
 			SandboxNamespace: "default",
-			Name:             "other-runtime",
+			WorkloadName:     "other-runtime",
 		},
 	}
 	m := &manager{
@@ -181,9 +183,9 @@ func TestGetSandboxBySession_TargetMatch(t *testing.T) {
 	r := &fakeStoreClient{
 		sandbox: &types.SandboxInfo{
 			SessionID:        "sess-1",
-			Kind:             types.AgentRuntimeKind,
+			WorkloadKind:     types.AgentRuntimeKind,
 			SandboxNamespace: "default",
-			Name:             "test-runtime",
+			WorkloadName:     "test-runtime",
 		},
 	}
 	m := &manager{
@@ -207,8 +209,11 @@ func TestGetSandboxBySession_TargetMatch_EmptyFields(t *testing.T) {
 	}
 
 	_, err := m.GetSandboxBySession(context.Background(), "sess-1", "default", "test-runtime", types.AgentRuntimeKind)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	if err == nil {
+		t.Fatalf("expected conflict error for missing session metadata")
+	}
+	if !apierrors.IsConflict(err) {
+		t.Fatalf("expected conflict error, got %v", err)
 	}
 }
 
@@ -229,8 +234,8 @@ func TestSessionTargetMatches(t *testing.T) {
 		{
 			name: "perfect match with all fields populated",
 			sandbox: &types.SandboxInfo{
-				Kind:             types.AgentRuntimeKind,
-				Name:             "test-agent",
+				WorkloadKind:     types.AgentRuntimeKind,
+				WorkloadName:     "test-agent",
 				SandboxNamespace: "default",
 			},
 			sessionID:    "sess-1",
@@ -242,8 +247,8 @@ func TestSessionTargetMatches(t *testing.T) {
 		{
 			name: "perfect match with CodeInterpreter kind",
 			sandbox: &types.SandboxInfo{
-				Kind:             types.CodeInterpreterKind,
-				Name:             "my-ci",
+				WorkloadKind:     types.CodeInterpreterKind,
+				WorkloadName:     "my-ci",
 				SandboxNamespace: "ai-namespace",
 			},
 			sessionID:    "sess-2",
@@ -256,8 +261,8 @@ func TestSessionTargetMatches(t *testing.T) {
 		{
 			name: "Kind mismatch",
 			sandbox: &types.SandboxInfo{
-				Kind:             types.AgentRuntimeKind,
-				Name:             "test-agent",
+				WorkloadKind:     types.AgentRuntimeKind,
+				WorkloadName:     "test-agent",
 				SandboxNamespace: "default",
 			},
 			sessionID:    "sess-3",
@@ -269,8 +274,8 @@ func TestSessionTargetMatches(t *testing.T) {
 		{
 			name: "Name mismatch",
 			sandbox: &types.SandboxInfo{
-				Kind:             types.AgentRuntimeKind,
-				Name:             "test-agent",
+				WorkloadKind:     types.AgentRuntimeKind,
+				WorkloadName:     "test-agent",
 				SandboxNamespace: "default",
 			},
 			sessionID:    "sess-4",
@@ -282,8 +287,8 @@ func TestSessionTargetMatches(t *testing.T) {
 		{
 			name: "Namespace mismatch",
 			sandbox: &types.SandboxInfo{
-				Kind:             types.AgentRuntimeKind,
-				Name:             "test-agent",
+				WorkloadKind:     types.AgentRuntimeKind,
+				WorkloadName:     "test-agent",
 				SandboxNamespace: "default",
 			},
 			sessionID:    "sess-5",
@@ -302,72 +307,72 @@ func TestSessionTargetMatches(t *testing.T) {
 			kind:         types.AgentRuntimeKind,
 			expects:      false,
 		},
-		// Empty fields in sandbox (should match as they're treated as wildcards)
+		// Empty fields in sandbox (should fail closed)
 		{
-			name: "all sandbox fields empty - wildcard matching",
+			name: "all sandbox fields empty",
 			sandbox: &types.SandboxInfo{
-				Kind:             "",
-				Name:             "",
+				WorkloadKind:     "",
+				WorkloadName:     "",
 				SandboxNamespace: "",
 			},
 			sessionID:    "sess-7",
 			namespace:    "default",
 			workloadName: "test-agent",
 			kind:         types.AgentRuntimeKind,
-			expects:      true,
+			expects:      false,
 		},
 		{
-			name: "only Kind populated in sandbox",
+			name: "only workload kind populated in sandbox",
 			sandbox: &types.SandboxInfo{
-				Kind:             types.AgentRuntimeKind,
-				Name:             "",
+				WorkloadKind:     types.AgentRuntimeKind,
+				WorkloadName:     "",
 				SandboxNamespace: "",
 			},
 			sessionID:    "sess-8",
 			namespace:    "default",
 			workloadName: "test-agent",
 			kind:         types.AgentRuntimeKind,
-			expects:      true,
+			expects:      false,
 		},
 		{
-			name: "Kind empty in sandbox but kind matches request",
+			name: "workload kind empty in sandbox",
 			sandbox: &types.SandboxInfo{
-				Kind:             "",
-				Name:             "test-agent",
+				WorkloadKind:     "",
+				WorkloadName:     "test-agent",
 				SandboxNamespace: "default",
 			},
 			sessionID:    "sess-9",
 			namespace:    "default",
 			workloadName: "test-agent",
 			kind:         types.AgentRuntimeKind,
-			expects:      true,
+			expects:      false,
 		},
 		// Edge cases
 		{
 			name: "empty string kind in request",
 			sandbox: &types.SandboxInfo{
-				Kind:             "",
-				Name:             "test-agent",
+				WorkloadKind:     "",
+				WorkloadName:     "test-agent",
 				SandboxNamespace: "default",
 			},
 			sessionID:    "sess-10",
 			namespace:    "default",
 			workloadName: "test-agent",
 			kind:         "",
-			expects:      true,
+			expects:      false,
 		},
 		{
 			name: "multiple empty fields in sandbox",
 			sandbox: &types.SandboxInfo{
-				Kind:             types.AgentRuntimeKind,
-				Name:             "",
+				WorkloadKind:     types.AgentRuntimeKind,
+				WorkloadName:     "",
 				SandboxNamespace: "",
 			},
 			sessionID:    "sess-11",
 			namespace:    "prod",
 			workloadName: "my-workload",
 			kind:         types.AgentRuntimeKind,
-			expects:      true,
+			expects:      false,
 		},
 	}
 
@@ -377,7 +382,7 @@ func TestSessionTargetMatches(t *testing.T) {
 			if result != tt.expects {
 				t.Errorf("sessionTargetMatches returned %v, expected %v", result, tt.expects)
 				if tt.sandbox != nil {
-					t.Logf("  Sandbox: Kind=%q Name=%q Namespace=%q", tt.sandbox.Kind, tt.sandbox.Name, tt.sandbox.SandboxNamespace)
+					t.Logf("  Sandbox: WorkloadKind=%q WorkloadName=%q Namespace=%q", tt.sandbox.WorkloadKind, tt.sandbox.WorkloadName, tt.sandbox.SandboxNamespace)
 				}
 				t.Logf("  Request: Kind=%q Name=%q Namespace=%q SessionID=%q", tt.kind, tt.workloadName, tt.namespace, tt.sessionID)
 			}
@@ -387,18 +392,18 @@ func TestSessionTargetMatches(t *testing.T) {
 
 // ---- tests: GetSandboxBySession with empty sessionID (sandbox creation path) ----
 
-func TestGetSandboxBySession_CreateSandbox_AgentRuntime_Success(t *testing.T) {
-	// Mock workload manager server
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Verify request method and path
+// agentRuntimeCreateHandler is a reusable mock HTTP handler for the
+// /v1/agent-runtime endpoint, extracted to reduce cyclomatic complexity of its
+// parent test.
+func agentRuntimeCreateHandler(t *testing.T) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST request, got %s", r.Method)
 		}
 		if r.URL.Path != "/v1/agent-runtime" {
 			t.Errorf("expected path /v1/agent-runtime, got %s", r.URL.Path)
 		}
-
-		// Verify request body
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("failed to read request body: %v", err)
@@ -416,8 +421,6 @@ func TestGetSandboxBySession_CreateSandbox_AgentRuntime_Success(t *testing.T) {
 		if req.Namespace != "default" {
 			t.Errorf("expected namespace default, got %s", req.Namespace)
 		}
-
-		// Send successful response
 		resp := types.CreateSandboxResponse{
 			SessionID:   "new-session-123",
 			SandboxID:   "sandbox-456",
@@ -429,7 +432,11 @@ func TestGetSandboxBySession_CreateSandbox_AgentRuntime_Success(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(resp)
-	}))
+	}
+}
+
+func TestGetSandboxBySession_CreateSandbox_AgentRuntime_Success(t *testing.T) {
+	mockServer := httptest.NewServer(agentRuntimeCreateHandler(t))
 	defer mockServer.Close()
 
 	r := &fakeStoreClient{}

--- a/pkg/router/session_manager_test.go
+++ b/pkg/router/session_manager_test.go
@@ -212,6 +212,179 @@ func TestGetSandboxBySession_TargetMatch_EmptyFields(t *testing.T) {
 	}
 }
 
+// ---- tests: sessionTargetMatches ----
+
+// TestSessionTargetMatches provides comprehensive coverage for the sessionTargetMatches function.
+func TestSessionTargetMatches(t *testing.T) {
+	tests := []struct {
+		name         string
+		sandbox      *types.SandboxInfo
+		sessionID    string
+		namespace    string
+		workloadName string
+		kind         string
+		expects      bool
+	}{
+		// Perfect match cases
+		{
+			name: "perfect match with all fields populated",
+			sandbox: &types.SandboxInfo{
+				Kind:             types.AgentRuntimeKind,
+				Name:             "test-agent",
+				SandboxNamespace: "default",
+			},
+			sessionID:    "sess-1",
+			namespace:    "default",
+			workloadName: "test-agent",
+			kind:         types.AgentRuntimeKind,
+			expects:      true,
+		},
+		{
+			name: "perfect match with CodeInterpreter kind",
+			sandbox: &types.SandboxInfo{
+				Kind:             types.CodeInterpreterKind,
+				Name:             "my-ci",
+				SandboxNamespace: "ai-namespace",
+			},
+			sessionID:    "sess-2",
+			namespace:    "ai-namespace",
+			workloadName: "my-ci",
+			kind:         types.CodeInterpreterKind,
+			expects:      true,
+		},
+		// Mismatch cases - each field mismatches independently
+		{
+			name: "Kind mismatch",
+			sandbox: &types.SandboxInfo{
+				Kind:             types.AgentRuntimeKind,
+				Name:             "test-agent",
+				SandboxNamespace: "default",
+			},
+			sessionID:    "sess-3",
+			namespace:    "default",
+			workloadName: "test-agent",
+			kind:         types.CodeInterpreterKind,
+			expects:      false,
+		},
+		{
+			name: "Name mismatch",
+			sandbox: &types.SandboxInfo{
+				Kind:             types.AgentRuntimeKind,
+				Name:             "test-agent",
+				SandboxNamespace: "default",
+			},
+			sessionID:    "sess-4",
+			namespace:    "default",
+			workloadName: "different-agent",
+			kind:         types.AgentRuntimeKind,
+			expects:      false,
+		},
+		{
+			name: "Namespace mismatch",
+			sandbox: &types.SandboxInfo{
+				Kind:             types.AgentRuntimeKind,
+				Name:             "test-agent",
+				SandboxNamespace: "default",
+			},
+			sessionID:    "sess-5",
+			namespace:    "kube-system",
+			workloadName: "test-agent",
+			kind:         types.AgentRuntimeKind,
+			expects:      false,
+		},
+		// Nil sandbox case
+		{
+			name:         "nil sandbox",
+			sandbox:      nil,
+			sessionID:    "sess-6",
+			namespace:    "default",
+			workloadName: "test-agent",
+			kind:         types.AgentRuntimeKind,
+			expects:      false,
+		},
+		// Empty fields in sandbox (should match as they're treated as wildcards)
+		{
+			name: "all sandbox fields empty - wildcard matching",
+			sandbox: &types.SandboxInfo{
+				Kind:             "",
+				Name:             "",
+				SandboxNamespace: "",
+			},
+			sessionID:    "sess-7",
+			namespace:    "default",
+			workloadName: "test-agent",
+			kind:         types.AgentRuntimeKind,
+			expects:      true,
+		},
+		{
+			name: "only Kind populated in sandbox",
+			sandbox: &types.SandboxInfo{
+				Kind:             types.AgentRuntimeKind,
+				Name:             "",
+				SandboxNamespace: "",
+			},
+			sessionID:    "sess-8",
+			namespace:    "default",
+			workloadName: "test-agent",
+			kind:         types.AgentRuntimeKind,
+			expects:      true,
+		},
+		{
+			name: "Kind empty in sandbox but kind matches request",
+			sandbox: &types.SandboxInfo{
+				Kind:             "",
+				Name:             "test-agent",
+				SandboxNamespace: "default",
+			},
+			sessionID:    "sess-9",
+			namespace:    "default",
+			workloadName: "test-agent",
+			kind:         types.AgentRuntimeKind,
+			expects:      true,
+		},
+		// Edge cases
+		{
+			name: "empty string kind in request",
+			sandbox: &types.SandboxInfo{
+				Kind:             "",
+				Name:             "test-agent",
+				SandboxNamespace: "default",
+			},
+			sessionID:    "sess-10",
+			namespace:    "default",
+			workloadName: "test-agent",
+			kind:         "",
+			expects:      true,
+		},
+		{
+			name: "multiple empty fields in sandbox",
+			sandbox: &types.SandboxInfo{
+				Kind:             types.AgentRuntimeKind,
+				Name:             "",
+				SandboxNamespace: "",
+			},
+			sessionID:    "sess-11",
+			namespace:    "prod",
+			workloadName: "my-workload",
+			kind:         types.AgentRuntimeKind,
+			expects:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sessionTargetMatches(tt.sandbox, tt.sessionID, tt.namespace, tt.workloadName, tt.kind)
+			if result != tt.expects {
+				t.Errorf("sessionTargetMatches returned %v, expected %v", result, tt.expects)
+				if tt.sandbox != nil {
+					t.Logf("  Sandbox: Kind=%q Name=%q Namespace=%q", tt.sandbox.Kind, tt.sandbox.Name, tt.sandbox.SandboxNamespace)
+				}
+				t.Logf("  Request: Kind=%q Name=%q Namespace=%q SessionID=%q", tt.kind, tt.workloadName, tt.namespace, tt.sessionID)
+			}
+		})
+	}
+}
+
 // ---- tests: GetSandboxBySession with empty sessionID (sandbox creation path) ----
 
 func TestGetSandboxBySession_CreateSandbox_AgentRuntime_Success(t *testing.T) {
@@ -279,8 +452,14 @@ func TestGetSandboxBySession_CreateSandbox_AgentRuntime_Success(t *testing.T) {
 	if sandbox.SandboxID != "sandbox-456" {
 		t.Errorf("expected SandboxID sandbox-456, got %s", sandbox.SandboxID)
 	}
-	if sandbox.Name != "sandbox-test" {
-		t.Errorf("expected Name sandbox-test, got %s", sandbox.Name)
+	if sandbox.Name != "test-runtime" {
+		t.Errorf("expected Name test-runtime (the requested workload name), got %s", sandbox.Name)
+	}
+	if sandbox.SandboxNamespace != "default" {
+		t.Errorf("expected SandboxNamespace default, got %s", sandbox.SandboxNamespace)
+	}
+	if sandbox.Kind != types.AgentRuntimeKind {
+		t.Errorf("expected Kind %s, got %s", types.AgentRuntimeKind, sandbox.Kind)
 	}
 	if len(sandbox.EntryPoints) != 1 {
 		t.Fatalf("expected 1 entry point, got %d", len(sandbox.EntryPoints))

--- a/pkg/workloadmanager/k8s_client.go
+++ b/pkg/workloadmanager/k8s_client.go
@@ -74,10 +74,12 @@ type K8sClient struct {
 }
 
 type sandboxEntry struct {
-	Kind        string
-	SessionID   string
-	Ports       []runtimev1alpha1.TargetPort
-	IdleTimeout time.Duration
+	Kind         string
+	WorkloadKind string
+	WorkloadName string
+	SessionID    string
+	Ports        []runtimev1alpha1.TargetPort
+	IdleTimeout  time.Duration
 }
 
 // NewK8sClient creates a new Kubernetes client

--- a/pkg/workloadmanager/sandbox_helper.go
+++ b/pkg/workloadmanager/sandbox_helper.go
@@ -60,6 +60,8 @@ func buildSandboxPlaceHolder(sandboxCR *sandboxv1alpha1.Sandbox, entry *sandboxE
 	}
 	return &types.SandboxInfo{
 		Kind:             entry.Kind,
+		WorkloadKind:     entry.WorkloadKind,
+		WorkloadName:     entry.WorkloadName,
 		SessionID:        entry.SessionID,
 		SandboxNamespace: sandboxCR.GetNamespace(),
 		Name:             sandboxCR.GetName(),
@@ -89,6 +91,8 @@ func buildSandboxInfo(sandbox *sandboxv1alpha1.Sandbox, podIP string, entry *san
 	}
 	return &types.SandboxInfo{
 		Kind:             entry.Kind,
+		WorkloadKind:     entry.WorkloadKind,
+		WorkloadName:     entry.WorkloadName,
 		SandboxID:        string(sandbox.GetUID()),
 		Name:             sandbox.GetName(),
 		SandboxNamespace: sandbox.GetNamespace(),

--- a/pkg/workloadmanager/sandbox_helper_test.go
+++ b/pkg/workloadmanager/sandbox_helper_test.go
@@ -50,14 +50,18 @@ func TestBuildSandboxPlaceHolder_TableDriven(t *testing.T) {
 				}
 			},
 			entry: &sandboxEntry{
-				Kind:      types.SandboxKind,
-				SessionID: "session-123",
+				Kind:         types.SandboxKind,
+				WorkloadKind: types.AgentRuntimeKind,
+				WorkloadName: "test-runtime",
+				SessionID:    "session-123",
 			},
 			validate: func(t *testing.T, result *types.SandboxInfo) {
 				expected := now.Add(DefaultSandboxTTL)
 				assert.WithinDuration(t, expected, result.ExpiresAt, 2*time.Second)
 				assert.Equal(t, "creating", result.Status)
 				assert.Equal(t, "session-123", result.SessionID)
+				assert.Equal(t, types.AgentRuntimeKind, result.WorkloadKind)
+				assert.Equal(t, "test-runtime", result.WorkloadName)
 			},
 		},
 		{
@@ -77,8 +81,10 @@ func TestBuildSandboxPlaceHolder_TableDriven(t *testing.T) {
 				}
 			},
 			entry: &sandboxEntry{
-				Kind:      types.SandboxKind,
-				SessionID: "session-456",
+				Kind:         types.SandboxKind,
+				WorkloadKind: types.AgentRuntimeKind,
+				WorkloadName: "test-runtime",
+				SessionID:    "session-456",
 			},
 			validate: func(t *testing.T, result *types.SandboxInfo) {
 				expected := now.Add(24 * time.Hour)
@@ -102,8 +108,10 @@ func TestBuildSandboxPlaceHolder_TableDriven(t *testing.T) {
 				}
 			},
 			entry: &sandboxEntry{
-				Kind:      types.SandboxClaimsKind,
-				SessionID: "session-789",
+				Kind:         types.SandboxClaimsKind,
+				WorkloadKind: types.AgentRuntimeKind,
+				WorkloadName: "test-runtime",
+				SessionID:    "session-789",
 			},
 			validate: func(t *testing.T, result *types.SandboxInfo) {
 				expected := now.Add(30 * time.Minute)
@@ -135,8 +143,10 @@ func TestBuildSandboxPlaceHolder_TableDriven(t *testing.T) {
 				}
 			},
 			entry: &sandboxEntry{
-				Kind:      types.SandboxClaimsKind,
-				SessionID: "session-wp-001",
+				Kind:         types.SandboxClaimsKind,
+				WorkloadKind: types.CodeInterpreterKind,
+				WorkloadName: "ci-template",
+				SessionID:    "session-wp-001",
 			},
 			validate: func(t *testing.T, result *types.SandboxInfo) {
 				expected := now.Add(24 * time.Hour)
@@ -144,6 +154,8 @@ func TestBuildSandboxPlaceHolder_TableDriven(t *testing.T) {
 					"warm-pool placeholder ExpiresAt must reflect MaxSessionDuration, not the 8h default")
 				assert.Equal(t, "creating", result.Status)
 				assert.Equal(t, types.SandboxClaimsKind, result.Kind)
+				assert.Equal(t, types.CodeInterpreterKind, result.WorkloadKind)
+				assert.Equal(t, "ci-template", result.WorkloadName)
 			},
 		},
 	}
@@ -189,8 +201,10 @@ func TestBuildSandboxInfo_TableDriven(t *testing.T) {
 			},
 			podIP: sandboxHelperTestPodIP,
 			entry: &sandboxEntry{
-				Kind:      types.AgentRuntimeKind,
-				SessionID: "test-session-123",
+				Kind:         types.AgentRuntimeKind,
+				WorkloadKind: types.AgentRuntimeKind,
+				WorkloadName: "test-runtime",
+				SessionID:    "test-session-123",
 				Ports: []runtimev1alpha1.TargetPort{
 					{
 						Port:       8080,
@@ -211,6 +225,8 @@ func TestBuildSandboxInfo_TableDriven(t *testing.T) {
 				assert.Equal(t, sandboxHelperTestPodIP+":8080", result.EntryPoints[0].Endpoint)
 				assert.Equal(t, "/metrics", result.EntryPoints[1].Path)
 				assert.Equal(t, sandboxHelperTestPodIP+":9090", result.EntryPoints[1].Endpoint)
+				assert.Equal(t, types.AgentRuntimeKind, result.WorkloadKind)
+				assert.Equal(t, "test-runtime", result.WorkloadName)
 			},
 		},
 		{
@@ -346,7 +362,7 @@ func TestGetSandboxStatus_TableDriven(t *testing.T) {
 					},
 				},
 			},
-			expected:    "ready",
+			expected: "ready",
 		},
 		{
 			name: "ready condition false without reason",
@@ -360,7 +376,7 @@ func TestGetSandboxStatus_TableDriven(t *testing.T) {
 					},
 				},
 			},
-			expected:    "not-ready",
+			expected: "not-ready",
 		},
 		{
 			name: "ready condition false with reason is not-ready",
@@ -376,7 +392,7 @@ func TestGetSandboxStatus_TableDriven(t *testing.T) {
 					},
 				},
 			},
-			expected:    "not-ready",
+			expected: "not-ready",
 		},
 		{
 			name: "ready condition unknown",
@@ -390,7 +406,7 @@ func TestGetSandboxStatus_TableDriven(t *testing.T) {
 					},
 				},
 			},
-			expected:    "not-ready",
+			expected: "not-ready",
 		},
 		{
 			name: "no conditions",
@@ -399,7 +415,7 @@ func TestGetSandboxStatus_TableDriven(t *testing.T) {
 					Conditions: []metav1.Condition{},
 				},
 			},
-			expected:    "not-ready",
+			expected: "not-ready",
 		},
 		{
 			name: "nil conditions",
@@ -408,7 +424,7 @@ func TestGetSandboxStatus_TableDriven(t *testing.T) {
 					Conditions: nil,
 				},
 			},
-			expected:    "not-ready",
+			expected: "not-ready",
 		},
 		{
 			name: "other condition type",
@@ -422,7 +438,7 @@ func TestGetSandboxStatus_TableDriven(t *testing.T) {
 					},
 				},
 			},
-			expected:    "not-ready",
+			expected: "not-ready",
 		},
 		{
 			name: "multiple conditions with ready true",
@@ -440,7 +456,7 @@ func TestGetSandboxStatus_TableDriven(t *testing.T) {
 					},
 				},
 			},
-			expected:    "ready",
+			expected: "ready",
 		},
 	}
 

--- a/pkg/workloadmanager/workload_builder.go
+++ b/pkg/workloadmanager/workload_builder.go
@@ -129,6 +129,9 @@ func loadPublicKeyFromSecret(clientset kubernetes.Interface) error {
 	return nil
 }
 
+// buildSandboxParams holds all parameters needed to construct a Sandbox object.
+// workloadName carries the name of the AgentRuntime or CodeInterpreter template
+// that owns the sandbox, used to populate route-identity validation metadata.
 type buildSandboxParams struct {
 	namespace      string
 	workloadName   string
@@ -292,6 +295,8 @@ func buildSandboxByAgentRuntime(namespace string, name string, ifm *Informers) (
 	}
 	buildParams.idleTimeout = idleTimeout
 	sandbox := buildSandboxObject(buildParams)
+	// WorkloadKind and WorkloadName record the route-identity of the owning workload
+	// so the router can validate session reuse against the correct target.
 	entry := &sandboxEntry{
 		Kind:         types.SandboxKind,
 		WorkloadKind: types.AgentRuntimeKind,
@@ -351,6 +356,8 @@ func buildSandboxByCodeInterpreter(namespace string, codeInterpreterName string,
 		idleTimeout = codeInterpreterObj.Spec.SessionTimeout.Duration
 	}
 
+	// WorkloadKind and WorkloadName record the route-identity of the owning workload
+	// so the router can validate session reuse against the correct target.
 	sandboxEntry := &sandboxEntry{
 		Kind:         types.SandboxKind,
 		WorkloadKind: types.CodeInterpreterKind,

--- a/pkg/workloadmanager/workload_builder.go
+++ b/pkg/workloadmanager/workload_builder.go
@@ -184,7 +184,7 @@ func buildSandboxObject(params *buildSandboxParams) *sandboxv1alpha1.Sandbox {
 			Labels: map[string]string{
 				SessionIdLabelKey:    params.sessionID,
 				WorkloadNameLabelKey: params.workloadName,
-				"managed-by":        "agentcube-workload-manager",
+				"managed-by":         "agentcube-workload-manager",
 			},
 			Annotations: map[string]string{
 				IdleTimeoutAnnotationKey: params.idleTimeout.String(),
@@ -293,10 +293,12 @@ func buildSandboxByAgentRuntime(namespace string, name string, ifm *Informers) (
 	buildParams.idleTimeout = idleTimeout
 	sandbox := buildSandboxObject(buildParams)
 	entry := &sandboxEntry{
-		Kind:        types.SandboxKind,
-		Ports:       agentRuntimeObj.Spec.Ports,
-		SessionID:   sessionID,
-		IdleTimeout: idleTimeout,
+		Kind:         types.SandboxKind,
+		WorkloadKind: types.AgentRuntimeKind,
+		WorkloadName: name,
+		Ports:        agentRuntimeObj.Spec.Ports,
+		SessionID:    sessionID,
+		IdleTimeout:  idleTimeout,
 	}
 	return sandbox, entry, nil
 }
@@ -350,10 +352,12 @@ func buildSandboxByCodeInterpreter(namespace string, codeInterpreterName string,
 	}
 
 	sandboxEntry := &sandboxEntry{
-		Kind:        types.SandboxKind,
-		Ports:       codeInterpreterObj.Spec.Ports,
-		SessionID:   sessionID,
-		IdleTimeout: idleTimeout,
+		Kind:         types.SandboxKind,
+		WorkloadKind: types.CodeInterpreterKind,
+		WorkloadName: codeInterpreterName,
+		Ports:        codeInterpreterObj.Spec.Ports,
+		SessionID:    sessionID,
+		IdleTimeout:  idleTimeout,
 	}
 
 	// Set default port for code interpreter if not configured
@@ -426,6 +430,7 @@ func buildSandboxByCodeInterpreter(namespace string, codeInterpreterName string,
 		sandboxName:    sandboxName,
 		namespace:      namespace,
 		sessionID:      sessionID,
+		workloadName:   codeInterpreterName,
 		podSpec:        podSpec,
 		podLabels:      codeInterpreterObj.Spec.Template.Labels,
 		podAnnotations: codeInterpreterObj.Spec.Template.Annotations,


### PR DESCRIPTION
## Problem

When a client sends `x-agentcube-session-id`, the router retrieves the sandbox from the store and forwards the request **without checking** whether the session belongs to the namespace/name/kind in the URL. A valid session from Runtime A can be replayed against Route B, bypassing tenant and workload isolation.

## Solution

Added strict three-field validation `(namespace, name, kind)` between the route and the session metadata stored at creation time. Mismatched sessions are rejected before forwarding with a `409 Conflict` response and a `SESSION_TARGET_MISMATCH` error code.

## Changes

| Package | Change |
|---|---|
| `pkg/common/types` | Added `WorkloadKind`/`WorkloadName` to `SandboxInfo` to persist route-identity at session creation |
| `pkg/api/errors` | Added `NewSessionTargetMismatchError` (409) and `IsSessionTargetMismatch` predicate |
| `pkg/router/session_manager` | Rewrote `sessionTargetMatches`: fail-closed on empty metadata, strict 3-field comparison, `klog.Warning` on mismatch |
| `pkg/router/handlers` | Surfaces `SESSION_TARGET_MISMATCH` code in JSON response body |
| `pkg/workloadmanager` | Propagates `WorkloadKind`/`WorkloadName` through `sandboxEntry` → `buildSandboxPlaceHolder`/`buildSandboxInfo` |

## Testing

- Unit tests cover: mismatch on each field, fail-closed on empty metadata, happy-path sticky-session reuse, `SESSION_TARGET_MISMATCH` in JSON body, field propagation through workload manager builders.
- Pre-existing `gocyclo` lint violation fixed by extracting `agentRuntimeCreateHandler` helper.

```
ok  pkg/router          6.04s
ok  pkg/api             0.00s
ok  pkg/common/types    0.00s
ok  pkg/workloadmanager 0.18s
golangci-lint run ./...   # exits 0
```