### PR TITLE
fix(examples): sync AgentRuntime SDK example name

### DIFF
--- a/sdk-python/examples/agent_runtime_usage.py
+++ b/sdk-python/examples/agent_runtime_usage.py
@@ -14,9 +14,11 @@
 
 from agentcube import AgentRuntimeClient
 
+AGENT_NAME = "simple-agentruntime"
+
 # first time: it will create a new pod
 agent_client_v1 = AgentRuntimeClient(
-    agent_name="my-agent",
+    agent_name=AGENT_NAME,
     router_url="http://localhost:8081",
     namespace="default",
     verbose=True,
@@ -30,7 +32,7 @@ print(result_v1)
 
 # second time: it will try to reuse the pod created before
 agent_client_v2 = AgentRuntimeClient(
-    agent_name="my-agent",
+    agent_name=AGENT_NAME,
     router_url="http://localhost:8081",
     namespace="default",
     session_id=agent_client_v1.session_id,
@@ -43,5 +45,4 @@ result_v2 = agent_client_v2.invoke(
     payload={"prompt": "Hello World!"},
 )
 print(result_v2)
-
 


### PR DESCRIPTION


**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This makes the Python SDK AgentRuntime example use the same name as the sample YAML.

Before this change, the YAML created `simple-agentruntime`, but the Python example used `my-agent`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This is only an example-name fix.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```



## What I fixed

I fixed a small mismatch in the AgentRuntime examples.

The YAML example creates an AgentRuntime named `simple-agentruntime`, but the Python SDK example was still using `my-agent`. Now the Python example uses `simple-agentruntime` too.

## How I found it

I checked the two files from the report. The names did not match, and nearby examples did not show a larger change was needed.

## What I changed

- Added `AGENT_NAME = "simple-agentruntime"` in `sdk-python/examples/agent_runtime_usage.py`.
- Used that value in both `AgentRuntimeClient` calls.

## Why this is legit

This is a real example bug. If someone applies the YAML and then runs the Python example, both should point to the same AgentRuntime.

I only changed the Python example because the YAML name already looked correct for this example.

## Validation

- `../.venv/bin/python -m pytest tests/test_agent_runtime.py -q` from `sdk-python/` - Passed, 7 tests.
- `../.venv/bin/python -m ruff check examples/agent_runtime_usage.py tests/test_agent_runtime.py --config ../pyproject.toml` from `sdk-python/` - Passed.
- `.venv/bin/python -m ruff check . --config pyproject.toml` from repo root - Passed.
- `git diff --check -- sdk-python/examples/agent_runtime_usage.py` - Passed.

