### PR TITLE
feat(picod): add gzip middleware for response compression

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.24.9
 require (
 	github.com/agiledragon/gomonkey/v2 v2.13.0
 	github.com/alicebob/miniredis/v2 v2.35.0
+	github.com/gin-contrib/gzip v1.0.1
 	github.com/gin-gonic/gin v1.10.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sa
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
+github.com/gin-contrib/gzip v1.0.1 h1:HQ8ENHODeLY7a4g1Au/46Z92bdGFl74OhxcZble9WJE=
+github.com/gin-contrib/gzip v1.0.1/go.mod h1:njt428fdUNRvjuJf16tZMYZ2Yl+WQB53X5wmhDwXvC4=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.10.0 h1:nTuyha1TYqgedzytsKYqna+DfLos46nTv2ygFy86HFU=

--- a/pkg/picod/server.go
+++ b/pkg/picod/server.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/gin-contrib/gzip"
 	"github.com/gin-gonic/gin"
 	"k8s.io/klog/v2"
 )
@@ -72,6 +73,7 @@ func NewServer(config Config) *Server {
 	// Global middleware
 	engine.Use(gin.Logger())   // Request logging
 	engine.Use(gin.Recovery()) // Crash recovery
+	engine.Use(gzip.Gzip(gzip.BestSpeed, gzip.WithExcludedPaths([]string{"/health"}))) // Response compression
 
 	// Load public key from environment variable (required)
 	if err := s.authManager.LoadPublicKeyFromEnv(); err != nil {

--- a/pkg/picod/server.go
+++ b/pkg/picod/server.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/gin-contrib/gzip"
 	"github.com/gin-gonic/gin"
 	"k8s.io/klog/v2"
 )
@@ -94,6 +95,7 @@ func NewServer(config Config) *Server {
 		c.Next()
 	})
 	engine.MaxMultipartMemory = MaxBodySize
+	engine.Use(gzip.Gzip(gzip.BestSpeed, gzip.WithExcludedPaths([]string{"/health"}))) // Response compression
 
 	// Load public key from environment variable (required)
 	if err := s.authManager.LoadPublicKeyFromEnv(); err != nil {

--- a/pkg/picod/server_test.go
+++ b/pkg/picod/server_test.go
@@ -371,6 +371,83 @@ func TestNewServer_DifferentPorts(t *testing.T) {
 	}
 }
 
+func TestServer_GzipMiddleware_CompressesResponse(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "picod-server-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	pubKeyPEM := generateTestPublicKeyPEM(t)
+	os.Setenv(PublicKeyEnvVar, pubKeyPEM)
+	defer os.Unsetenv(PublicKeyEnvVar)
+
+	server := NewServer(Config{
+		Port:      8080,
+		Workspace: tmpDir,
+	})
+
+	ts := httptest.NewServer(server.engine)
+	defer ts.Close()
+
+	// A client that sends Accept-Encoding: gzip should receive a gzip-compressed response.
+	// The /health endpoint responds with a JSON body that gin-contrib/gzip will compress.
+	// However, /health is in the excluded paths — so we use /api/execute (which returns
+	// 401 Unauthorized, a non-empty JSON body that gzip will still compress).
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/execute", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	client := &http.Client{
+		// Disable automatic transparent decompression so we can inspect the raw header.
+		Transport: &http.Transport{
+			DisableCompression: true,
+		},
+	}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// The middleware must set Content-Encoding: gzip on the wire.
+	assert.Equal(t, "gzip", resp.Header.Get("Content-Encoding"),
+		"response should be gzip-compressed when client advertises Accept-Encoding: gzip")
+}
+
+func TestServer_GzipMiddleware_ExcludesHealthEndpoint(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "picod-server-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	pubKeyPEM := generateTestPublicKeyPEM(t)
+	os.Setenv(PublicKeyEnvVar, pubKeyPEM)
+	defer os.Unsetenv(PublicKeyEnvVar)
+
+	server := NewServer(Config{
+		Port:      8080,
+		Workspace: tmpDir,
+	})
+
+	ts := httptest.NewServer(server.engine)
+	defer ts.Close()
+
+	// /health is in the WithExcludedPaths list, so even when the client requests gzip
+	// the middleware must NOT set Content-Encoding: gzip on that path.
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/health", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DisableCompression: true,
+		},
+	}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.NotEqual(t, "gzip", resp.Header.Get("Content-Encoding"),
+		"/health is an excluded path and must not be gzip-compressed")
+}
+
 func TestServer_MaxBodySizeMiddleware(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "picod-server-test-*")
 	require.NoError(t, err)


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement
/kind feature

**What this PR does / why we need it**:

This PR implements Gzip compression for the PicoD daemon, fulfilling one of the planned network enhancements in the [`picod-proposal.md`](../docs/design/picod-proposal.md) design doc (Future Enhancements, item-2).

By injecting the `gin-contrib/gzip` middleware, the PicoD server performs on-the-fly compression for HTTP responses. This reduces network bandwidth and improves latency for large data transfers, such as retrieving bulky `stdout`/`stderr` payloads from `/api/execute` or downloading large text/JSON files via `/api/files/*path`.

The middleware uses standard HTTP content negotiation:
- Clients advertising `Accept-Encoding: gzip` receive compressed payloads.
- Clients that do not support compression seamlessly receive plain responses (no change in behavior).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

- Pinned `gin-contrib/gzip` to `v1.0.1` to avoid a transitive upgrade to Go 1.25.0+, keeping compatibility with the project's `go1.24.4` toolchain directive.
- Uses `gzip.BestSpeed` (level 1) rather than the default level 6, prioritising minimal CPU overhead over maximum compression ratio — appropriate for a latency-sensitive daemon serving constrained sandbox networks.
- `/health` is excluded from compression via `gzip.WithExcludedPaths` to avoid unnecessary processing on a lightweight liveness probe.
- Two focused tests have been added to `server_test.go`:
  - `TestServer_GzipMiddleware_CompressesResponse` — verifies `Content-Encoding: gzip` is set when the client sends `Accept-Encoding: gzip`.
  - `TestServer_GzipMiddleware_ExcludesHealthEndpoint` — verifies `/health` is **not** compressed even when the client requests it.

**Does this PR introduce a user-facing change?**:

```release-note
Added Gzip compression support to the PicoD daemon to reduce bandwidth usage for file transfers and command execution payloads over constrained networks.
```
