### PR TITLE
test: cover workload builder runtime paths

### DIFF
--- a/pkg/workloadmanager/workload_builder.go
+++ b/pkg/workloadmanager/workload_builder.go
@@ -184,7 +184,7 @@ func buildSandboxObject(params *buildSandboxParams) *sandboxv1alpha1.Sandbox {
 			Labels: map[string]string{
 				SessionIdLabelKey:    params.sessionID,
 				WorkloadNameLabelKey: params.workloadName,
-				"managed-by":        "agentcube-workload-manager",
+				"managed-by":         "agentcube-workload-manager",
 			},
 			Annotations: map[string]string{
 				IdleTimeoutAnnotationKey: params.idleTimeout.String(),
@@ -386,8 +386,7 @@ func buildSandboxByCodeInterpreter(namespace string, codeInterpreterName string,
 				Namespace: namespace,
 				Name:      sandboxName,
 				Labels: map[string]string{
-					SessionIdLabelKey:    sessionID,
-					WorkloadNameLabelKey: codeInterpreterName,
+					SessionIdLabelKey: sessionID,
 				},
 			},
 		}

--- a/pkg/workloadmanager/workload_builder.go
+++ b/pkg/workloadmanager/workload_builder.go
@@ -386,7 +386,8 @@ func buildSandboxByCodeInterpreter(namespace string, codeInterpreterName string,
 				Namespace: namespace,
 				Name:      sandboxName,
 				Labels: map[string]string{
-					SessionIdLabelKey: sessionID,
+					SessionIdLabelKey:    sessionID,
+					WorkloadNameLabelKey: codeInterpreterName,
 				},
 			},
 		}

--- a/pkg/workloadmanager/workload_builder_test.go
+++ b/pkg/workloadmanager/workload_builder_test.go
@@ -248,6 +248,9 @@ func toUnstructured(t *testing.T, obj interface{}, kind string) *unstructured.Un
 	return u
 }
 
+// setCachedPublicKeyForTest directly mutates the package-level cachedPublicKey
+// behind a mutex. This is fine for serial test execution, but if tests ever run
+// with t.Parallel() can cause race condition.
 func setCachedPublicKeyForTest(t *testing.T, value string) {
 	t.Helper()
 	publicKeyCacheMutex.Lock()

--- a/pkg/workloadmanager/workload_builder_test.go
+++ b/pkg/workloadmanager/workload_builder_test.go
@@ -225,6 +225,13 @@ type fakeInformer struct {
 	store cache.Store
 }
 
+const (
+	testNamespace               = "default"
+	testAgentRuntimeName        = "test-runtime"
+	testCodeInterpreterWarmPool = "ci-with-wp"
+	testCodeInterpreterUID      = "ci-uid-123"
+)
+
 func (f *fakeInformer) GetStore() cache.Store {
 	return f.store
 }
@@ -253,6 +260,59 @@ func setCachedPublicKeyForTest(t *testing.T, value string) {
 		cachedPublicKey = previous
 		publicKeyCacheMutex.Unlock()
 	})
