### PR TITLE
fix(agentd): use custom idle timeout annotation for garbage collection

### DIFF
--- a/pkg/agentd/agentd.go
+++ b/pkg/agentd/agentd.go
@@ -29,10 +29,6 @@ import (
 	"github.com/volcano-sh/agentcube/pkg/workloadmanager"
 )
 
-var (
-	SessionExpirationTimeout = 15 * time.Minute
-)
-
 // Reconciler reconciles a Sandbox object
 type Reconciler struct {
 	client.Client
@@ -57,7 +53,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 
-		expirationTime := lastActivity.Add(SessionExpirationTimeout)
+		expirationTime := lastActivity.Add(workloadmanager.DefaultSandboxIdleTimeout)
+		
+		// Use custom idle timeout if defined.
+		// Ignore invalid, zero, or negative values and fall back to the default timeout.
+		if timeoutStr, exists := sandbox.Annotations[workloadmanager.IdleTimeoutAnnotationKey]; exists && timeoutStr != "" {
+			if customTimeout, err := time.ParseDuration(timeoutStr); err == nil && customTimeout > 0 {
+				expirationTime = lastActivity.Add(customTimeout)
+			}
+		}
 		// Delete sandbox if expired
 		if time.Now().After(expirationTime) {
 			if err := r.Delete(ctx, sandbox); err != nil {

--- a/pkg/agentd/agentd_test.go
+++ b/pkg/agentd/agentd_test.go
@@ -160,7 +160,7 @@ func TestReconciler_Reconcile_LifecycleOrchestration(t *testing.T) {
 					Name:      "expired-sandbox",
 					Namespace: "default",
 					Annotations: map[string]string{
-						workloadmanager.LastActivityAnnotationKey: now.Add(-SessionExpirationTimeout).Format(time.RFC3339),
+						workloadmanager.LastActivityAnnotationKey: now.Add(-workloadmanager.DefaultSandboxIdleTimeout).Format(time.RFC3339),
 					},
 				},
 			},
@@ -175,7 +175,7 @@ func TestReconciler_Reconcile_LifecycleOrchestration(t *testing.T) {
 					Name:      "past-expired-sandbox",
 					Namespace: "default",
 					Annotations: map[string]string{
-						workloadmanager.LastActivityAnnotationKey: now.Add(-SessionExpirationTimeout - 1*time.Minute).Format(time.RFC3339),
+						workloadmanager.LastActivityAnnotationKey: now.Add(-workloadmanager.DefaultSandboxIdleTimeout - 1*time.Minute).Format(time.RFC3339),
 					},
 				},
 			},
@@ -190,7 +190,7 @@ func TestReconciler_Reconcile_LifecycleOrchestration(t *testing.T) {
 					Name:      "near-expiration-sandbox",
 					Namespace: "default",
 					Annotations: map[string]string{
-						workloadmanager.LastActivityAnnotationKey: now.Add(-SessionExpirationTimeout + 1*time.Minute).Format(time.RFC3339),
+						workloadmanager.LastActivityAnnotationKey: now.Add(-workloadmanager.DefaultSandboxIdleTimeout + 1*time.Minute).Format(time.RFC3339),
 					},
 				},
 			},
