### PR TITLE
test: add tests for sandbox Kind and Namespace properties

### DIFF
--- a/pkg/router/session_manager_test.go
+++ b/pkg/router/session_manager_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -157,6 +158,7 @@ func TestGetSandboxBySession_NotFound(t *testing.T) {
 // ---- tests: GetSandboxBySession with empty sessionID (sandbox creation path) ----
 
 func TestGetSandboxBySession_CreateSandbox_AgentRuntime_Success(t *testing.T) {
+	const defaultNS = "default"
 	// Mock workload manager server
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Verify request method and path
@@ -182,13 +184,13 @@ func TestGetSandboxBySession_CreateSandbox_AgentRuntime_Success(t *testing.T) {
 		if req.Name != "test-runtime" {
 			t.Errorf("expected name test-runtime, got %s", req.Name)
 		}
-		if req.Namespace != "default" {
-			t.Errorf("expected namespace default, got %s", req.Namespace)
+		if req.Namespace != defaultNS {
+			t.Errorf("expected namespace %s, got %s", defaultNS, req.Namespace)
 		}
 
 		// Send successful response
 		resp := types.CreateSandboxResponse{
-			Kind:        types.AgentRuntimeKind,
+			Kind:        types.SandboxKind,
 			SessionID:   "new-session-123",
 			SandboxID:   "sandbox-456",
 			SandboxName: "sandbox-test",
@@ -209,33 +211,25 @@ func TestGetSandboxBySession_CreateSandbox_AgentRuntime_Success(t *testing.T) {
 		httpClient:      &http.Client{},
 	}
 
-	sandbox, err := m.GetSandboxBySession(context.Background(), "", "default", "test-runtime", types.AgentRuntimeKind)
+	sandbox, err := m.GetSandboxBySession(context.Background(), "", defaultNS, "test-runtime", types.AgentRuntimeKind)
 	if err != nil {
 		t.Fatalf("GetSandboxBySession unexpected error: %v", err)
 	}
 	if sandbox == nil {
 		t.Fatalf("expected non-nil sandbox")
 	}
-	if sandbox.SessionID != "new-session-123" {
-		t.Errorf("expected SessionID new-session-123, got %s", sandbox.SessionID)
+	expectedSandbox := &types.SandboxInfo{
+		Kind:             types.SandboxKind,
+		SandboxNamespace: defaultNS,
+		SandboxID:        "sandbox-456",
+		Name:             "sandbox-test",
+		SessionID:        "new-session-123",
+		EntryPoints: []types.SandboxEntryPoint{
+			{Endpoint: "10.0.0.1:9000", Protocol: "http", Path: "/"},
+		},
 	}
-	if sandbox.SandboxID != "sandbox-456" {
-		t.Errorf("expected SandboxID sandbox-456, got %s", sandbox.SandboxID)
-	}
-	if sandbox.Name != "sandbox-test" {
-		t.Errorf("expected Name sandbox-test, got %s", sandbox.Name)
-	}
-	if sandbox.Kind != types.AgentRuntimeKind {
-		t.Errorf("expected Kind %s, got %s", types.AgentRuntimeKind, sandbox.Kind)
-	}
-	if sandbox.SandboxNamespace != "default" {
-		t.Errorf("expected SandboxNamespace default, got %s", sandbox.SandboxNamespace)
-	}
-	if len(sandbox.EntryPoints) != 1 {
-		t.Fatalf("expected 1 entry point, got %d", len(sandbox.EntryPoints))
-	}
-	if sandbox.EntryPoints[0].Endpoint != "10.0.0.1:9000" {
-		t.Errorf("expected endpoint 10.0.0.1:9000, got %s", sandbox.EntryPoints[0].Endpoint)
+	if !reflect.DeepEqual(sandbox, expectedSandbox) {
+		t.Errorf("expected sandbox %+v, got %+v", expectedSandbox, sandbox)
 	}
 }
 
@@ -356,6 +350,7 @@ func TestGetSandboxBySession_CreateSandbox_TokenFileReadError(t *testing.T) {
 }
 
 func TestGetSandboxBySession_CreateSandbox_CodeInterpreter_Success(t *testing.T) {
+	const defaultNS = "default"
 	// Mock workload manager server
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Verify request method and path
@@ -381,7 +376,7 @@ func TestGetSandboxBySession_CreateSandbox_CodeInterpreter_Success(t *testing.T)
 
 		// Send successful response
 		resp := types.CreateSandboxResponse{
-			Kind:        types.CodeInterpreterKind,
+			Kind:        types.SandboxClaimsKind,
 			SessionID:   "ci-session-789",
 			SandboxID:   "ci-sandbox-101",
 			SandboxName: "ci-sandbox-test",
@@ -402,21 +397,25 @@ func TestGetSandboxBySession_CreateSandbox_CodeInterpreter_Success(t *testing.T)
 		httpClient:      &http.Client{},
 	}
 
-	sandbox, err := m.GetSandboxBySession(context.Background(), "", "default", "test-ci", types.CodeInterpreterKind)
+	sandbox, err := m.GetSandboxBySession(context.Background(), "", defaultNS, "test-ci", types.CodeInterpreterKind)
 	if err != nil {
 		t.Fatalf("GetSandboxBySession unexpected error: %v", err)
 	}
 	if sandbox == nil {
 		t.Fatalf("expected non-nil sandbox")
 	}
-	if sandbox.SessionID != "ci-session-789" {
-		t.Errorf("expected SessionID ci-session-789, got %s", sandbox.SessionID)
+	expectedSandbox := &types.SandboxInfo{
+		Kind:             types.SandboxClaimsKind,
+		SandboxNamespace: defaultNS,
+		SandboxID:        "ci-sandbox-101",
+		Name:             "ci-sandbox-test",
+		SessionID:        "ci-session-789",
+		EntryPoints: []types.SandboxEntryPoint{
+			{Endpoint: "10.0.0.2:8080", Protocol: "http", Path: "/"},
+		},
 	}
-	if sandbox.Kind != types.CodeInterpreterKind {
-		t.Errorf("expected Kind %s, got %s", types.CodeInterpreterKind, sandbox.Kind)
-	}
-	if sandbox.SandboxNamespace != "default" {
-		t.Errorf("expected SandboxNamespace default, got %s", sandbox.SandboxNamespace)
+	if !reflect.DeepEqual(sandbox, expectedSandbox) {
+		t.Errorf("expected sandbox %+v, got %+v", expectedSandbox, sandbox)
 	}
 }
 

--- a/pkg/router/session_manager_test.go
+++ b/pkg/router/session_manager_test.go
@@ -188,6 +188,7 @@ func TestGetSandboxBySession_CreateSandbox_AgentRuntime_Success(t *testing.T) {
 
 		// Send successful response
 		resp := types.CreateSandboxResponse{
+			Kind:        types.AgentRuntimeKind,
 			SessionID:   "new-session-123",
 			SandboxID:   "sandbox-456",
 			SandboxName: "sandbox-test",
@@ -223,6 +224,12 @@ func TestGetSandboxBySession_CreateSandbox_AgentRuntime_Success(t *testing.T) {
 	}
 	if sandbox.Name != "sandbox-test" {
 		t.Errorf("expected Name sandbox-test, got %s", sandbox.Name)
+	}
+	if sandbox.Kind != types.AgentRuntimeKind {
+		t.Errorf("expected Kind %s, got %s", types.AgentRuntimeKind, sandbox.Kind)
+	}
+	if sandbox.SandboxNamespace != "default" {
+		t.Errorf("expected SandboxNamespace default, got %s", sandbox.SandboxNamespace)
 	}
 	if len(sandbox.EntryPoints) != 1 {
 		t.Fatalf("expected 1 entry point, got %d", len(sandbox.EntryPoints))
@@ -374,6 +381,7 @@ func TestGetSandboxBySession_CreateSandbox_CodeInterpreter_Success(t *testing.T)
 
 		// Send successful response
 		resp := types.CreateSandboxResponse{
+			Kind:        types.CodeInterpreterKind,
 			SessionID:   "ci-session-789",
 			SandboxID:   "ci-sandbox-101",
 			SandboxName: "ci-sandbox-test",
@@ -403,6 +411,12 @@ func TestGetSandboxBySession_CreateSandbox_CodeInterpreter_Success(t *testing.T)
 	}
 	if sandbox.SessionID != "ci-session-789" {
 		t.Errorf("expected SessionID ci-session-789, got %s", sandbox.SessionID)
+	}
+	if sandbox.Kind != types.CodeInterpreterKind {
+		t.Errorf("expected Kind %s, got %s", types.CodeInterpreterKind, sandbox.Kind)
+	}
+	if sandbox.SandboxNamespace != "default" {
+		t.Errorf("expected SandboxNamespace default, got %s", sandbox.SandboxNamespace)
 	}
 }
 

--- a/pkg/workloadmanager/handlers_test.go
+++ b/pkg/workloadmanager/handlers_test.go
@@ -263,6 +263,7 @@ func TestServerCreateSandbox(t *testing.T) {
 			require.Equal(t, "sess-1", resp.SessionID)
 			require.Equal(t, sb.Name, resp.SandboxName)
 			require.Equal(t, string(sb.UID), resp.SandboxID)
+			require.Equal(t, types.AgentRuntimeKind, resp.Kind)
 			require.Len(t, resp.EntryPoints, 1)
 			require.Equal(t, "/api", resp.EntryPoints[0].Path)
 			require.Equal(t, "10.0.0.9:8080", resp.EntryPoints[0].Endpoint)

--- a/pkg/workloadmanager/handlers_test.go
+++ b/pkg/workloadmanager/handlers_test.go
@@ -92,7 +92,7 @@ func readySandbox() *sandboxv1alpha1.Sandbox {
 
 func makeEntry() *sandboxEntry {
 	return &sandboxEntry{
-		Kind:      types.AgentRuntimeKind,
+		Kind:      types.SandboxKind,
 		SessionID: "sess-1",
 		Ports: []runtimev1alpha1.TargetPort{
 			{Port: 8080, Protocol: runtimev1alpha1.ProtocolTypeHTTP, PathPrefix: "/api"},
@@ -242,7 +242,11 @@ func TestServerCreateSandbox(t *testing.T) {
 				claim = &extensionsv1alpha1.SandboxClaim{ObjectMeta: metav1.ObjectMeta{Name: sb.Name, Namespace: sb.Namespace}}
 			}
 
-			resp, err := server.createSandbox(context.Background(), nil, sb, claim, makeEntry(), resultChan)
+			entry := makeEntry()
+			if tt.sandboxClaim {
+				entry.Kind = types.SandboxClaimsKind
+			}
+			resp, err := server.createSandbox(context.Background(), nil, sb, claim, entry, resultChan)
 
 			require.Equal(t, tt.expectCreateCalls, createCalls, "createSandbox call count")
 			require.Equal(t, tt.expectClaimCalls, claimCalls, "createSandboxClaim call count")
@@ -263,7 +267,11 @@ func TestServerCreateSandbox(t *testing.T) {
 			require.Equal(t, "sess-1", resp.SessionID)
 			require.Equal(t, sb.Name, resp.SandboxName)
 			require.Equal(t, string(sb.UID), resp.SandboxID)
-			require.Equal(t, types.AgentRuntimeKind, resp.Kind)
+			expectedKind := types.SandboxKind
+			if tt.sandboxClaim {
+				expectedKind = types.SandboxClaimsKind
+			}
+			require.Equal(t, expectedKind, resp.Kind)
 			require.Len(t, resp.EntryPoints, 1)
 			require.Equal(t, "/api", resp.EntryPoints[0].Path)
 			require.Equal(t, "10.0.0.9:8080", resp.EntryPoints[0].Endpoint)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
This PR adds missing unit tests to verify that the `Kind` and `SandboxNamespace` fields are correctly populated in the `CreateSandboxResponse` during sandbox creation. This addresses the reviewer feedback from PR #338 where tests were requested for the newly added fields.

**Which issue(s) this PR fixes**:
Follow-up to #338

**Special notes for your reviewer**:
This adds test assertions for `resp.Kind` and `resp.SandboxNamespace` in the sandbox creation flows within `pkg/router/session_manager_test.go` and `pkg/workloadmanager/handlers_test.go`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
