### PR TITLE
fix(cli): add publish endpoint option

### DIFF
--- a/cmd/cli/agentcube/cli/main.py
+++ b/cmd/cli/agentcube/cli/main.py
@@ -303,6 +303,11 @@ def publish(
         "--replicas",
         help="Number of replicas for K8s deployment (default: 1)",
     ),
+    endpoint: Optional[str] = typer.Option(
+        None,
+        "--endpoint",
+        help="Custom API endpoint for AgentCube or Kubernetes cluster",
+    ),
     namespace: Optional[str] = typer.Option(
         None,
         "--namespace",
@@ -339,9 +344,10 @@ def publish(
                 "description": description,
                 "region": region,
                 "cloud_provider": cloud_provider,
-                "provider": provider, # Pass provider down
+                "provider": provider,
                 "node_port": node_port,
                 "replicas": replicas,
+                "agent_endpoint": endpoint,
                 "namespace": namespace,
             }
 

--- a/cmd/cli/agentcube/runtime/publish_runtime.py
+++ b/cmd/cli/agentcube/runtime/publish_runtime.py
@@ -171,19 +171,19 @@ class PublishRuntime:
         except Exception as e:
             raise RuntimeError(f"Failed to deploy AgentRuntime CR to K8s: {str(e)}")
 
+        endpoint = options.get('agent_endpoint') or metadata.agent_endpoint
+        if not endpoint:
+            raise ValueError("Please enter the endpoint for the agent")
+
         # Step 4: Update metadata with K8s deployment information
         updates = {
             "agent_id": k8s_info["deployment_name"],
+            "agent_endpoint": endpoint,
             "k8s_deployment": {
                 **k8s_info,
                 "type": "AgentRuntime",
             }
         }
-
-        # Use provided endpoint or fall back to router_url from metadata
-        endpoint = options.get('agent_endpoint') or metadata.agent_endpoint
-        if not endpoint:
-            raise ValueError("Please enter the endpoint for the agent")
 
         self.metadata_service.update_metadata(workspace_path, updates)
 

--- a/cmd/cli/tests/test_cli_publish.py
+++ b/cmd/cli/tests/test_cli_publish.py
@@ -1,0 +1,55 @@
+# Copyright The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typer.testing import CliRunner
+
+from agentcube.cli.main import app
+
+
+def test_publish_endpoint_option_is_forwarded(monkeypatch, tmp_path):
+    call = {}
+
+    class StubPublishRuntime:
+        def __init__(self, verbose=False, provider="agentcube"):
+            call["verbose"] = verbose
+            call["provider"] = provider
+
+        def publish(self, workspace_path, **options):
+            call["workspace_path"] = workspace_path
+            call["options"] = options
+            return {
+                "agent_name": "test-agent",
+                "agent_id": "test-agent",
+                "agent_endpoint": options["agent_endpoint"],
+                "namespace": options.get("namespace", "default"),
+                "status": "deployed",
+            }
+
+    monkeypatch.setattr("agentcube.cli.main.PublishRuntime", StubPublishRuntime)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "publish",
+            "-f",
+            str(tmp_path),
+            "--endpoint",
+            "http://router.example.com",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert call["provider"] == "agentcube"
+    assert call["workspace_path"] == tmp_path.resolve()
+    assert call["options"]["agent_endpoint"] == "http://router.example.com"

--- a/cmd/cli/tests/test_env_support.py
+++ b/cmd/cli/tests/test_env_support.py
@@ -123,10 +123,10 @@ class TestMetadataServiceEnvRoundTrip:
 # PublishRuntime env forwarding tests
 # ---------------------------------------------------------------------------
 
-class TestPublishRuntimeEnvForwarding:
-    """Test that env from metadata is forwarded to providers."""
+class TestPublishRuntimePublishOptions:
+    """Test publish options passed to providers and metadata."""
 
-    def _make_metadata(self, env=None):
+    def _make_metadata(self, env=None, agent_endpoint="http://localhost:8080"):
         return AgentMetadata(
             agent_name="test-agent",
             entrypoint="python main.py",
@@ -138,7 +138,7 @@ class TestPublishRuntimeEnvForwarding:
             router_url="http://router:8080",
             readiness_probe_path="/health",
             readiness_probe_port=8080,
-            agent_endpoint="http://localhost:8080",
+            agent_endpoint=agent_endpoint,
             image={"repository_url": "registry.example.com/test:latest"},
             env=env,
         )
@@ -259,3 +259,44 @@ class TestPublishRuntimeEnvForwarding:
         call_kwargs = mock_provider.deploy_agent_runtime.call_args
         passed_env = call_kwargs.kwargs.get("env_vars") or call_kwargs[1].get("env_vars")
         assert passed_env is None
+
+    @patch("agentcube.runtime.publish_runtime.AgentCubeProvider")
+    @patch("agentcube.runtime.publish_runtime.DockerService")
+    @patch("agentcube.runtime.publish_runtime.MetadataService")
+    def test_agentcube_publish_saves_endpoint(
+        self, MockMetaSvc, MockDockerSvc, MockACProvider
+    ):
+        from agentcube.runtime.publish_runtime import PublishRuntime
+
+        endpoint = "http://router.example.com"
+        meta = self._make_metadata(agent_endpoint=None)
+
+        mock_meta_svc = MockMetaSvc.return_value
+        mock_meta_svc.load_metadata.return_value = meta
+
+        mock_docker = MockDockerSvc.return_value
+        mock_docker.push_image.return_value = {"pushed_image": "registry.example.com/test:latest"}
+
+        mock_provider = MagicMock()
+        mock_provider.deploy_agent_runtime.return_value = {
+            "deployment_name": "test-agent",
+            "namespace": "default",
+            "status": "deployed",
+            "type": "AgentRuntime",
+        }
+        MockACProvider.return_value = mock_provider
+
+        runtime = PublishRuntime(verbose=False, provider="agentcube")
+        runtime.metadata_service = mock_meta_svc
+        runtime.docker_service = mock_docker
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = runtime.publish(
+                Path(tmpdir),
+                provider="agentcube",
+                agent_endpoint=endpoint,
+            )
+
+        updates = mock_meta_svc.update_metadata.call_args.args[1]
+        assert updates["agent_endpoint"] == endpoint
+        assert result["agent_endpoint"] == endpoint


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This makes the documented `kubectl agentcube publish --endpoint` option work. The CLI passes it to `PublishRuntime` as `agent_endpoint`, and the AgentCube publish path saves it in metadata so later commands like `invoke` can read it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

I found this while working on PR #325. This adds a CLI test for the option pass-through and a runtime test to check that the endpoint is saved in metadata.

## What I fixed

I fixed the Python CLI publish command so `kubectl agentcube publish --endpoint` works as documented. The endpoint is now passed to the runtime and saved in metadata.

## How I found it

I found this while working on PR #325. I checked the README section for `publish`, then looked at `cmd/cli/agentcube/cli/main.py` and `cmd/cli/agentcube/runtime/publish_runtime.py`. The runtime already checked `options.get('agent_endpoint')`, but the CLI did not expose the option. A review also pointed out that the AgentCube publish path returned the endpoint but did not save it in metadata.

## What I changed

- Added `--endpoint` to the `publish` command options.
- Passed it to `PublishRuntime.publish` as `agent_endpoint`.
- Saved `agent_endpoint` in metadata in the AgentCube publish path.
- Added a CLI test for `publish --endpoint`.
- Added a runtime test for saving the endpoint in metadata.

## Why this is legit

This matches the README and keeps `publish` and `invoke` behavior consistent. It is a small Python CLI/runtime change and does not touch Kubernetes resources, Go code, generated files, or chart templates.

## Tests

- <img width="1012" height="76" alt="Screenshot 2026-05-12 at 6 09 01 PM" src="https://github.com/user-attachments/assets/3b025d80-eafd-4ef5-a70b-bdcd3e906523" />

- <img width="1030" height="63" alt="Screenshot 2026-05-12 at 6 09 24 PM" src="https://github.com/user-attachments/assets/2208a812-94c1-4f47-9b2f-0ba9648f5b6a" />

- <img width="1030" height="60" alt="Screenshot 2026-05-12 at 6 09 51 PM" src="https://github.com/user-attachments/assets/26da35de-2332-40b3-936a-7fb8e64ee62d" />

- <img width="1026" height="747" alt="Screenshot 2026-05-12 at 6 10 23 PM" src="https://github.com/user-attachments/assets/665e4519-42c9-4d3d-ac30-c2ecac7e724c" />



