### PR TITLE
Fix typo in store_valkey.go: stingsSliceResults to stringSliceResults

### DIFF
--- a/pkg/store/store_valkey.go
+++ b/pkg/store/store_valkey.go
@@ -111,17 +111,17 @@ func (vs *valkeyStore) loadSandboxesBySessionIDs(ctx context.Context, sessionIDs
 		sessionIDKeys = append(sessionIDKeys, vs.sessionKey(sessionID))
 	}
 	// MGet should in same slot
-	stingSliceResults, err := vs.cli.Do(ctx, vs.cli.B().Mget().Key(sessionIDKeys...).Build()).AsStrSlice()
+	stringSliceResults, err := vs.cli.Do(ctx, vs.cli.B().Mget().Key(sessionIDKeys...).Build()).AsStrSlice()
 	if err != nil {
 		return nil, fmt.Errorf("loadSandboxesBySessionIDs: Valkey MGet sandboxes failed: %w", err)
 	}
 
-	if len(stingSliceResults) > len(sessionIDKeys) {
-		return nil, fmt.Errorf("unexpected MGet result size: %d, param size: %d", len(stingSliceResults), len(sessionIDKeys))
+	if len(stringSliceResults) > len(sessionIDKeys) {
+		return nil, fmt.Errorf("unexpected MGet result size: %d, param size: %d", len(stringSliceResults), len(sessionIDKeys))
 	}
 
-	sandboxResults := make([]*types.SandboxInfo, 0, len(stingSliceResults))
-	for i, sandboxObjString := range stingSliceResults {
+	sandboxResults := make([]*types.SandboxInfo, 0, len(stringSliceResults))
+	for i, sandboxObjString := range stringSliceResults {
 		if len(sandboxObjString) == 0 {
 			// sandboxObjString is empty while sessionKey not exist, ignore
 			continue


### PR DESCRIPTION
…alkey.go

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->
/kind cleanup
**What this PR does / why we need it**:
Fix typo `stingsSliceResults` to `stringSliceResults` in store_valkey.go.
**Which issue(s) this PR fixes**:
Fixes #345 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
