### PR TITLE
Limit picod request body size for prevent DoS attack

### DIFF
--- a/pkg/picod/auth.go
+++ b/pkg/picod/auth.go
@@ -33,9 +33,6 @@ import (
 )
 
 const (
-	// MaxBodySize limits request body size to prevent memory exhaustion
-	MaxBodySize = 32 << 20 // 32 MB
-
 	// PublicKeyEnvVar is the environment variable name for the public key
 	PublicKeyEnvVar = "PICOD_AUTH_PUBLIC_KEY"
 )
@@ -130,9 +127,6 @@ func (am *AuthManager) AuthMiddleware() gin.HandlerFunc {
 			c.Abort()
 			return
 		}
-
-		// Enforce maximum body size to prevent memory exhaustion
-		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, MaxBodySize)
 
 		c.Next()
 	}

--- a/pkg/picod/auth_test.go
+++ b/pkg/picod/auth_test.go
@@ -302,31 +302,4 @@ func TestAuthMiddleware_TokenValidation(t *testing.T) {
 	}
 }
 
-func TestAuthMiddleware_MaxBodySize(t *testing.T) {
-	privateKey, pubKeyPEM, err := generateTestRSAKeyPair()
-	require.NoError(t, err)
 
-	os.Setenv(PublicKeyEnvVar, pubKeyPEM)
-	defer os.Unsetenv(PublicKeyEnvVar)
-
-	manager := NewAuthManager()
-	err = manager.LoadPublicKeyFromEnv()
-	require.NoError(t, err)
-
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
-		"exp": time.Now().Add(time.Hour).Unix(),
-		"iat": time.Now().Unix(),
-	})
-	tokenString, err := token.SignedString(privateKey)
-	require.NoError(t, err)
-
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request, _ = http.NewRequest("POST", "/api/execute", nil)
-	c.Request.Header.Set("Authorization", "Bearer "+tokenString)
-
-	handler := manager.AuthMiddleware()
-	handler(c)
-
-	assert.NotNil(t, c.Request.Body)
-}

--- a/pkg/picod/server.go
+++ b/pkg/picod/server.go
@@ -26,6 +26,11 @@ import (
 	"k8s.io/klog/v2"
 )
 
+const (
+	// MaxBodySize limits request body size to prevent memory exhaustion
+	MaxBodySize = 32 << 20 // 32 MB
+)
+
 // Config defines server configuration
 type Config struct {
 	Port      int    `json:"port"`
@@ -72,6 +77,23 @@ func NewServer(config Config) *Server {
 	// Global middleware
 	engine.Use(gin.Logger())   // Request logging
 	engine.Use(gin.Recovery()) // Crash recovery
+	// Limit request body size to prevent DoS attacks.
+	// First reject requests whose Content-Length already exceeds the limit,
+	// then wrap the body with MaxBytesReader as a safety net for chunked
+	// transfers or requests without Content-Length.
+	engine.Use(func(c *gin.Context) {
+		if c.Request.ContentLength > MaxBodySize {
+			c.JSON(http.StatusRequestEntityTooLarge, gin.H{
+				"error":  "request body too large",
+				"detail": fmt.Sprintf("maximum allowed size is %d bytes", MaxBodySize),
+			})
+			c.Abort()
+			return
+		}
+		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, MaxBodySize)
+		c.Next()
+	})
+	engine.MaxMultipartMemory = MaxBodySize
 
 	// Load public key from environment variable (required)
 	if err := s.authManager.LoadPublicKeyFromEnv(); err != nil {

--- a/pkg/picod/server_test.go
+++ b/pkg/picod/server_test.go
@@ -23,10 +23,12 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -367,4 +369,36 @@ func TestNewServer_DifferentPorts(t *testing.T) {
 			assert.Equal(t, port, server.config.Port)
 		})
 	}
+}
+
+func TestServer_MaxBodySizeMiddleware(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "picod-server-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	pubKeyPEM := generateTestPublicKeyPEM(t)
+	os.Setenv(PublicKeyEnvVar, pubKeyPEM)
+	defer os.Unsetenv(PublicKeyEnvVar)
+
+	server := NewServer(Config{
+		Port:      8080,
+		Workspace: tmpDir,
+	})
+
+	ts := httptest.NewServer(server.engine)
+	defer ts.Close()
+
+	// When Content-Length exceeds MaxBodySize, the global body-size limiter
+	// middleware should reject the request with 413 before any other
+	// middleware (auth, handler) gets a chance to run.
+	oversizedBody := strings.NewReader(strings.Repeat("x", int(MaxBodySize)+1))
+	resp, err := http.Post(ts.URL+"/api/execute", "application/json", oversizedBody)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "request body too large")
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind security

**What this PR does / why we need it**:

This pull request refactors how the maximum request body size is enforced in the application. The body size limit logic has been moved from the authentication middleware to a new global middleware, ensuring that all incoming requests are protected from large payloads, not just those passing through authentication.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This PR is split from #250 to address the comments of https://github.com/volcano-sh/agentcube/pull/250#discussion_r3042507194.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`picod`: All incoming requests are now protected from large payloads. 
```
