### PR TITLE
fix(makefile): remove stale clean target cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,9 +107,9 @@ run-router:
 		--debug
 
 # Clean build artifacts
-clean:
+clean: ## Clean build artifacts
 	@echo "Cleaning..."
-	rm -rf bin/
+	rm -rf bin/ sdk-python/dist/ cmd/cli/dist/
 
 # Install dependencies
 deps:

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,6 @@ run-router:
 clean:
 	@echo "Cleaning..."
 	rm -rf bin/
-	rm -f workloadmanager agentd agentcube-router
 
 # Install dependencies
 deps:


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This updates `make clean` so it removes the Go binary output and Python package build artifacts. It also adds the clean target to `make help`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

No generated files changed. I checked the target with `make -n clean`, `make clean`, and `make help`.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

## What I fixed

I fixed `make clean`.

The Makefile builds Go binaries inside `bin/`, and the Python SDK and CLI build targets write packages to `sdk-python/dist/` and `cmd/cli/dist/`. The old clean target removed only `bin/`.

## How I checked it

I checked the Makefile build targets and confirmed the Go and Python build output paths.

## What I changed

I removed the unused root-level `rm -f` line, added a help description for `clean`, and included the Python package `dist/` folders in cleanup.

## Why this is okay

This is a small cleanup fix. The target now matches the actual build outputs and appears in `make help`.

## Validation

- `make -n clean` - Passed.
- `make clean` - Passed.
- `make help` - Passed; `clean` is listed with its description.
- DCO check - Passed; both commits have `Signed-off-by` lines.

