### PR TITLE
fix(workloadmanager): deduplicate GC candidates before deletion

### DIFF
--- a/pkg/workloadmanager/garbage_collection.go
+++ b/pkg/workloadmanager/garbage_collection.go
@@ -109,9 +109,21 @@ func (gc *garbageCollector) once() {
 	if err != nil {
 		klog.Errorf("garbage collector error listing expired sandboxes: %v", err)
 	}
+	// Remove duplicates based on SessionID
+	seen := make(map[string]struct{}, len(inactiveSandboxes)+len(expiredSandboxes))
 	gcSandboxes := make([]*types.SandboxInfo, 0, len(inactiveSandboxes)+len(expiredSandboxes))
-	gcSandboxes = append(gcSandboxes, inactiveSandboxes...)
-	gcSandboxes = append(gcSandboxes, expiredSandboxes...)
+	for _, s := range inactiveSandboxes {
+		if _, ok := seen[s.SessionID]; !ok {
+			seen[s.SessionID] = struct{}{}
+			gcSandboxes = append(gcSandboxes, s)
+		}
+	}
+	for _, s := range expiredSandboxes {
+		if _, ok := seen[s.SessionID]; !ok {
+			seen[s.SessionID] = struct{}{}
+			gcSandboxes = append(gcSandboxes, s)
+		}
+	}
 
 	if len(gcSandboxes) > 0 {
 		klog.Infof("garbage collector found %d sandboxes to be deleted", len(gcSandboxes))

--- a/pkg/workloadmanager/garbage_collection.go
+++ b/pkg/workloadmanager/garbage_collection.go
@@ -109,21 +109,9 @@ func (gc *garbageCollector) once() {
 	if err != nil {
 		klog.Errorf("garbage collector error listing expired sandboxes: %v", err)
 	}
-	// Remove duplicates based on SessionID
-	seen := make(map[string]struct{}, len(inactiveSandboxes)+len(expiredSandboxes))
-	gcSandboxes := make([]*types.SandboxInfo, 0, len(inactiveSandboxes)+len(expiredSandboxes))
-	for _, s := range inactiveSandboxes {
-		if _, ok := seen[s.SessionID]; !ok {
-			seen[s.SessionID] = struct{}{}
-			gcSandboxes = append(gcSandboxes, s)
-		}
-	}
-	for _, s := range expiredSandboxes {
-		if _, ok := seen[s.SessionID]; !ok {
-			seen[s.SessionID] = struct{}{}
-			gcSandboxes = append(gcSandboxes, s)
-		}
-	}
+	// Merge and deduplicate: a sandbox may appear in both lists when it is
+	// simultaneously idle-timed-out and past its TTL.
+	gcSandboxes := deduplicateSandboxes(inactiveSandboxes, expiredSandboxes)
 
 	if len(gcSandboxes) > 0 {
 		klog.Infof("garbage collector found %d sandboxes to be deleted", len(gcSandboxes))
@@ -173,4 +161,24 @@ func (gc *garbageCollector) deleteSandboxClaim(ctx context.Context, namespace, n
 		return fmt.Errorf("error deleting sandboxClaim %s/%s: %w", namespace, name, err)
 	}
 	return nil
+}
+
+// deduplicateSandboxes merges multiple sandbox lists and removes duplicates
+// by SessionID, preserving the order of first occurrence.
+func deduplicateSandboxes(lists ...[]*types.SandboxInfo) []*types.SandboxInfo {
+	total := 0
+	for _, l := range lists {
+		total += len(l)
+	}
+	seen := make(map[string]struct{}, total)
+	result := make([]*types.SandboxInfo, 0, total)
+	for _, list := range lists {
+		for _, s := range list {
+			if _, ok := seen[s.SessionID]; !ok {
+				seen[s.SessionID] = struct{}{}
+				result = append(result, s)
+			}
+		}
+	}
+	return result
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The garbage collector's `once()` method merges two candidate lists - inactive sandboxes (idle timeout elapsed) and expired sandboxes (past TTL) - before iterating over them for deletion. A sandbox that qualifies for both conditions appears in both lists, causing the GC to attempt deleting it twice in the same cycle. The second attempt fails on `DeleteSandboxBySessionID` (store entry already removed) and logs a spurious error.

This PR deduplicates the merged candidate slice by `SessionID` before the deletion loop, ensuring each sandbox is processed exactly once.

**Special notes for your reviewer**:

The deduplication uses a `map[string]struct{}` keyed by `SessionID`. Inactive sandboxes are inserted first, then expired ones, preserving the original iteration order while skipping duplicates.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
