### PR TITLE
perf(store): optimize redis session last activity check

### DIFF
--- a/pkg/store/store_redis.go
+++ b/pkg/store/store_redis.go
@@ -297,6 +297,11 @@ func (rs *redisStore) Close() error {
 	return rs.cli.Close()
 }
 
+// updateSessionLastActivityScript atomically checks if the session key exists
+// and updates its last activity time in the sorted-set index.
+// It uses EXISTS to verify presence rather than GET (which retrieved the
+// actual value in older implementations). This saves data transfer overhead,
+// if in future the value is required GET can be used instead.
 var updateSessionLastActivityScript = redisv9.NewScript(`
 if redis.call("EXISTS", KEYS[1]) == 1 then
 	redis.call("ZADD", KEYS[2], ARGV[2], ARGV[1])

--- a/pkg/store/store_redis.go
+++ b/pkg/store/store_redis.go
@@ -297,6 +297,15 @@ func (rs *redisStore) Close() error {
 	return rs.cli.Close()
 }
 
+var updateSessionLastActivityScript = redisv9.NewScript(`
+if redis.call("EXISTS", KEYS[1]) == 1 then
+	redis.call("ZADD", KEYS[2], ARGV[2], ARGV[1])
+	return 1
+else
+	return 0
+end
+`)
+
 // UpdateSessionLastActivity updates the last-activity index for the given session.
 func (rs *redisStore) UpdateSessionLastActivity(ctx context.Context, sessionID string, at time.Time) error {
 	if sessionID == "" {
@@ -306,21 +315,14 @@ func (rs *redisStore) UpdateSessionLastActivity(ctx context.Context, sessionID s
 		at = time.Now()
 	}
 
-	// Ensure the sandbox mapping exists; otherwise treat as not found.
 	sessionKey := rs.sessionKey(sessionID)
-	_, err := rs.cli.Get(ctx, sessionKey).Result()
-	if errors.Is(err, redisv9.Nil) {
-		return ErrNotFound
-	}
+	res, err := updateSessionLastActivityScript.Run(ctx, rs.cli, []string{sessionKey, rs.lastActivityIndexKey}, sessionID, at.Unix()).Int64()
 	if err != nil {
-		return fmt.Errorf("UpdateSessionLastActivity: get mapping for sessionID %s: %w", sessionID, err)
+		return fmt.Errorf("UpdateSessionLastActivity: script execution failed: %w", err)
 	}
 
-	if _, err := rs.cli.ZAdd(ctx, rs.lastActivityIndexKey, redisv9.Z{
-		Score:  float64(at.Unix()),
-		Member: sessionID,
-	}).Result(); err != nil {
-		return fmt.Errorf("UpdateSessionLastActivity: ZAdd: %w", err)
+	if res == 0 {
+		return ErrNotFound
 	}
 
 	return nil

--- a/pkg/store/store_redis.go
+++ b/pkg/store/store_redis.go
@@ -323,7 +323,7 @@ func (rs *redisStore) UpdateSessionLastActivity(ctx context.Context, sessionID s
 	sessionKey := rs.sessionKey(sessionID)
 	res, err := updateSessionLastActivityScript.Run(ctx, rs.cli, []string{sessionKey, rs.lastActivityIndexKey}, sessionID, at.Unix()).Int64()
 	if err != nil {
-		return fmt.Errorf("UpdateSessionLastActivity: script execution failed: %w", err)
+		return fmt.Errorf("UpdateSessionLastActivity: script execution failed for sessionID %s: %w", sessionID, err)
 	}
 
 	if res == 0 {

--- a/pkg/store/store_redis_test.go
+++ b/pkg/store/store_redis_test.go
@@ -343,4 +343,13 @@ func TestUpdateSandboxLastActivity(t *testing.T) {
 	if int64(score) != newLastActivity.Unix() {
 		t.Fatalf("unexpected lastActivity score after update: got %v, want %v", score, newLastActivity.Unix())
 	}
+
+	// session not exists
+	err = c.UpdateSessionLastActivity(ctx, "sess-1-not-exist", newLastActivity)
+	if err == nil {
+		t.Fatalf("expected error for non-existent session")
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
This PR optimizes Redis session tracking inside `UpdateSessionLastActivity` for performance and atomicity.
Previously, a full `GET` fetched the entire `SandboxInfo` JSON payload solely to check existence, introducing severe serialization and network overhead under concurrent routing

- Replaced sequential round-trips with an atomic Redis Lua script performing `EXISTS` and `ZADD` in a single network round-trip. This prevents race conditions.
-  Replaced ambiguous error strings with the standard `ErrNotFound` sentinel when a session is missing.
- Added coverage verifying missing-session error propagation.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
