### PR TITLE
fix(cli): include models package in wheel

### DIFF
--- a/.github/workflows/python-cli-publish.yml
+++ b/.github/workflows/python-cli-publish.yml
@@ -31,6 +31,13 @@ jobs:
       - name: Build package
         run: make build-python-cli
 
+      - name: Verify wheel install
+        run: |
+          python -m venv /tmp/agentcube-cli-smoke
+          /tmp/agentcube-cli-smoke/bin/python -m pip install --upgrade pip
+          /tmp/agentcube-cli-smoke/bin/python -m pip install cmd/cli/dist/*.whl
+          /tmp/agentcube-cli-smoke/bin/kubectl-agentcube --help
+
       - name: Read package version
         id: package
         working-directory: cmd/cli

--- a/.github/workflows/python-cli-tests.yml
+++ b/.github/workflows/python-cli-tests.yml
@@ -1,0 +1,53 @@
+name: Python CLI Tests
+
+on:
+  pull_request:
+  merge_group:
+
+jobs:
+  python-cli-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Filter paths
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            cli:
+              - "cmd/cli/**"
+              - "Makefile"
+              - ".github/workflows/python-cli-publish.yml"
+              - ".github/workflows/python-cli-tests.yml"
+
+      - name: Setup Python
+        if: steps.changes.outputs.cli == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        if: steps.changes.outputs.cli == 'true'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build pytest setuptools
+          python -m pip install -e ./cmd/cli
+
+      - name: Run unit tests
+        if: steps.changes.outputs.cli == 'true'
+        run: python -m pytest cmd/cli/tests -q
+
+      - name: Build CLI package
+        if: steps.changes.outputs.cli == 'true'
+        run: make build-python-cli
+
+      - name: Verify wheel install
+        if: steps.changes.outputs.cli == 'true'
+        run: |
+          python -m venv /tmp/agentcube-cli-smoke
+          /tmp/agentcube-cli-smoke/bin/python -m pip install --upgrade pip
+          /tmp/agentcube-cli-smoke/bin/python -m pip install cmd/cli/dist/*.whl
+          /tmp/agentcube-cli-smoke/bin/kubectl-agentcube --help

--- a/cmd/cli/agentcube/models/__init__.py
+++ b/cmd/cli/agentcube/models/__init__.py
@@ -1,0 +1,13 @@
+# Copyright The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/cmd/cli/pyproject.toml
+++ b/cmd/cli/pyproject.toml
@@ -61,5 +61,7 @@ Issues = "https://github.com/volcano-sh/agentcube/issues"
 [project.scripts]
 kubectl-agentcube = "agentcube.cli.main:app"
 
-[tool.setuptools]
-packages = ["agentcube", "agentcube.cli", "agentcube.runtime", "agentcube.operations", "agentcube.services"]
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["agentcube*"]
+namespaces = false

--- a/cmd/cli/pyproject.toml
+++ b/cmd/cli/pyproject.toml
@@ -43,12 +43,14 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.5.0",
     "pre-commit>=3.3.0",
+    "setuptools>=61.0",
 ]
 test = [
     "pytest>=7.4.0",
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.1.0",
     "pytest-mock>=3.11.0",
+    "setuptools>=61.0",
     "httpx-mock>=0.10.0",
 ]
 

--- a/cmd/cli/tests/test_packaging.py
+++ b/cmd/cli/tests/test_packaging.py
@@ -1,0 +1,33 @@
+# Copyright The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+from setuptools import find_packages
+
+
+def test_packages_are_correctly_discovered():
+    package_root = Path(__file__).resolve().parents[1]
+    packages = set(find_packages(where=package_root, include=["agentcube*"]))
+
+    expected_packages = {
+        "agentcube",
+        "agentcube.cli",
+        "agentcube.runtime",
+        "agentcube.operations",
+        "agentcube.services",
+        "agentcube.models",
+    }
+
+    assert expected_packages.issubset(packages)


### PR DESCRIPTION

# Description

**What type of PR is this?**

/kind bug

## What I fixed

I fixed the Python CLI wheel packaging so `agentcube.models` is included after a normal wheel install. The CLI entry point can now import `agentcube.models.pack_models` instead of crashing with `ModuleNotFoundError`.

## How I found it

I started from the reported importers in `cmd/cli/agentcube/cli/main.py`, `cmd/cli/agentcube/runtime/pack_runtime.py`, and `cmd/cli/agentcube/runtime/__init__.py`. The source tree had `agentcube/models/pack_models.py`, but there was no `agentcube/models/__init__.py`, and `cmd/cli/pyproject.toml` listed packages manually without `agentcube.models`.

## What I changed

- I added `cmd/cli/agentcube/models/__init__.py`.
- I switched the CLI pyproject to `setuptools.packages.find`, matching the Python SDK style.
- I added a focused packaging discovery test for `agentcube.models`.
- I added PR and publish workflow smoke tests that install the built CLI wheel and run `kubectl-agentcube --help`.

## Why this is legit

This keeps the package layout aligned with the existing `agentcube*` Python package structure instead of maintaining a fragile hand-written package list. The added CI checks the actual installed-wheel path that broke for users, so source-tree imports will not hide this class of issue again.

## Tests

- <img width="862" height="44" alt="Screenshot 2026-05-12 at 3 38 10 PM" src="https://github.com/user-attachments/assets/0a7a2fe3-2f92-4c0c-89a3-b6b460976b12" />

- <img width="861" height="26" alt="Screenshot 2026-05-12 at 3 38 31 PM" src="https://github.com/user-attachments/assets/0d257f05-2e18-42c6-85b2-31c72ff9fd52" />

- <img width="1022" height="785" alt="Screenshot 2026-05-12 at 3 39 06 PM" src="https://github.com/user-attachments/assets/e8063cc1-2282-4f37-9041-37a287fb982f" />

-  <img width="1021" height="423" alt="Screenshot 2026-05-12 at 3 39 30 PM" src="https://github.com/user-attachments/assets/eaa44780-11d6-4e36-91b8-851472e6809a" />

- `.venv/bin/python -m ruff check . --config pyproject.toml` - Passed.
- `git diff --check` - Passed.


## Notes

I did not run Go or Kubernetes codegen because this change only touches the Python CLI packaging and CI workflow. 


