### PR TITLE
fix(makefile): remove unsupported workload-manager run flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,18 +86,13 @@ build-all: build build-agentd build-router ## Build all binaries
 run:
 	@echo "Running workloadmanager..."
 	go run ./cmd/workload-manager/main.go \
-		--port=8080 \
-		--ssh-username=sandbox \
-		--ssh-port=22
+		--port=8080
 
 # Run server (with kubeconfig)
 run-local:
 	@echo "Running workloadmanager with local kubeconfig..."
 	go run ./cmd/workload-manager/main.go \
-		--port=8080 \
-		--kubeconfig=${HOME}/.kube/config \
-		--ssh-username=sandbox \
-		--ssh-port=22
+		--port=8080
 
 # Run router (development mode)
 run-router:


### PR DESCRIPTION



**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This fixes the workload-manager Makefile run targets. They no longer pass unsupported flags, so local development commands do not fail during flag parsing.

**Which issue(s) this PR fixes**:

Fixes #


**Does this PR introduce a user-facing change?**:

```release-note
NONE
```


## What I fixed

I fixed the workload-manager run commands in the Makefile.

Earlier, `make run` and `make run-local` passed flags that the workload-manager binary does not have. Because of that, the command could fail during `flag.Parse()` before the server started.

## How I found it

I checked the flags passed from the Makefile and compared them with the flags defined in `cmd/workload-manager/main.go`.

The binary has these flags:

- `port`
- `runtime-class-name`
- `enable-tls`
- `tls-cert`
- `tls-key`
- `enable-auth`

It does not have `ssh-username`, `ssh-port`, or `kubeconfig`.

## What I changed

- Removed `--ssh-username=sandbox` from `make run`.
- Removed `--ssh-port=22` from `make run`.
- Removed the unsupported SSH flags from `make run-local`.
- Removed `--kubeconfig` from `make run-local`.

## Why this is correct

This fixes the issue at the place where the bad flags were added. I did not add new flags to the Go binary because these Makefile flags were not connected to any workload-manager behavior.

For local kubeconfig use, client-go already checks the normal kubeconfig locations and respects any `KUBECONFIG` value the user has set. So `make run-local` does not need to force a path.



## Tests

- `make -n run` - Passed. The command now only passes `--port=8080`.
- `make -n run-local` - Passed. The command now only passes `--port=8080`.
- `git diff --check` - Passed.
- DCO - Passed. 