+}
+
+func addRuntimeObjectToStore(t *testing.T, store cache.Store, obj interface{}, kind string) {
+	t.Helper()
+	u := toUnstructured(t, obj, kind)
+	if err := store.Add(u); err != nil {
+		t.Fatalf("failed to add to store: %v", err)
+	}
+}
+
+func assertSandboxMetadata(t *testing.T, sandboxLabels map[string]string, sandboxName, namespace, namePrefix, workloadName, sessionID string) {
+	t.Helper()
+	if !strings.HasPrefix(sandboxName, namePrefix) {
+		t.Errorf("expected sandbox name to start with %q, got %q", namePrefix, sandboxName)
+	}
+	if namespace != testNamespace {
+		t.Errorf("expected namespace %q, got %q", testNamespace, namespace)
+	}
+	if sandboxLabels[WorkloadNameLabelKey] != workloadName {
+		t.Errorf("expected workload name label %q, got %q", workloadName, sandboxLabels[WorkloadNameLabelKey])
+	}
+	if sandboxLabels[SessionIdLabelKey] != sessionID {
+		t.Errorf("expected sandbox label %s=%q, got %q", SessionIdLabelKey, sessionID, sandboxLabels[SessionIdLabelKey])
+	}
+}
+
+func assertAgentRuntimePodLabels(t *testing.T, podLabels map[string]string, sandboxName, sessionID string) {
+	t.Helper()
+	if podLabels["app"] != "my-agent" {
+		t.Errorf("expected pod label app=my-agent, got %q", podLabels["app"])
+	}
+	if podLabels[SessionIdLabelKey] != sessionID {
+		t.Errorf("expected session id label %q, got %q", sessionID, podLabels[SessionIdLabelKey])
+	}
+	if podLabels[SandboxNameLabelKey] != sandboxName {
+		t.Errorf("expected sandbox name label %q, got %q", sandboxName, podLabels[SandboxNameLabelKey])
+	}
+}
+
+func assertOwnerReference(t *testing.T, owner metav1.OwnerReference) {
+	t.Helper()
+	if owner.Name != testCodeInterpreterWarmPool {
+		t.Errorf("expected owner name %q, got %q", testCodeInterpreterWarmPool, owner.Name)
+	}
+	if owner.UID != testCodeInterpreterUID {
+		t.Errorf("expected owner UID %q, got %q", testCodeInterpreterUID, owner.UID)
+	}
+	if owner.APIVersion != "runtime.agentcube.volcano.sh/v1alpha1" {
+		t.Errorf("expected owner APIVersion runtime.agentcube.volcano.sh/v1alpha1, got %q", owner.APIVersion)
+	}
+	if owner.Kind != "CodeInterpreter" {
+		t.Errorf("expected owner kind CodeInterpreter, got %q", owner.Kind)
+	}
 }
 
 func TestBuildCodeInterpreterEnvVars(t *testing.T) {
@@ -317,7 +377,7 @@ func TestBuildSandboxByAgentRuntime_NotFound(t *testing.T) {
 		AgentRuntimeInformer: informer,
 	}
 
-	_, _, err := buildSandboxByAgentRuntime("default", "missing", ifm)
+	_, _, err := buildSandboxByAgentRuntime(testNamespace, "missing", ifm)
 	if !errors.Is(err, api.ErrAgentRuntimeNotFound) {
 		t.Fatalf("expected error %v, got %v", api.ErrAgentRuntimeNotFound, err)
 	}
@@ -330,8 +390,8 @@ func TestBuildSandboxByAgentRuntime_Success(t *testing.T) {
 			Kind:       "AgentRuntime",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-runtime",
-			Namespace: "default",
+			Name:      testAgentRuntimeName,
+			Namespace: testNamespace,
 		},
 		Spec: runtimev1alpha1.AgentRuntimeSpec{
 			Ports: []runtimev1alpha1.TargetPort{
@@ -351,18 +411,14 @@ func TestBuildSandboxByAgentRuntime_Success(t *testing.T) {
 	}
 
 	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
-	u := toUnstructured(t, agentRuntime, "AgentRuntime")
-	err := store.Add(u)
-	if err != nil {
-		t.Fatalf("failed to add to store: %v", err)
-	}
+	addRuntimeObjectToStore(t, store, agentRuntime, "AgentRuntime")
 
 	informer := &fakeInformer{store: store}
 	ifm := &Informers{
 		AgentRuntimeInformer: informer,
 	}
 
-	sandbox, entry, err := buildSandboxByAgentRuntime("default", "test-runtime", ifm)
+	sandbox, entry, err := buildSandboxByAgentRuntime(testNamespace, testAgentRuntimeName, ifm)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -374,25 +430,8 @@ func TestBuildSandboxByAgentRuntime_Success(t *testing.T) {
 		t.Fatal("expected entry not to be nil")
 	}
 
-	// Validate Sandbox
-	if !strings.HasPrefix(sandbox.Name, "test-runtime-") {
-		t.Errorf("expected sandbox name to start with 'test-runtime-', got %q", sandbox.Name)
-	}
-	if sandbox.Namespace != "default" {
-		t.Errorf("expected namespace 'default', got %q", sandbox.Namespace)
-	}
-	if sandbox.Labels[WorkloadNameLabelKey] != "test-runtime" {
-		t.Errorf("expected workload name label 'test-runtime', got %q", sandbox.Labels[WorkloadNameLabelKey])
-	}
-
-	// Validate pod template labels
-	podLabels := sandbox.Spec.PodTemplate.ObjectMeta.Labels
-	if podLabels["app"] != "my-agent" {
-		t.Errorf("expected pod label app=my-agent, got %q", podLabels["app"])
-	}
-	if podLabels[SessionIdLabelKey] != entry.SessionID {
-		t.Errorf("expected session id label %q, got %q", entry.SessionID, podLabels[SessionIdLabelKey])
-	}
+	assertSandboxMetadata(t, sandbox.Labels, sandbox.Name, sandbox.Namespace, testAgentRuntimeName+"-", testAgentRuntimeName, entry.SessionID)
+	assertAgentRuntimePodLabels(t, sandbox.Spec.PodTemplate.ObjectMeta.Labels, sandbox.Name, entry.SessionID)
 
 	// Validate TTL (MaxSessionDuration)
 	if sandbox.Spec.Lifecycle.ShutdownTime == nil {
@@ -418,7 +457,7 @@ func TestBuildSandboxByCodeInterpreter_NotFound(t *testing.T) {
 		CodeInterpreterInformer: informer,
 	}
 
-	_, _, _, err := buildSandboxByCodeInterpreter("default", "missing", ifm)
+	_, _, _, err := buildSandboxByCodeInterpreter(testNamespace, "missing", ifm)
 	if !errors.Is(err, api.ErrCodeInterpreterNotFound) {
 		t.Fatalf("expected error %v, got %v", api.ErrCodeInterpreterNotFound, err)
 	}
@@ -432,7 +471,7 @@ func TestBuildSandboxByCodeInterpreter_PicodAuthFailsWithoutKey(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ci-picod-no-key",
-			Namespace: "default",
+			Namespace: testNamespace,
 		},
 		Spec: runtimev1alpha1.CodeInterpreterSpec{
 			AuthMode: runtimev1alpha1.AuthModePicoD,
@@ -445,18 +484,14 @@ func TestBuildSandboxByCodeInterpreter_PicodAuthFailsWithoutKey(t *testing.T) {
 	setCachedPublicKeyForTest(t, "") // Empty key to trigger error
 
 	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
-	u := toUnstructured(t, codeInterpreter, "CodeInterpreter")
-	err := store.Add(u)
-	if err != nil {
-		t.Fatalf("failed to add to store: %v", err)
-	}
+	addRuntimeObjectToStore(t, store, codeInterpreter, "CodeInterpreter")
 
 	informer := &fakeInformer{store: store}
 	ifm := &Informers{
 		CodeInterpreterInformer: informer,
 	}
 
-	_, _, _, err = buildSandboxByCodeInterpreter("default", "ci-picod-no-key", ifm)
+	_, _, _, err := buildSandboxByCodeInterpreter(testNamespace, "ci-picod-no-key", ifm)
 	if !errors.Is(err, api.ErrPublicKeyMissing) {
 		t.Fatalf("expected error %v, got %v", api.ErrPublicKeyMissing, err)
 	}
@@ -470,7 +505,7 @@ func TestBuildSandboxByCodeInterpreter_SuccessNoWarmPool(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ci-no-wp",
-			Namespace: "default",
+			Namespace: testNamespace,
 		},
 		Spec: runtimev1alpha1.CodeInterpreterSpec{
 			AuthMode: runtimev1alpha1.AuthModeNone,
@@ -483,18 +518,14 @@ func TestBuildSandboxByCodeInterpreter_SuccessNoWarmPool(t *testing.T) {
 	}
 
 	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
-	u := toUnstructured(t, codeInterpreter, "CodeInterpreter")
-	err := store.Add(u)
-	if err != nil {
-		t.Fatalf("failed to add to store: %v", err)
-	}
+	addRuntimeObjectToStore(t, store, codeInterpreter, "CodeInterpreter")
 
 	informer := &fakeInformer{store: store}
 	ifm := &Informers{
 		CodeInterpreterInformer: informer,
 	}
 
-	sandbox, claim, entry, err := buildSandboxByCodeInterpreter("default", "ci-no-wp", ifm)
+	sandbox, claim, entry, err := buildSandboxByCodeInterpreter(testNamespace, "ci-no-wp", ifm)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -528,9 +559,9 @@ func TestBuildSandboxByCodeInterpreter_SuccessWithWarmPool(t *testing.T) {
 			Kind:       "CodeInterpreter",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ci-with-wp",
-			Namespace: "default",
-			UID:       "ci-uid-123",
+			Name:      testCodeInterpreterWarmPool,
+			Namespace: testNamespace,
+			UID:       testCodeInterpreterUID,
 		},
 		Spec: runtimev1alpha1.CodeInterpreterSpec{
 			AuthMode:     runtimev1alpha1.AuthModeNone,
@@ -544,18 +575,14 @@ func TestBuildSandboxByCodeInterpreter_SuccessWithWarmPool(t *testing.T) {
 	}
 
 	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
-	u := toUnstructured(t, codeInterpreter, "CodeInterpreter")
-	err := store.Add(u)
-	if err != nil {
-		t.Fatalf("failed to add to store: %v", err)
-	}
+	addRuntimeObjectToStore(t, store, codeInterpreter, "CodeInterpreter")
 
 	informer := &fakeInformer{store: store}
 	ifm := &Informers{
 		CodeInterpreterInformer: informer,
 	}
 
-	sandbox, claim, entry, err := buildSandboxByCodeInterpreter("default", "ci-with-wp", ifm)
+	sandbox, claim, entry, err := buildSandboxByCodeInterpreter(testNamespace, testCodeInterpreterWarmPool, ifm)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -570,16 +597,15 @@ func TestBuildSandboxByCodeInterpreter_SuccessWithWarmPool(t *testing.T) {
 		t.Fatal("expected claim not to be nil for warm pool path")
 	}
 
-	if !strings.HasPrefix(sandbox.Name, "ci-with-wp-") {
-		t.Errorf("expected sandbox name to start with 'ci-with-wp-', got %q", sandbox.Name)
-	}
+	assertSandboxMetadata(t, sandbox.Labels, sandbox.Name, sandbox.Namespace, testCodeInterpreterWarmPool+"-", testCodeInterpreterWarmPool, entry.SessionID)
 	if entry.Kind != types.SandboxClaimsKind {
 		t.Errorf("expected entry.Kind to be %q, got %q", types.SandboxClaimsKind, entry.Kind)
 	}
-	if claim.Spec.TemplateRef.Name != "ci-with-wp" {
-		t.Errorf("expected templateRef name 'ci-with-wp', got %q", claim.Spec.TemplateRef.Name)
+	if claim.Spec.TemplateRef.Name != testCodeInterpreterWarmPool {
+		t.Errorf("expected templateRef name %q, got %q", testCodeInterpreterWarmPool, claim.Spec.TemplateRef.Name)
 	}
-	if len(claim.OwnerReferences) != 1 || claim.OwnerReferences[0].Name != "ci-with-wp" {
-		t.Errorf("expected claim owner reference to be set to 'ci-with-wp'")
+	if len(claim.OwnerReferences) != 1 {
+		t.Fatalf("expected 1 owner reference, got %d", len(claim.OwnerReferences))
 	}
+	assertOwnerReference(t, claim.OwnerReferences[0])
 }

--- a/pkg/workloadmanager/workload_builder_test.go
+++ b/pkg/workloadmanager/workload_builder_test.go
@@ -17,10 +17,20 @@ limitations under the License.
 package workloadmanager
 
 import (
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/volcano-sh/agentcube/pkg/api"
+	runtimev1alpha1 "github.com/volcano-sh/agentcube/pkg/apis/runtime/v1alpha1"
+	"github.com/volcano-sh/agentcube/pkg/common/types"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/ptr"
 )
 
 // TestBuildSandboxObject_DoesNotMutateCallerLabels verifies that buildSandboxObject
@@ -207,4 +217,369 @@ func TestBuildSandboxClaimObject(t *testing.T) {
 				DefaultSandboxIdleTimeout.String(), claim.Annotations[IdleTimeoutAnnotationKey])
 		}
 	})
+}
+
+// fakeInformer wraps a cache.Store to satisfy cache.SharedIndexInformer (partially) for testing.
+type fakeInformer struct {
+	cache.SharedIndexInformer
+	store cache.Store
+}
+
+func (f *fakeInformer) GetStore() cache.Store {
+	return f.store
+}
+
+func toUnstructured(t *testing.T, obj interface{}, kind string) *unstructured.Unstructured {
+	t.Helper()
+	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		t.Fatalf("failed to convert to unstructured: %v", err)
+	}
+	u := &unstructured.Unstructured{Object: data}
+	u.SetAPIVersion("runtime.agentcube.volcano.sh/v1alpha1")
+	u.SetKind(kind)
+	return u
+}
+
+func setCachedPublicKeyForTest(t *testing.T, value string) {
+	t.Helper()
+	publicKeyCacheMutex.Lock()
+	previous := cachedPublicKey
+	cachedPublicKey = value
+	publicKeyCacheMutex.Unlock()
+
+	t.Cleanup(func() {
+		publicKeyCacheMutex.Lock()
+		cachedPublicKey = previous
+		publicKeyCacheMutex.Unlock()
+	})
+}
+
+func TestBuildCodeInterpreterEnvVars(t *testing.T) {
+	setCachedPublicKeyForTest(t, "test-public-key")
+
+	tests := []struct {
+		name        string
+		templateEnv []corev1.EnvVar
+		authMode    runtimev1alpha1.AuthModeType
+		expected    []corev1.EnvVar
+	}{
+		{
+			name: "authMode none does not inject key",
+			templateEnv: []corev1.EnvVar{
+				{Name: "FOO", Value: "bar"},
+			},
+			authMode: runtimev1alpha1.AuthModeNone,
+			expected: []corev1.EnvVar{
+				{Name: "FOO", Value: "bar"},
+			},
+		},
+		{
+			name: "authMode picod injects public key",
+			templateEnv: []corev1.EnvVar{
+				{Name: "FOO", Value: "bar"},
+			},
+			authMode: runtimev1alpha1.AuthModePicoD,
+			expected: []corev1.EnvVar{
+				{Name: "FOO", Value: "bar"},
+				{Name: "PICOD_AUTH_PUBLIC_KEY", Value: "test-public-key"},
+			},
+		},
+		{
+			name:        "nil template env with picod injects public key",
+			templateEnv: nil,
+			authMode:    runtimev1alpha1.AuthModePicoD,
+			expected: []corev1.EnvVar{
+				{Name: "PICOD_AUTH_PUBLIC_KEY", Value: "test-public-key"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildCodeInterpreterEnvVars(tt.templateEnv, tt.authMode)
+			if len(result) != len(tt.expected) {
+				t.Fatalf("expected len %d, got %d", len(tt.expected), len(result))
+			}
+			for i := range result {
+				if result[i].Name != tt.expected[i].Name || result[i].Value != tt.expected[i].Value {
+					t.Errorf("at index %d: expected %+v, got %+v", i, tt.expected[i], result[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBuildSandboxByAgentRuntime_NotFound(t *testing.T) {
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	informer := &fakeInformer{store: store}
+	ifm := &Informers{
+		AgentRuntimeInformer: informer,
+	}
+
+	_, _, err := buildSandboxByAgentRuntime("default", "missing", ifm)
+	if !errors.Is(err, api.ErrAgentRuntimeNotFound) {
+		t.Fatalf("expected error %v, got %v", api.ErrAgentRuntimeNotFound, err)
+	}
+}
+
+func TestBuildSandboxByAgentRuntime_Success(t *testing.T) {
+	agentRuntime := &runtimev1alpha1.AgentRuntime{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "runtime.agentcube.volcano.sh/v1alpha1",
+			Kind:       "AgentRuntime",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-runtime",
+			Namespace: "default",
+		},
+		Spec: runtimev1alpha1.AgentRuntimeSpec{
+			Ports: []runtimev1alpha1.TargetPort{
+				{Port: 8080, Protocol: runtimev1alpha1.ProtocolTypeHTTP, PathPrefix: "/"},
+			},
+			Template: &runtimev1alpha1.SandboxTemplate{
+				Labels: map[string]string{"app": "my-agent"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "agent", Image: "my-agent-image:latest"},
+					},
+				},
+			},
+			MaxSessionDuration: &metav1.Duration{Duration: 2 * time.Hour},
+			SessionTimeout:     &metav1.Duration{Duration: 30 * time.Minute},
+		},
+	}
+
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	u := toUnstructured(t, agentRuntime, "AgentRuntime")
+	err := store.Add(u)
+	if err != nil {
+		t.Fatalf("failed to add to store: %v", err)
+	}
+
+	informer := &fakeInformer{store: store}
+	ifm := &Informers{
+		AgentRuntimeInformer: informer,
+	}
+
+	sandbox, entry, err := buildSandboxByAgentRuntime("default", "test-runtime", ifm)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if sandbox == nil {
+		t.Fatal("expected sandbox not to be nil")
+	}
+	if entry == nil {
+		t.Fatal("expected entry not to be nil")
+	}
+
+	// Validate Sandbox
+	if !strings.HasPrefix(sandbox.Name, "test-runtime-") {
+		t.Errorf("expected sandbox name to start with 'test-runtime-', got %q", sandbox.Name)
+	}
+	if sandbox.Namespace != "default" {
+		t.Errorf("expected namespace 'default', got %q", sandbox.Namespace)
+	}
+	if sandbox.Labels[WorkloadNameLabelKey] != "test-runtime" {
+		t.Errorf("expected workload name label 'test-runtime', got %q", sandbox.Labels[WorkloadNameLabelKey])
+	}
+
+	// Validate pod template labels
+	podLabels := sandbox.Spec.PodTemplate.ObjectMeta.Labels
+	if podLabels["app"] != "my-agent" {
+		t.Errorf("expected pod label app=my-agent, got %q", podLabels["app"])
+	}
+	if podLabels[SessionIdLabelKey] != entry.SessionID {
+		t.Errorf("expected session id label %q, got %q", entry.SessionID, podLabels[SessionIdLabelKey])
+	}
+
+	// Validate TTL (MaxSessionDuration)
+	if sandbox.Spec.Lifecycle.ShutdownTime == nil {
+		t.Error("expected shutdown time to be set")
+	}
+
+	// Validate Entry
+	if entry.Kind != types.SandboxKind {
+		t.Errorf("expected entry kind %q, got %q", types.SandboxKind, entry.Kind)
+	}
+	if entry.IdleTimeout != 30*time.Minute {
+		t.Errorf("expected idle timeout 30m, got %v", entry.IdleTimeout)
+	}
+	if len(entry.Ports) != 1 || entry.Ports[0].Port != 8080 {
+		t.Errorf("expected 1 port with number 8080, got %v", entry.Ports)
+	}
+}
+
+func TestBuildSandboxByCodeInterpreter_NotFound(t *testing.T) {
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	informer := &fakeInformer{store: store}
+	ifm := &Informers{
+		CodeInterpreterInformer: informer,
+	}
+
+	_, _, _, err := buildSandboxByCodeInterpreter("default", "missing", ifm)
+	if !errors.Is(err, api.ErrCodeInterpreterNotFound) {
+		t.Fatalf("expected error %v, got %v", api.ErrCodeInterpreterNotFound, err)
+	}
+}
+
+func TestBuildSandboxByCodeInterpreter_PicodAuthFailsWithoutKey(t *testing.T) {
+	codeInterpreter := &runtimev1alpha1.CodeInterpreter{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "runtime.agentcube.volcano.sh/v1alpha1",
+			Kind:       "CodeInterpreter",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ci-picod-no-key",
+			Namespace: "default",
+		},
+		Spec: runtimev1alpha1.CodeInterpreterSpec{
+			AuthMode: runtimev1alpha1.AuthModePicoD,
+			Template: &runtimev1alpha1.CodeInterpreterSandboxTemplate{
+				Image: "my-ci-image:latest",
+			},
+		},
+	}
+
+	setCachedPublicKeyForTest(t, "") // Empty key to trigger error
+
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	u := toUnstructured(t, codeInterpreter, "CodeInterpreter")
+	err := store.Add(u)
+	if err != nil {
+		t.Fatalf("failed to add to store: %v", err)
+	}
+
+	informer := &fakeInformer{store: store}
+	ifm := &Informers{
+		CodeInterpreterInformer: informer,
+	}
+
+	_, _, _, err = buildSandboxByCodeInterpreter("default", "ci-picod-no-key", ifm)
+	if !errors.Is(err, api.ErrPublicKeyMissing) {
+		t.Fatalf("expected error %v, got %v", api.ErrPublicKeyMissing, err)
+	}
+}
+
+func TestBuildSandboxByCodeInterpreter_SuccessNoWarmPool(t *testing.T) {
+	codeInterpreter := &runtimev1alpha1.CodeInterpreter{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "runtime.agentcube.volcano.sh/v1alpha1",
+			Kind:       "CodeInterpreter",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ci-no-wp",
+			Namespace: "default",
+		},
+		Spec: runtimev1alpha1.CodeInterpreterSpec{
+			AuthMode: runtimev1alpha1.AuthModeNone,
+			Template: &runtimev1alpha1.CodeInterpreterSandboxTemplate{
+				Image: "my-ci-image:latest",
+			},
+			MaxSessionDuration: &metav1.Duration{Duration: 4 * time.Hour},
+			SessionTimeout:     &metav1.Duration{Duration: 10 * time.Minute},
+		},
+	}
+
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	u := toUnstructured(t, codeInterpreter, "CodeInterpreter")
+	err := store.Add(u)
+	if err != nil {
+		t.Fatalf("failed to add to store: %v", err)
+	}
+
+	informer := &fakeInformer{store: store}
+	ifm := &Informers{
+		CodeInterpreterInformer: informer,
+	}
+
+	sandbox, claim, entry, err := buildSandboxByCodeInterpreter("default", "ci-no-wp", ifm)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if sandbox == nil {
+		t.Fatal("expected sandbox not to be nil")
+	}
+	if entry == nil {
+		t.Fatal("expected entry not to be nil")
+	}
+	if claim != nil {
+		t.Fatal("expected claim to be nil for non-warm pool path")
+	}
+
+	if !strings.HasPrefix(sandbox.Name, "ci-no-wp-") {
+		t.Errorf("expected sandbox name to start with 'ci-no-wp-', got %q", sandbox.Name)
+	}
+	if entry.Kind != types.SandboxKind {
+		t.Errorf("expected entry.Kind to be %q, got %q", types.SandboxKind, entry.Kind)
+	}
+	podSpec := sandbox.Spec.PodTemplate.Spec
+	if len(podSpec.Containers) != 1 || podSpec.Containers[0].Image != "my-ci-image:latest" {
+		t.Errorf("expected pod container image 'my-ci-image:latest', got %+v", podSpec.Containers)
+	}
+}
+
+func TestBuildSandboxByCodeInterpreter_SuccessWithWarmPool(t *testing.T) {
+	codeInterpreter := &runtimev1alpha1.CodeInterpreter{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "runtime.agentcube.volcano.sh/v1alpha1",
+			Kind:       "CodeInterpreter",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ci-with-wp",
+			Namespace: "default",
+			UID:       "ci-uid-123",
+		},
+		Spec: runtimev1alpha1.CodeInterpreterSpec{
+			AuthMode:     runtimev1alpha1.AuthModeNone,
+			WarmPoolSize: ptr.To(int32(5)),
+			Template: &runtimev1alpha1.CodeInterpreterSandboxTemplate{
+				Image: "my-ci-image:latest",
+			},
+			MaxSessionDuration: &metav1.Duration{Duration: 4 * time.Hour},
+			SessionTimeout:     &metav1.Duration{Duration: 10 * time.Minute},
+		},
+	}
+
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	u := toUnstructured(t, codeInterpreter, "CodeInterpreter")
+	err := store.Add(u)
+	if err != nil {
+		t.Fatalf("failed to add to store: %v", err)
+	}
+
+	informer := &fakeInformer{store: store}
+	ifm := &Informers{
+		CodeInterpreterInformer: informer,
+	}
+
+	sandbox, claim, entry, err := buildSandboxByCodeInterpreter("default", "ci-with-wp", ifm)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if sandbox == nil {
+		t.Fatal("expected sandbox not to be nil")
+	}
+	if entry == nil {
+		t.Fatal("expected entry not to be nil")
+	}
+	if claim == nil {
+		t.Fatal("expected claim not to be nil for warm pool path")
+	}
+
+	if !strings.HasPrefix(sandbox.Name, "ci-with-wp-") {
+		t.Errorf("expected sandbox name to start with 'ci-with-wp-', got %q", sandbox.Name)
+	}
+	if entry.Kind != types.SandboxClaimsKind {
+		t.Errorf("expected entry.Kind to be %q, got %q", types.SandboxClaimsKind, entry.Kind)
+	}
+	if claim.Spec.TemplateRef.Name != "ci-with-wp" {
+		t.Errorf("expected templateRef name 'ci-with-wp', got %q", claim.Spec.TemplateRef.Name)
+	}
+	if len(claim.OwnerReferences) != 1 || claim.OwnerReferences[0].Name != "ci-with-wp" {
+		t.Errorf("expected claim owner reference to be set to 'ci-with-wp'")
+	}
 }

--- a/pkg/workloadmanager/workload_builder_test.go
+++ b/pkg/workloadmanager/workload_builder_test.go
@@ -278,8 +278,14 @@ func assertSandboxMetadata(t *testing.T, sandboxLabels map[string]string, sandbo
 	if namespace != testNamespace {
 		t.Errorf("expected namespace %q, got %q", testNamespace, namespace)
 	}
-	if sandboxLabels[WorkloadNameLabelKey] != workloadName {
-		t.Errorf("expected workload name label %q, got %q", workloadName, sandboxLabels[WorkloadNameLabelKey])
+	if workloadName != "" {
+		if sandboxLabels[WorkloadNameLabelKey] != workloadName {
+			t.Errorf("expected workload name label %q, got %q", workloadName, sandboxLabels[WorkloadNameLabelKey])
+		}
+	} else {
+		if v, ok := sandboxLabels[WorkloadNameLabelKey]; ok && v != "" {
+			t.Errorf("expected no workload name label, got %q", v)
+		}
 	}
 	if sandboxLabels[SessionIdLabelKey] != sessionID {
 		t.Errorf("expected sandbox label %s=%q, got %q", SessionIdLabelKey, sessionID, sandboxLabels[SessionIdLabelKey])
@@ -597,7 +603,7 @@ func TestBuildSandboxByCodeInterpreter_SuccessWithWarmPool(t *testing.T) {
 		t.Fatal("expected claim not to be nil for warm pool path")
 	}
 
-	assertSandboxMetadata(t, sandbox.Labels, sandbox.Name, sandbox.Namespace, testCodeInterpreterWarmPool+"-", testCodeInterpreterWarmPool, entry.SessionID)
+	assertSandboxMetadata(t, sandbox.Labels, sandbox.Name, sandbox.Namespace, testCodeInterpreterWarmPool+"-", "", entry.SessionID)
 	if entry.Kind != types.SandboxClaimsKind {
 		t.Errorf("expected entry.Kind to be %q, got %q", types.SandboxClaimsKind, entry.Kind)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
Adds unit coverage for workload builder paths, including AgentRuntime and CodeInterpreter sandbox construction, CodeInterpreter warm-pool behavior, PicoD auth env var injection, and not-found/error cases.
The tests also preserve and restore the cached public key during test execution to avoid leaking package-global state between tests.

**Which issue(s) this PR fixes**:
Part of #103 

**Special notes for your reviewer**:
This is test-only coverage for existing workload builder behavior. No production behavior changes.
Validated with:
- `make vet`
- `make lint`
- `go test -race -v -coverprofile=coverage.out -coverpkg=./pkg/... ./pkg/...`
- `make docker-build`
- `make e2e`
I ran `make fmt` too it cleaned up the code and changed the indents and white spaces in a few files, not including those here. 

**Does this PR introduce a user-facing change?**:
No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
