### PR TITLE
fix(router,workloadmanager): populate sandbox Kind and Namespace on create

### DIFF
--- a/pkg/common/types/sandbox.go
+++ b/pkg/common/types/sandbox.go
@@ -57,6 +57,7 @@ type CreateSandboxRequest struct {
 }
 
 type CreateSandboxResponse struct {
+	Kind        string              `json:"kind"`
 	SessionID   string              `json:"sessionId"`
 	SandboxID   string              `json:"sandboxId"`
 	SandboxName string              `json:"sandboxName"`

--- a/pkg/router/session_manager.go
+++ b/pkg/router/session_manager.go
@@ -185,10 +185,12 @@ func (m *manager) createSandbox(ctx context.Context, namespace string, name stri
 
 	// Construct Sandbox Info from response
 	sandbox := &types.SandboxInfo{
-		SandboxID:   res.SandboxID,
-		Name:        res.SandboxName,
-		SessionID:   res.SessionID,
-		EntryPoints: res.EntryPoints,
+		Kind:             res.Kind,
+		SandboxNamespace: namespace,
+		SandboxID:        res.SandboxID,
+		Name:             res.SandboxName,
+		SessionID:        res.SessionID,
+		EntryPoints:      res.EntryPoints,
 	}
 
 	return sandbox, nil

--- a/pkg/workloadmanager/handlers.go
+++ b/pkg/workloadmanager/handlers.go
@@ -264,6 +264,7 @@ func (s *Server) createSandbox(ctx context.Context, dynamicClient dynamic.Interf
 	storeCacheInfo := buildSandboxInfo(createdSandbox, podIP, sandboxEntry)
 
 	response := &types.CreateSandboxResponse{
+		Kind:        storeCacheInfo.Kind,
 		SessionID:   sandboxEntry.SessionID,
 		SandboxID:   storeCacheInfo.SandboxID,
 		SandboxName: sandbox.Name,


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

When the router creates a new sandbox via the workload manager, the returned `SandboxInfo` had empty `Kind` and `SandboxNamespace` fields. This causes `generateSandboxJWT` to skip JWT signing for freshly-created sandboxes, since it checks `sandbox.Kind` against `SandboxKind`/`SandboxClaimsKind`.

This PR:
1. Adds `Kind` to `CreateSandboxResponse` and populates it from the workload manager with the real resource kind (`Sandbox` or `SandboxClaim`)
2. Populates `SandboxNamespace` in the router for consistency with store-fetched sandboxes

**Special notes for your reviewer**:

- The `Kind` uses the resource kind (`Sandbox`/`SandboxClaim`), not the invoke kind (`AgentRuntime`/`CodeInterpreter`), to stay consistent with the store path and the workload manager's deletion logic.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
