### PR TITLE
test: fix comment style and add trailing newline

### DIFF
--- a/pkg/workloadmanager/handlers_test.go
+++ b/pkg/workloadmanager/handlers_test.go
@@ -476,16 +476,14 @@ func TestHandleSandboxCreate(t *testing.T) {
 	}
 }
 
-/*
-This test verifies that the deleteSandbox handler correctly handles scenarios where the client disconnects (Context Cancellation) before the deletion operation completes.
-
-Key Points:
-
-The handler creates a new context for the K8s deletion operation using context.WithTimeout(ctx, deletionTimeout).
-This derived context remains valid even if the parent context (c.Request.Context()) is canceled.
-The test simulates a client disconnect by canceling the request context immediately after calling the deleteSandbox function.
-It verifies that the store deletion (the final cleanup step) still occurs by checking that the store's DeleteSandboxBySessionID method was called with a valid, non-canceled context.
-*/
+// This test verifies that the deleteSandbox handler correctly handles scenarios where the client disconnects (Context Cancellation) before the deletion operation completes.
+//
+// Key Points:
+//
+// The handler creates a new context for the K8s deletion operation using context.WithTimeout(ctx, deletionTimeout).
+// This derived context remains valid even if the parent context (c.Request.Context()) is canceled.
+// The test simulates a client disconnect by canceling the request context immediately after calling the deleteSandbox function.
+// It verifies that the store deletion (the final cleanup step) still occurs by checking that the store's DeleteSandboxBySessionID method was called with a valid, non-canceled context.
 func TestHandleDeleteSandbox_DetachedContext(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	fakeServer := newFakeServer()


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
This PR addresses minor reviewer feedback on `pkg/workloadmanager/handlers_test.go` from PR #321. Specifically, it:
1. Adds a missing trailing newline to the end of the file.
2. Converts a `/* ... */` block comment into idiomatic Go `//` line comments above the `TestHandleDeleteSandbox_DetachedContext` function.

**Which issue(s) this PR fixes**:
Follow-up to #321

**Special notes for your reviewer**:
These are minor formatting and stylistic cleanups requested during the review of #321.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