@@ -198,6 +198,90 @@ func TestReconciler_Reconcile_LifecycleOrchestration(t *testing.T) {
 			expectRequeue:     true,
 			expectedRequeueAt: 1 * time.Minute,
 			description:       "Should requeue when close to expiration",
+		},
+		{
+			name: "Sandbox with custom short timeout should be deleted",
+			sandbox: &sandboxv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "custom-short-timeout-sandbox",
+					Namespace: "default",
+					Annotations: map[string]string{
+						workloadmanager.LastActivityAnnotationKey: now.Add(-6 * time.Minute).Format(time.RFC3339),
+						workloadmanager.IdleTimeoutAnnotationKey:  "5m",
+					},
+				},
+			},
+			expectDeletion: true,
+			expectRequeue:  false,
+			description:    "Should delete when past custom shorter expiration time",
+		},
+		{
+			name: "Sandbox with custom long timeout should be requeued",
+			sandbox: &sandboxv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "custom-long-timeout-sandbox",
+					Namespace: "default",
+					Annotations: map[string]string{
+						workloadmanager.LastActivityAnnotationKey: now.Add(-20 * time.Minute).Format(time.RFC3339),
+						workloadmanager.IdleTimeoutAnnotationKey:  "1h",
+					},
+				},
+			},
+			expectDeletion:    false,
+			expectRequeue:     true,
+			expectedRequeueAt: 40 * time.Minute, // 1h timeout - 20m elapsed
+			description:       "Should requeue when not past custom longer expiration time",
+		},
+		{
+			name: "Sandbox with invalid custom timeout should fallback to default",
+			sandbox: &sandboxv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-timeout-sandbox",
+					Namespace: "default",
+					Annotations: map[string]string{
+						workloadmanager.LastActivityAnnotationKey: now.Add(-10 * time.Minute).Format(time.RFC3339),
+						workloadmanager.IdleTimeoutAnnotationKey:  "invalid-duration",
+					},
+				},
+			},
+			expectDeletion:    false,
+			expectRequeue:     true,
+			expectedRequeueAt: 5 * time.Minute, // Falls back to 15m default timeout - 10m elapsed
+			description:       "Should fallback to default expiration time when custom timeout is invalid",
+		},
+		{
+			name: "Sandbox with negative custom timeout should fallback to default",
+			sandbox: &sandboxv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "negative-timeout-sandbox",
+					Namespace: "default",
+					Annotations: map[string]string{
+						workloadmanager.LastActivityAnnotationKey: now.Add(-10 * time.Minute).Format(time.RFC3339),
+						workloadmanager.IdleTimeoutAnnotationKey:  "-5m",
+					},
+				},
+			},
+			expectDeletion:    false,
+			expectRequeue:     true,
+			expectedRequeueAt: 5 * time.Minute, // Falls back to 15m default timeout - 10m elapsed
+			description:       "Should fallback to default expiration time when custom timeout is negative",
+		},
+		{
+			name: "Sandbox with zero custom timeout should fallback to default",
+			sandbox: &sandboxv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "zero-timeout-sandbox",
+					Namespace: "default",
+					Annotations: map[string]string{
+						workloadmanager.LastActivityAnnotationKey: now.Add(-10 * time.Minute).Format(time.RFC3339),
+						workloadmanager.IdleTimeoutAnnotationKey:  "0s",
+					},
+				},
+			},
+			expectDeletion:    false,
+			expectRequeue:     true,
+			expectedRequeueAt: 5 * time.Minute, // Falls back to 15m default timeout - 10m elapsed
+			description:       "Should fallback to default expiration time when custom timeout is zero",
 		},
 	}
 
@@ -334,10 +418,6 @@ func TestReconciler_Reconcile_ErrorPaths(t *testing.T) {
 	}
 }
 
-// TestSessionExpirationTimeout tests the timeout constant
-func TestSessionExpirationTimeout(t *testing.T) {
-	assert.Equal(t, 15*time.Minute, SessionExpirationTimeout, "SessionExpirationTimeout should be 15 minutes")
-}
 
 // TestReconciler_Reconcile_EdgeCases tests edge cases
 func TestReconciler_Reconcile_EdgeCases(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug where `agentd` ignores the custom `runtime.agentcube.io/idle-timeout` annotation set on a Sandbox. Previously, the garbage collection reconciliation loop used a hardcoded `15 * time.Minute` value for every sandbox. 

With this change, `agentd` successfully parses the Sandbox's custom idle timeout from the metadata annotations and correctly honors shorter or longer custom session durations. It will fall back to the default `15 * time.Minute` if the annotation is missing or improperly formatted.

It also introduces new unit test coverage inside `agentd_test.go` to explicitly verify custom short timeouts, custom long timeouts, and invalid timeout fallback paths.

**Which issue(s) this PR fixes**:
Fixes #342

**Special notes for your reviewer**:
* All changes covered by unit tests.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Fixes an issue where custom Sandbox idle timeouts (`runtime.agentcube.io/idle-timeout`) were ignored by the garbage collector and always fell back to 15 minutes.
```
