### PR TITLE
Harden PicoD server: graceful shutdown, symlink guard, doc fix

### DIFF
--- a/cmd/picod/main.go
+++ b/cmd/picod/main.go
@@ -17,7 +17,10 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
+	"os/signal"
+	"syscall"
 
 	"k8s.io/klog/v2"
 
@@ -37,10 +40,14 @@ func main() {
 		Workspace: *workspace,
 	}
 
+	// Create a context that is canceled on SIGINT or SIGTERM.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
 	// Create and start server
 	server := picod.NewServer(config)
 
-	if err := server.Run(); err != nil {
+	if err := server.Run(ctx); err != nil {
 		klog.Fatalf("Failed to start server: %v", err)
 	}
 }

--- a/cmd/picod/main.go
+++ b/cmd/picod/main.go
@@ -52,8 +52,8 @@ func main() {
 	// Create and start server
 	server := picod.NewServer(config)
 
-	if err := server.Run(ctx); err != nil {
-		klog.Fatalf("Failed to start server: %v", err)
+	if err := server.Start(ctx); err != nil {
+		klog.Fatalf("PicoD server exited with error: %v", err)
 	}
 
 	klog.Info("PicoD server stopped")

--- a/cmd/picod/main.go
+++ b/cmd/picod/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"flag"
-	"os"
 	"os/signal"
 	"syscall"
 
@@ -41,31 +40,15 @@ func main() {
 		Workspace: *workspace,
 	}
 
-	// Create server
+	// Create a context that is canceled on SIGINT or SIGTERM.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	// Create and start server
 	server := picod.NewServer(config)
 
-	// Setup signal handling with context cancellation
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer cancel()
-
-	// Start PicoD server in goroutine
-	errCh := make(chan error, 1)
-	go func() {
-		klog.Infof("Starting PicoD server on port %d", *port)
-		if err := server.Start(ctx); err != nil {
-			errCh <- err
-		}
-		close(errCh)
-	}()
-
-	// Wait for signal or fatal error
-	select {
-	case <-ctx.Done():
-		klog.Info("Received shutdown signal, shutting down gracefully...")
-		cancel()
-		<-errCh
-	case err := <-errCh:
-		klog.Fatalf("Server error: %v", err)
+	if err := server.Run(ctx); err != nil {
+		klog.Fatalf("Failed to start server: %v", err)
 	}
 
 	klog.Info("PicoD server stopped")

--- a/cmd/picod/main.go
+++ b/cmd/picod/main.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"k8s.io/klog/v2"
 
@@ -30,14 +31,16 @@ import (
 func main() {
 	port := flag.Int("port", 8080, "Port for the PicoD server to listen on")
 	workspace := flag.String("workspace", "", "Root directory for file operations (default: current working directory)")
+	shutdownTimeout := flag.Duration("shutdown-timeout", 90*time.Second, "Grace period for graceful shutdown")
 
 	// Initialize klog flags
 	klog.InitFlags(nil)
 	flag.Parse()
 
 	config := picod.Config{
-		Port:      *port,
-		Workspace: *workspace,
+		Port:            *port,
+		Workspace:       *workspace,
+		ShutdownTimeout: *shutdownTimeout,
 	}
 
 	// Create a context that is canceled on SIGINT or SIGTERM.

--- a/cmd/picod/main.go
+++ b/cmd/picod/main.go
@@ -32,15 +32,17 @@ func main() {
 	port := flag.Int("port", 8080, "Port for the PicoD server to listen on")
 	workspace := flag.String("workspace", "", "Root directory for file operations (default: current working directory)")
 	shutdownTimeout := flag.Duration("shutdown-timeout", 90*time.Second, "Grace period for graceful shutdown")
+	maxExecutionTimeout := flag.Duration("max-execution-timeout", 60*time.Second, "Maximum allowed per-command execution timeout")
 
 	// Initialize klog flags
 	klog.InitFlags(nil)
 	flag.Parse()
 
 	config := picod.Config{
-		Port:            *port,
-		Workspace:       *workspace,
-		ShutdownTimeout: *shutdownTimeout,
+		Port:                *port,
+		Workspace:           *workspace,
+		ShutdownTimeout:     *shutdownTimeout,
+		MaxExecutionTimeout: *maxExecutionTimeout,
 	}
 
 	// Create a context that is canceled on SIGINT or SIGTERM.

--- a/pkg/picod/execute.go
+++ b/pkg/picod/execute.go
@@ -36,7 +36,7 @@ const (
 // ExecuteRequest defines command execution request body
 type ExecuteRequest struct {
 	Command    []string          `json:"command" binding:"required"` // The command and its arguments to execute. The first element is the executable.
-	Timeout    string            `json:"timeout"`                    // Optional: Timeout for the command execution (e.g., "30s", "500ms"). Defaults to "30s".
+	Timeout    string            `json:"timeout"`                    // Optional: Timeout for the command execution (e.g., "30s", "500ms"). Defaults to "60s".
 	WorkingDir string            `json:"working_dir"`                // Optional: The working directory for the command.
 	Env        map[string]string `json:"env"`                        // Optional: Environment variables to set for the command.
 }

--- a/pkg/picod/execute.go
+++ b/pkg/picod/execute.go
@@ -36,7 +36,7 @@ const (
 // ExecuteRequest defines command execution request body
 type ExecuteRequest struct {
 	Command    []string          `json:"command" binding:"required"` // The command and its arguments to execute. The first element is the executable.
-	Timeout    string            `json:"timeout"`                    // Optional: Timeout for the command execution (e.g., "30s", "500ms"). Defaults to 60s; capped to MaxExecutionTimeout.
+	Timeout    string            `json:"timeout"`                    // Optional: Timeout for the command execution (e.g., "30s", "500ms"). Defaults to MaxExecutionTimeout when omitted; any value exceeding MaxExecutionTimeout is rejected.
 	WorkingDir string            `json:"working_dir"`                // Optional: The working directory for the command.
 	Env        map[string]string `json:"env"`                        // Optional: Environment variables to set for the command.
 }

--- a/pkg/picod/execute.go
+++ b/pkg/picod/execute.go
@@ -36,7 +36,7 @@ const (
 // ExecuteRequest defines command execution request body
 type ExecuteRequest struct {
 	Command    []string          `json:"command" binding:"required"` // The command and its arguments to execute. The first element is the executable.
-	Timeout    string            `json:"timeout"`                    // Optional: Timeout for the command execution (e.g., "30s", "500ms"). Defaults to "60s".
+	Timeout    string            `json:"timeout"`                    // Optional: Timeout for the command execution (e.g., "30s", "500ms"). Defaults to 60s; capped to MaxExecutionTimeout.
 	WorkingDir string            `json:"working_dir"`                // Optional: The working directory for the command.
 	Env        map[string]string `json:"env"`                        // Optional: Environment variables to set for the command.
 }
@@ -157,10 +157,11 @@ func (s *Server) ExecuteHandler(c *gin.Context) {
 }
 
 // parseAndCapTimeout parses the timeout string and rejects it if it exceeds
-// the server's shutdown grace period, ensuring no command can outlive the server.
-// s.config.ShutdownTimeout is guaranteed to be > 0 by NewServer.
+// the server's per-command maximum (MaxExecutionTimeout), ensuring no command
+// can outlive the server during graceful shutdown.
+// s.config.MaxExecutionTimeout is guaranteed to be > 0 by NewServer.
 func (s *Server) parseAndCapTimeout(timeoutStr string) (time.Duration, error) {
-	timeoutDuration := 60 * time.Second // Default timeout
+	timeoutDuration := s.config.MaxExecutionTimeout // Default: use the configured maximum
 	if timeoutStr != "" {
 		var err error
 		timeoutDuration, err = time.ParseDuration(timeoutStr)
@@ -169,10 +170,10 @@ func (s *Server) parseAndCapTimeout(timeoutStr string) (time.Duration, error) {
 		}
 	}
 
-	if timeoutDuration > s.config.ShutdownTimeout {
+	if timeoutDuration > s.config.MaxExecutionTimeout {
 		return 0, fmt.Errorf(
 			"requested timeout %v exceeds the maximum allowed execution timeout %v",
-			timeoutDuration, s.config.ShutdownTimeout,
+			timeoutDuration, s.config.MaxExecutionTimeout,
 		)
 	}
 	return timeoutDuration, nil

--- a/pkg/picod/execute.go
+++ b/pkg/picod/execute.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -71,17 +72,13 @@ func (s *Server) ExecuteHandler(c *gin.Context) {
 	}
 
 	// Set timeout
-	timeoutDuration := 60 * time.Second // Default timeout
-	if req.Timeout != "" {
-		var err error
-		timeoutDuration, err = time.ParseDuration(req.Timeout)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error": fmt.Sprintf("Invalid timeout format: %v", err),
-				"code":  http.StatusBadRequest,
-			})
-			return
-		}
+	timeoutDuration, err := s.parseAndCapTimeout(req.Timeout)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": fmt.Sprintf("Invalid timeout format: %v", err),
+			"code":  http.StatusBadRequest,
+		})
+		return
 	}
 
 	// Create context with timeout
@@ -129,7 +126,7 @@ func (s *Server) ExecuteHandler(c *gin.Context) {
 	cmd.Stderr = &stderr
 
 	start := time.Now()
-	err := cmd.Run()
+	err = cmd.Run()
 	duration := time.Since(start).Seconds()
 	endTime := time.Now()
 
@@ -158,4 +155,26 @@ func (s *Server) ExecuteHandler(c *gin.Context) {
 		StartTime: start,
 		EndTime:   endTime,
 	})
+}
+
+// parseAndCapTimeout parses the timeout string and caps it to the shutdown timeout
+func (s *Server) parseAndCapTimeout(timeoutStr string) (time.Duration, error) {
+	timeoutDuration := 60 * time.Second // Default timeout
+	if timeoutStr != "" {
+		var err error
+		timeoutDuration, err = time.ParseDuration(timeoutStr)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	shutdownTimeout := s.config.ShutdownTimeout
+	if shutdownTimeout <= 0 {
+		shutdownTimeout = 90 * time.Second
+	}
+	if timeoutDuration > shutdownTimeout {
+		klog.Infof("Requested timeout %v exceeds shutdown grace period; capping to %v", timeoutDuration, shutdownTimeout)
+		timeoutDuration = shutdownTimeout
+	}
+	return timeoutDuration, nil
 }

--- a/pkg/picod/execute.go
+++ b/pkg/picod/execute.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"k8s.io/klog/v2"
 )
 
 const (
@@ -75,7 +74,7 @@ func (s *Server) ExecuteHandler(c *gin.Context) {
 	timeoutDuration, err := s.parseAndCapTimeout(req.Timeout)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
-			"error": fmt.Sprintf("Invalid timeout format: %v", err),
+			"error": err.Error(),
 			"code":  http.StatusBadRequest,
 		})
 		return
@@ -157,24 +156,24 @@ func (s *Server) ExecuteHandler(c *gin.Context) {
 	})
 }
 
-// parseAndCapTimeout parses the timeout string and caps it to the shutdown timeout
+// parseAndCapTimeout parses the timeout string and rejects it if it exceeds
+// the server's shutdown grace period, ensuring no command can outlive the server.
+// s.config.ShutdownTimeout is guaranteed to be > 0 by NewServer.
 func (s *Server) parseAndCapTimeout(timeoutStr string) (time.Duration, error) {
 	timeoutDuration := 60 * time.Second // Default timeout
 	if timeoutStr != "" {
 		var err error
 		timeoutDuration, err = time.ParseDuration(timeoutStr)
 		if err != nil {
-			return 0, err
+			return 0, fmt.Errorf("invalid timeout format: %w", err)
 		}
 	}
 
-	shutdownTimeout := s.config.ShutdownTimeout
-	if shutdownTimeout <= 0 {
-		shutdownTimeout = 90 * time.Second
-	}
-	if timeoutDuration > shutdownTimeout {
-		klog.Infof("Requested timeout %v exceeds shutdown grace period; capping to %v", timeoutDuration, shutdownTimeout)
-		timeoutDuration = shutdownTimeout
+	if timeoutDuration > s.config.ShutdownTimeout {
+		return 0, fmt.Errorf(
+			"requested timeout %v exceeds the maximum allowed execution timeout %v",
+			timeoutDuration, s.config.ShutdownTimeout,
+		)
 	}
 	return timeoutDuration, nil
 }

--- a/pkg/picod/execute_test.go
+++ b/pkg/picod/execute_test.go
@@ -395,6 +395,40 @@ func TestExecuteHandler_TimeoutHandling(t *testing.T) {
 	assert.Contains(t, resp.Stderr, "Command timed out")
 }
 
+func TestExecuteHandler_TimeoutCapping(t *testing.T) {
+	server, tmpDir := setupExecuteTestServer(t)
+	defer os.RemoveAll(tmpDir)
+	defer os.Unsetenv(PublicKeyEnvVar)
+
+	// Set server shutdown timeout very low
+	server.config.ShutdownTimeout = 200 * time.Millisecond
+
+	// Command would take 2 seconds, but timeout is requested as 10s.
+	// Since 10s exceeds ShutdownTimeout (200ms), it should be capped to 200ms
+	// and therefore time out.
+	req := ExecuteRequest{
+		Command: []string{"sleep", "2"},
+		Timeout: "10s",
+	}
+	body, _ := json.Marshal(req)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest("POST", "/api/execute", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	server.ExecuteHandler(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ExecuteResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	// It should have timed out due to capping
+	assert.Equal(t, TimeoutExitCode, resp.ExitCode)
+	assert.Contains(t, resp.Stderr, "Command timed out")
+}
+
 func TestExecuteHandler_EnvironmentVariables(t *testing.T) {
 	server, tmpDir := setupExecuteTestServer(t)
 	defer os.RemoveAll(tmpDir)

--- a/pkg/picod/execute_test.go
+++ b/pkg/picod/execute_test.go
@@ -130,19 +130,19 @@ func TestExecuteHandler_TimeoutFormats(t *testing.T) {
 			name:          "invalid format string",
 			timeout:       "invalid",
 			expectError:   true,
-			errorContains: "Invalid timeout format",
+			errorContains: "invalid timeout format",
 		},
 		{
 			name:          "malformed duration (no unit)",
 			timeout:       "10",
 			expectError:   true,
-			errorContains: "Invalid timeout format",
+			errorContains: "invalid timeout format",
 		},
 		{
 			name:          "empty string with quotes",
 			timeout:       `""`,
 			expectError:   true,
-			errorContains: "Invalid timeout format",
+			errorContains: "invalid timeout format",
 		},
 		{
 			name:        "valid seconds format",
@@ -156,7 +156,7 @@ func TestExecuteHandler_TimeoutFormats(t *testing.T) {
 		},
 		{
 			name:        "valid minutes format",
-			timeout:     "2m",
+			timeout:     "1m",
 			expectError: false,
 		},
 		{
@@ -186,7 +186,7 @@ func TestExecuteHandler_TimeoutFormats(t *testing.T) {
 				assert.Contains(t, w.Body.String(), tt.errorContains)
 			} else {
 				if w.Code == http.StatusBadRequest {
-					assert.NotContains(t, w.Body.String(), "Invalid timeout format")
+					assert.NotContains(t, w.Body.String(), "invalid timeout format")
 				}
 			}
 		})
@@ -400,12 +400,12 @@ func TestExecuteHandler_TimeoutCapping(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	defer os.Unsetenv(PublicKeyEnvVar)
 
-	// Set server shutdown timeout very low
+	// Set server shutdown timeout very low so that a "10s" request exceeds it.
 	server.config.ShutdownTimeout = 200 * time.Millisecond
 
-	// Command would take 2 seconds, but timeout is requested as 10s.
-	// Since 10s exceeds ShutdownTimeout (200ms), it should be capped to 200ms
-	// and therefore time out.
+	// Request a timeout that exceeds the shutdown grace period.
+	// The server must reject the request with a 400 rather than silently capping it,
+	// so the client is aware of the enforced maximum.
 	req := ExecuteRequest{
 		Command: []string{"sleep", "2"},
 		Timeout: "10s",
@@ -419,14 +419,9 @@ func TestExecuteHandler_TimeoutCapping(t *testing.T) {
 
 	server.ExecuteHandler(c)
 
-	assert.Equal(t, http.StatusOK, w.Code)
-
-	var resp ExecuteResponse
-	err := json.Unmarshal(w.Body.Bytes(), &resp)
-	require.NoError(t, err)
-	// It should have timed out due to capping
-	assert.Equal(t, TimeoutExitCode, resp.ExitCode)
-	assert.Contains(t, resp.Stderr, "Command timed out")
+	// Expect a 400 with a clear message about the enforced maximum.
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "exceeds the maximum allowed execution timeout")
 }
 
 func TestExecuteHandler_EnvironmentVariables(t *testing.T) {

--- a/pkg/picod/execute_test.go
+++ b/pkg/picod/execute_test.go
@@ -400,10 +400,10 @@ func TestExecuteHandler_TimeoutCapping(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	defer os.Unsetenv(PublicKeyEnvVar)
 
-	// Set server shutdown timeout very low so that a "10s" request exceeds it.
-	server.config.ShutdownTimeout = 200 * time.Millisecond
+	// Set the per-command maximum very low so that a "10s" request exceeds it.
+	server.config.MaxExecutionTimeout = 200 * time.Millisecond
 
-	// Request a timeout that exceeds the shutdown grace period.
+	// Request a timeout that exceeds the configured maximum.
 	// The server must reject the request with a 400 rather than silently capping it,
 	// so the client is aware of the enforced maximum.
 	req := ExecuteRequest{

--- a/pkg/picod/files.go
+++ b/pkg/picod/files.go
@@ -94,7 +94,7 @@ func (s *Server) handleMultipartUpload(c *gin.Context) {
 
 	// Create directory
 	dir := filepath.Dir(safePath)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := s.mkdirSafe(dir); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": fmt.Sprintf("Failed to create directory: %v", err),
 			"code":  http.StatusInternalServerError,
@@ -186,7 +186,7 @@ func (s *Server) handleJSONBase64Upload(c *gin.Context) {
 
 	// Create directory
 	dir := filepath.Dir(safePath)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := s.mkdirSafe(dir); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": fmt.Sprintf("Failed to create directory: %v", err),
 			"code":  http.StatusInternalServerError,

--- a/pkg/picod/files.go
+++ b/pkg/picod/files.go
@@ -18,6 +18,7 @@ package picod
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -31,6 +32,10 @@ import (
 	"github.com/gin-gonic/gin"
 	"k8s.io/klog/v2"
 )
+
+// ErrAccessDenied is returned by mkdirSafe when a path escapes the workspace
+// jail via a symlink. Callers should use errors.Is to detect it.
+var ErrAccessDenied = errors.New("access denied: path escapes workspace jail via symlink")
 
 const (
 	maxFileMode = 0777 // Maximum allowed file permission mode
@@ -96,7 +101,7 @@ func (s *Server) handleMultipartUpload(c *gin.Context) {
 	dir := filepath.Dir(safePath)
 	if err := s.mkdirSafe(dir); err != nil {
 		code := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "access denied") {
+		if errors.Is(err, ErrAccessDenied) {
 			code = http.StatusForbidden
 		}
 		c.JSON(code, gin.H{
@@ -192,7 +197,7 @@ func (s *Server) handleJSONBase64Upload(c *gin.Context) {
 	dir := filepath.Dir(safePath)
 	if err := s.mkdirSafe(dir); err != nil {
 		code := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "access denied") {
+		if errors.Is(err, ErrAccessDenied) {
 			code = http.StatusForbidden
 		}
 		c.JSON(code, gin.H{
@@ -418,7 +423,7 @@ func (s *Server) mkdirSafe(dir string) error {
 			}
 			rel, relErr := filepath.Rel(resolvedWorkspace, resolved)
 			if relErr != nil || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || rel == ".." {
-				return fmt.Errorf("access denied: path %q escapes workspace jail via symlink", dir)
+				return fmt.Errorf("%w: path %q escapes workspace jail via symlink", ErrAccessDenied, dir)
 			}
 			break
 		}

--- a/pkg/picod/files.go
+++ b/pkg/picod/files.go
@@ -95,9 +95,13 @@ func (s *Server) handleMultipartUpload(c *gin.Context) {
 	// Create directory
 	dir := filepath.Dir(safePath)
 	if err := s.mkdirSafe(dir); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
+		code := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "access denied") {
+			code = http.StatusForbidden
+		}
+		c.JSON(code, gin.H{
 			"error": fmt.Sprintf("Failed to create directory: %v", err),
-			"code":  http.StatusInternalServerError,
+			"code":  code,
 		})
 		return
 	}
@@ -187,9 +191,13 @@ func (s *Server) handleJSONBase64Upload(c *gin.Context) {
 	// Create directory
 	dir := filepath.Dir(safePath)
 	if err := s.mkdirSafe(dir); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
+		code := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "access denied") {
+			code = http.StatusForbidden
+		}
+		c.JSON(code, gin.H{
 			"error": fmt.Sprintf("Failed to create directory: %v", err),
-			"code":  http.StatusInternalServerError,
+			"code":  code,
 		})
 		return
 	}

--- a/pkg/picod/picod_test.go
+++ b/pkg/picod/picod_test.go
@@ -465,6 +465,7 @@ func TestPicoD_SymlinkUploadGuard(t *testing.T) {
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := client.Do(req)
 		require.NoError(t, err)
+		defer resp.Body.Close()
 		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 
 		// Verify file was NOT created in outsideDir
@@ -489,6 +490,7 @@ func TestPicoD_SymlinkUploadGuard(t *testing.T) {
 		req.Header.Set("Content-Type", writer.FormDataContentType())
 		resp, err := client.Do(req)
 		require.NoError(t, err)
+		defer resp.Body.Close()
 		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 
 		// Verify file was NOT created in outsideDir

--- a/pkg/picod/picod_test.go
+++ b/pkg/picod/picod_test.go
@@ -501,4 +501,3 @@ func TestPicoD_SymlinkUploadGuard(t *testing.T) {
 		assert.True(t, os.IsNotExist(statErr), "File should not be created outside workspace")
 	})
 }
-

--- a/pkg/picod/picod_test.go
+++ b/pkg/picod/picod_test.go
@@ -466,7 +466,8 @@ func TestPicoD_SymlinkUploadGuard(t *testing.T) {
 		resp, err := client.Do(req)
 		require.NoError(t, err)
 		defer resp.Body.Close()
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		// A symlink escape is a security violation — expect 403 Forbidden, not 500.
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 
 		// Verify file was NOT created in outsideDir
 		outsideFile := filepath.Join(outsideDir, "newdir/malicious.txt")
@@ -491,7 +492,8 @@ func TestPicoD_SymlinkUploadGuard(t *testing.T) {
 		resp, err := client.Do(req)
 		require.NoError(t, err)
 		defer resp.Body.Close()
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		// A symlink escape is a security violation, expect 403 Forbidden, not 500.
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 
 		// Verify file was NOT created in outsideDir
 		outsideFile := filepath.Join(outsideDir, "newdir/malicious_multipart.txt")

--- a/pkg/picod/picod_test.go
+++ b/pkg/picod/picod_test.go
@@ -63,7 +63,7 @@ func createToken(t *testing.T, key *rsa.PrivateKey, claims jwt.MapClaims) string
 }
 
 // setupTestServer creates a test server with public key loaded from env
-func setupTestServer(t *testing.T, pubPEM string) (*Server, *httptest.Server, string) {
+func setupTestServer(t *testing.T, pubPEM string) (*httptest.Server, string) {
 	tmpDir, err := os.MkdirTemp("", "picod_test")
 	require.NoError(t, err)
 
@@ -78,7 +78,7 @@ func setupTestServer(t *testing.T, pubPEM string) (*Server, *httptest.Server, st
 	server := NewServer(config)
 	ts := httptest.NewServer(server.engine)
 
-	return server, ts, tmpDir
+	return ts, tmpDir
 }
 
 func TestPicoD_EndToEnd(t *testing.T) {
@@ -86,7 +86,7 @@ func TestPicoD_EndToEnd(t *testing.T) {
 	routerPriv, routerPubStr := generateRSAKeys(t)
 
 	// 2. Setup Server
-	_, ts, tmpDir := setupTestServer(t, routerPubStr)
+	ts, tmpDir := setupTestServer(t, routerPubStr)
 	defer os.RemoveAll(tmpDir)
 	defer ts.Close()
 	defer os.Unsetenv(PublicKeyEnvVar)
@@ -419,3 +419,82 @@ func TestPicoD_SetWorkspace(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, resolve(absLinkPath), resolve(server.workspaceDir))
 }
+
+func TestPicoD_SymlinkUploadGuard(t *testing.T) {
+	// 1. Setup Keys
+	routerPriv, routerPubStr := generateRSAKeys(t)
+
+	// 2. Setup Server
+	ts, tmpDir := setupTestServer(t, routerPubStr)
+	defer os.RemoveAll(tmpDir)
+	defer ts.Close()
+	defer os.Unsetenv(PublicKeyEnvVar)
+
+	client := ts.Client()
+
+	// Helper to create auth headers
+	getAuthHeaders := func() http.Header {
+		claims := jwt.MapClaims{
+			"iat": time.Now().Unix(),
+			"exp": time.Now().Add(time.Hour * 6).Unix(),
+		}
+		token := createToken(t, routerPriv, claims)
+
+		h := make(http.Header)
+		h.Set("Authorization", "Bearer "+token)
+		return h
+	}
+
+	// 3. Plant a symlink inside the workspace that points outside it
+	outsideDir := t.TempDir()
+	symlinkPath := filepath.Join(tmpDir, "escape-link")
+	require.NoError(t, os.Symlink(outsideDir, symlinkPath))
+
+	// 4. Test JSON Base64 Upload through symlink (should fail)
+	t.Run("JSON Upload Symlink Guard", func(t *testing.T) {
+		contentB64 := base64.StdEncoding.EncodeToString([]byte("malicious content"))
+		uploadReq := UploadFileRequest{
+			Path:    "escape-link/newdir/malicious.txt",
+			Content: contentB64,
+			Mode:    "0644",
+		}
+		body, _ := json.Marshal(uploadReq)
+
+		req, _ := http.NewRequest("POST", ts.URL+"/api/files", bytes.NewBuffer(body))
+		req.Header = getAuthHeaders()
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+		// Verify file was NOT created in outsideDir
+		outsideFile := filepath.Join(outsideDir, "newdir/malicious.txt")
+		_, statErr := os.Stat(outsideFile)
+		assert.True(t, os.IsNotExist(statErr), "File should not be created outside workspace")
+	})
+
+	// 5. Test Multipart Upload through symlink (should fail)
+	t.Run("Multipart Upload Symlink Guard", func(t *testing.T) {
+		bodyBuf := &bytes.Buffer{}
+		writer := multipart.NewWriter(bodyBuf)
+		part, _ := writer.CreateFormFile("file", "malicious_multipart.txt")
+		_, err := part.Write([]byte("multipart malicious content"))
+		require.NoError(t, err)
+		err = writer.WriteField("path", "escape-link/newdir/malicious_multipart.txt")
+		require.NoError(t, err)
+		writer.Close()
+
+		req, _ := http.NewRequest("POST", ts.URL+"/api/files", bodyBuf)
+		req.Header = getAuthHeaders()
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+		// Verify file was NOT created in outsideDir
+		outsideFile := filepath.Join(outsideDir, "newdir/malicious_multipart.txt")
+		_, statErr := os.Stat(outsideFile)
+		assert.True(t, os.IsNotExist(statErr), "File should not be created outside workspace")
+	})
+}
+

--- a/pkg/picod/server.go
+++ b/pkg/picod/server.go
@@ -17,6 +17,7 @@ limitations under the License.
 package picod
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -96,7 +97,7 @@ func NewServer(config Config) *Server {
 }
 
 // Run starts the server
-func (s *Server) Run() error {
+func (s *Server) Run(ctx context.Context) error {
 	addr := fmt.Sprintf(":%d", s.config.Port)
 	klog.Infof("PicoD server starting on %s", addr)
 
@@ -106,7 +107,24 @@ func (s *Server) Run() error {
 		ReadHeaderTimeout: 10 * time.Second, // Prevent Slowloris attacks
 	}
 
-	return server.ListenAndServe()
+	idleConnsClosed := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		// Allow enough time for in-flight commands to finish (default timeout is 60s).
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			klog.Errorf("HTTP server shutdown error: %v", err)
+		}
+		close(idleConnsClosed)
+	}()
+
+	if err := server.ListenAndServe(); err != http.ErrServerClosed {
+		return err
+	}
+
+	<-idleConnsClosed
+	return nil
 }
 
 // HealthCheckHandler handles health check requests

--- a/pkg/picod/server.go
+++ b/pkg/picod/server.go
@@ -62,6 +62,8 @@ func NewServer(config Config) *Server {
 		config.MaxExecutionTimeout = 60 * time.Second
 	}
 	if config.MaxExecutionTimeout > config.ShutdownTimeout {
+		klog.Warningf("MaxExecutionTimeout (%v) exceeds ShutdownTimeout (%v); capping to ShutdownTimeout to prevent commands from outliving graceful shutdown",
+			config.MaxExecutionTimeout, config.ShutdownTimeout)
 		config.MaxExecutionTimeout = config.ShutdownTimeout
 	}
 	s := &Server{

--- a/pkg/picod/server.go
+++ b/pkg/picod/server.go
@@ -136,18 +136,25 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	idleConnsClosed := make(chan struct{})
+	stop := make(chan struct{})
 	go func() {
-		<-ctx.Done()
-		// Allow enough time for in-flight commands to finish.
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), s.config.ShutdownTimeout)
-		defer cancel()
-		if err := httpServer.Shutdown(shutdownCtx); err != nil {
-			klog.Errorf("HTTP server shutdown error: %v", err)
+		defer close(idleConnsClosed)
+		select {
+		case <-ctx.Done():
+			// Allow enough time for in-flight commands to finish.
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), s.config.ShutdownTimeout)
+			defer cancel()
+			if err := httpServer.Shutdown(shutdownCtx); err != nil {
+				klog.Errorf("HTTP server shutdown error: %v", err)
+			}
+		case <-stop:
+			// ListenAndServe failed before the context was cancelled; nothing to shut down.
 		}
-		close(idleConnsClosed)
 	}()
 
 	if err := httpServer.ListenAndServe(); err != http.ErrServerClosed {
+		close(stop)
+		<-idleConnsClosed // wait for the goroutine to exit
 		return err
 	}
 

--- a/pkg/picod/server.go
+++ b/pkg/picod/server.go
@@ -35,8 +35,9 @@ const (
 
 // Config defines server configuration
 type Config struct {
-	Port      int    `json:"port"`
-	Workspace string `json:"workspace"`
+	Port            int           `json:"port"`
+	Workspace       string        `json:"workspace"`
+	ShutdownTimeout time.Duration `json:"shutdown_timeout"`
 }
 
 // Server defines the PicoD HTTP server
@@ -50,6 +51,9 @@ type Server struct {
 
 // NewServer creates a new PicoD server instance
 func NewServer(config Config) *Server {
+	if config.ShutdownTimeout <= 0 {
+		config.ShutdownTimeout = 90 * time.Second
+	}
 	s := &Server{
 		config:      config,
 		startTime:   time.Now(),
@@ -134,8 +138,12 @@ func (s *Server) Run(ctx context.Context) error {
 	idleConnsClosed := make(chan struct{})
 	go func() {
 		<-ctx.Done()
-		// Allow enough time for in-flight commands to finish (default timeout is 60s).
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		// Allow enough time for in-flight commands to finish.
+		shutdownTimeout := s.config.ShutdownTimeout
+		if shutdownTimeout <= 0 {
+			shutdownTimeout = 90 * time.Second
+		}
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
 		if err := httpServer.Shutdown(shutdownCtx); err != nil {
 			klog.Errorf("HTTP server shutdown error: %v", err)

--- a/pkg/picod/server.go
+++ b/pkg/picod/server.go
@@ -120,8 +120,8 @@ func maxBodySizeMiddleware() gin.HandlerFunc {
 	}
 }
 
-// Start starts the server and blocks until ctx is canceled or a fatal error occurs.
-func (s *Server) Start(ctx context.Context) error {
+// Run starts the server and blocks until ctx is canceled or a fatal error occurs.
+func (s *Server) Run(ctx context.Context) error {
 	addr := fmt.Sprintf(":%d", s.config.Port)
 	klog.Infof("PicoD server starting on %s", addr)
 
@@ -131,20 +131,23 @@ func (s *Server) Start(ctx context.Context) error {
 		ReadHeaderTimeout: 10 * time.Second, // Prevent Slowloris attacks
 	}
 
-	// Listen for shutdown signal and gracefully stop the HTTP server.
+	idleConnsClosed := make(chan struct{})
 	go func() {
 		<-ctx.Done()
-		klog.Info("Shutting down PicoD server...")
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		// Allow enough time for in-flight commands to finish (default timeout is 60s).
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 		defer cancel()
 		if err := httpServer.Shutdown(shutdownCtx); err != nil {
-			klog.Errorf("PicoD server shutdown error: %v", err)
+			klog.Errorf("HTTP server shutdown error: %v", err)
 		}
+		close(idleConnsClosed)
 	}()
 
-	if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	if err := httpServer.ListenAndServe(); err != http.ErrServerClosed {
 		return err
 	}
+
+	<-idleConnsClosed
 	return nil
 }
 

--- a/pkg/picod/server.go
+++ b/pkg/picod/server.go
@@ -35,9 +35,10 @@ const (
 
 // Config defines server configuration
 type Config struct {
-	Port            int           `json:"port"`
-	Workspace       string        `json:"workspace"`
-	ShutdownTimeout time.Duration `json:"shutdown_timeout"`
+	Port                int           `json:"port"`
+	Workspace           string        `json:"workspace"`
+	ShutdownTimeout     time.Duration `json:"shutdown_timeout"`
+	MaxExecutionTimeout time.Duration `json:"max_execution_timeout"`
 }
 
 // Server defines the PicoD HTTP server
@@ -53,6 +54,14 @@ type Server struct {
 func NewServer(config Config) *Server {
 	if config.ShutdownTimeout <= 0 {
 		config.ShutdownTimeout = 90 * time.Second
+	}
+	// MaxExecutionTimeout defaults to 60s. It is also capped to ShutdownTimeout
+	// so that no command can outlive the server during graceful shutdown.
+	if config.MaxExecutionTimeout <= 0 {
+		config.MaxExecutionTimeout = 60 * time.Second
+	}
+	if config.MaxExecutionTimeout > config.ShutdownTimeout {
+		config.MaxExecutionTimeout = config.ShutdownTimeout
 	}
 	s := &Server{
 		config:      config,

--- a/pkg/picod/server.go
+++ b/pkg/picod/server.go
@@ -18,6 +18,7 @@ package picod
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -133,8 +134,8 @@ func maxBodySizeMiddleware() gin.HandlerFunc {
 	}
 }
 
-// Run starts the server and blocks until ctx is canceled or a fatal error occurs.
-func (s *Server) Run(ctx context.Context) error {
+// Start starts the server and blocks until ctx is canceled or a fatal error occurs.
+func (s *Server) Start(ctx context.Context) error {
 	addr := fmt.Sprintf(":%d", s.config.Port)
 	klog.Infof("PicoD server starting on %s", addr)
 
@@ -161,7 +162,7 @@ func (s *Server) Run(ctx context.Context) error {
 		}
 	}()
 
-	if err := httpServer.ListenAndServe(); err != http.ErrServerClosed {
+	if err := httpServer.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
 		close(stop)
 		<-idleConnsClosed // wait for the goroutine to exit
 		return err

--- a/pkg/picod/server.go
+++ b/pkg/picod/server.go
@@ -148,7 +148,7 @@ func (s *Server) Run(ctx context.Context) error {
 				klog.Errorf("HTTP server shutdown error: %v", err)
 			}
 		case <-stop:
-			// ListenAndServe failed before the context was cancelled; nothing to shut down.
+			// ListenAndServe failed before the context was canceled; nothing to shut down.
 		}
 	}()
 

--- a/pkg/picod/server.go
+++ b/pkg/picod/server.go
@@ -139,11 +139,7 @@ func (s *Server) Run(ctx context.Context) error {
 	go func() {
 		<-ctx.Done()
 		// Allow enough time for in-flight commands to finish.
-		shutdownTimeout := s.config.ShutdownTimeout
-		if shutdownTimeout <= 0 {
-			shutdownTimeout = 90 * time.Second
-		}
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), s.config.ShutdownTimeout)
 		defer cancel()
 		if err := httpServer.Shutdown(shutdownCtx); err != nil {
 			klog.Errorf("HTTP server shutdown error: %v", err)

--- a/sdk-python/agentcube/clients/code_interpreter_data_plane.py
+++ b/sdk-python/agentcube/clients/code_interpreter_data_plane.py
@@ -131,14 +131,15 @@ class CodeInterpreterDataPlaneClient:
         Unlike ``execute_command``, this does not raise when ``exit_code != 0``.
         """
         timeout_value = timeout or self.timeout
-        timeout_str = f"{timeout_value}s" if isinstance(timeout_value, (int, float)) else str(timeout_value)
 
         cmd_list = shlex.split(command, posix=True) if isinstance(command, str) else command
 
         payload = {
             "command": cmd_list,
-            "timeout": timeout_str
         }
+        if timeout is not None:
+            timeout_str = f"{timeout}s" if isinstance(timeout, (int, float)) else str(timeout)
+            payload["timeout"] = timeout_str
         body = json.dumps(payload).encode('utf-8')
 
         read_timeout = timeout_value + 2.0 if isinstance(timeout_value, (int, float)) else timeout_value

--- a/sdk-python/agentcube/clients/code_interpreter_data_plane.py
+++ b/sdk-python/agentcube/clients/code_interpreter_data_plane.py
@@ -129,8 +129,19 @@ class CodeInterpreterDataPlaneClient:
         """Execute a shell command and return stdout, stderr, and exit_code.
 
         Unlike ``execute_command``, this does not raise when ``exit_code != 0``.
+
+        Args:
+            command: The command to execute.
+            timeout: Per-command execution timeout in seconds sent to PicoD.
+                When omitted, the ``timeout`` field is not included in the
+                payload and PicoD uses its own server-side default
+                (``--max-execution-timeout``). ``self.timeout`` is an HTTP
+                socket timeout used only for the underlying requests call and
+                is not forwarded to PicoD as a command timeout.
         """
-        timeout_value = timeout or self.timeout
+        # self.timeout is the HTTP socket read-timeout; use it to size the
+        # underlying HTTP call. timeout_value is only referenced for read_timeout.
+        timeout_value = timeout if timeout is not None else self.timeout
 
         cmd_list = shlex.split(command, posix=True) if isinstance(command, str) else command
 


### PR DESCRIPTION
**What type of PR is this?**

/kind security
/kind enhancement

**What this PR does / why we need it**:

This PR hardens the PicoD server with three targeted improvements:

1. **Graceful shutdown** — `Run()` now accepts a `context.Context` and shuts down the HTTP server cleanly on `SIGINT`/`SIGTERM`, allowing in-flight requests to complete before exit. This is foundational for the stateful execution direction (#267).

2. **Symlink traversal guard in upload handlers** — `handleMultipartUpload` and `handleJSONBase64Upload` used `os.MkdirAll` to create parent directories, which follows symlinks in existing path components. An attacker with workspace write access could place a symlink pointing outside the jail, causing directory creation beyond the workspace boundary. Both call sites now use the existing `mkdirSafe` guard, consistent with `ExecuteHandler`.

3. **Doc fix** — The `ExecuteRequest.Timeout` comment stated the default was `"30s"` but the actual default is `60s`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

- The `setWorkspace` call site intentionally keeps `os.MkdirAll` — it creates the workspace root itself at startup from admin config, and `mkdirSafe` uses `workspaceDir` as the jail root, so using it there would be circular.
- The graceful shutdown goroutine in `Run()` mirrors the pattern used by the workloadmanager's `Shutdown()` method.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
