### PR TITLE
run go fmt and enable gofmt linter in CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,3 +53,4 @@ linters:
     - unparam
     - goconst
     - gocyclo
+    - gofmt

--- a/pkg/agentd/agentd.go
+++ b/pkg/agentd/agentd.go
@@ -54,7 +54,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 
 		expirationTime := lastActivity.Add(workloadmanager.DefaultSandboxIdleTimeout)
-		
+
 		// Use custom idle timeout if defined.
 		// Ignore invalid, zero, or negative values and fall back to the default timeout.
 		if timeoutStr, exists := sandbox.Annotations[workloadmanager.IdleTimeoutAnnotationKey]; exists && timeoutStr != "" {

--- a/pkg/agentd/agentd_test.go
+++ b/pkg/agentd/agentd_test.go
@@ -418,7 +418,6 @@ func TestReconciler_Reconcile_ErrorPaths(t *testing.T) {
 	}
 }
 
-
 // TestReconciler_Reconcile_EdgeCases tests edge cases
 func TestReconciler_Reconcile_EdgeCases(t *testing.T) {
 	testScheme := setupTestScheme()

--- a/pkg/picod/auth_test.go
+++ b/pkg/picod/auth_test.go
@@ -301,5 +301,3 @@ func TestAuthMiddleware_TokenValidation(t *testing.T) {
 		})
 	}
 }
-
-

--- a/pkg/picod/files_test.go
+++ b/pkg/picod/files_test.go
@@ -316,4 +316,3 @@ func TestMkdirSafe(t *testing.T) {
 		assert.True(t, os.IsNotExist(statErr), "directory should not exist outside workspace")
 	})
 }
-

--- a/pkg/workloadmanager/auth_test.go
+++ b/pkg/workloadmanager/auth_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	testToken = "test-token"
+	testToken          = "test-token"
 	testServiceAccount = "system:serviceaccount:default:test-sa"
 )
 
@@ -85,7 +85,7 @@ func TestAuthMiddleware_InvalidHeaderFormat(t *testing.T) {
 			name:             "no Bearer prefix",
 			header:           "token123",
 			expectedBodyPart: "Invalid authorization header format",
- 		},
+		},
 		{
 			name:             "wrong prefix",
 			header:           "Basic token123",

--- a/pkg/workloadmanager/client_cache_test.go
+++ b/pkg/workloadmanager/client_cache_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	jwtHeader = `{"alg":"HS256","typ":"JWT"}`
+	jwtHeader    = `{"alg":"HS256","typ":"JWT"}`
 	testCacheKey = "default:test-sa"
 )
 

--- a/pkg/workloadmanager/informers_test.go
+++ b/pkg/workloadmanager/informers_test.go
@@ -32,7 +32,7 @@ type neverSyncedInformer struct {
 	cache.SharedIndexInformer
 }
 
-func (n *neverSyncedInformer) HasSynced() bool           { return false }
+func (n *neverSyncedInformer) HasSynced() bool            { return false }
 func (n *neverSyncedInformer) Run(stopCh <-chan struct{}) { <-stopCh }
 
 // alwaysSyncedInformer is a cache.SharedIndexInformer whose HasSynced always returns true.
@@ -40,7 +40,7 @@ type alwaysSyncedInformer struct {
 	cache.SharedIndexInformer
 }
 
-func (a *alwaysSyncedInformer) HasSynced() bool           { return true }
+func (a *alwaysSyncedInformer) HasSynced() bool            { return true }
 func (a *alwaysSyncedInformer) Run(stopCh <-chan struct{}) { <-stopCh }
 
 // runCanceled starts RunAndWaitForCacheSync in a goroutine, cancels the context
@@ -69,10 +69,10 @@ func TestRunAndWaitForCacheSync_ContextCancellation(t *testing.T) {
 	always := func() cache.SharedIndexInformer { return &alwaysSyncedInformer{} }
 
 	tests := []struct {
-		name                    string
-		agentRuntime            cache.SharedIndexInformer
-		codeInterpreter         cache.SharedIndexInformer
-		pod                     cache.SharedIndexInformer
+		name            string
+		agentRuntime    cache.SharedIndexInformer
+		codeInterpreter cache.SharedIndexInformer
+		pod             cache.SharedIndexInformer
 	}{
 		{
 			name:            "AgentRuntimeInformer never syncs",

--- a/pkg/workloadmanager/sandbox_helper_test.go
+++ b/pkg/workloadmanager/sandbox_helper_test.go
@@ -346,7 +346,7 @@ func TestGetSandboxStatus_TableDriven(t *testing.T) {
 					},
 				},
 			},
-			expected:    "ready",
+			expected: "ready",
 		},
 		{
 			name: "ready condition false without reason",
@@ -360,7 +360,7 @@ func TestGetSandboxStatus_TableDriven(t *testing.T) {
 					},
 				},
 			},
-			expected:    "not-ready",
+			expected: "not-ready",
 		},
 		{
 			name: "ready condition false with reason is not-ready",
@@ -376,7 +376,7 @@ func TestGetSandboxStatus_TableDriven(t *testing.T) {
 					},
 				},
 			},
-			expected:    "not-ready",
+			expected: "not-ready",
 		},
 		{
 			name: "ready condition unknown",
@@ -390,7 +390,7 @@ func TestGetSandboxStatus_TableDriven(t *testing.T) {
 					},
 				},
 			},
-			expected:    "not-ready",
+			expected: "not-ready",
 		},
 		{
 			name: "no conditions",
@@ -399,7 +399,7 @@ func TestGetSandboxStatus_TableDriven(t *testing.T) {
 					Conditions: []metav1.Condition{},
 				},
 			},
-			expected:    "not-ready",
+			expected: "not-ready",
 		},
 		{
 			name: "nil conditions",
@@ -408,7 +408,7 @@ func TestGetSandboxStatus_TableDriven(t *testing.T) {
 					Conditions: nil,
 				},
 			},
-			expected:    "not-ready",
+			expected: "not-ready",
 		},
 		{
 			name: "other condition type",
@@ -422,7 +422,7 @@ func TestGetSandboxStatus_TableDriven(t *testing.T) {
 					},
 				},
 			},
-			expected:    "not-ready",
+			expected: "not-ready",
 		},
 		{
 			name: "multiple conditions with ready true",
@@ -440,7 +440,7 @@ func TestGetSandboxStatus_TableDriven(t *testing.T) {
 					},
 				},
 			},
-			expected:    "ready",
+			expected: "ready",
 		},
 	}
 

--- a/pkg/workloadmanager/workload_builder.go
+++ b/pkg/workloadmanager/workload_builder.go
@@ -184,7 +184,7 @@ func buildSandboxObject(params *buildSandboxParams) *sandboxv1alpha1.Sandbox {
 			Labels: map[string]string{
 				SessionIdLabelKey:    params.sessionID,
 				WorkloadNameLabelKey: params.workloadName,
-				"managed-by":        "agentcube-workload-manager",
+				"managed-by":         "agentcube-workload-manager",
 			},
 			Annotations: map[string]string{
 				IdleTimeoutAnnotationKey: params.idleTimeout.String(),


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
This PR runs `go fmt ./...` to clean up unformatted Go files across the `agentd`, `picod`, `store`, and `workloadmanager` packages.

To prevent future formatting regressions enable the `gofmt` linter in `.golangci.yml` so that correct code formatting is automatically enforced by golangci-lint in CI for all future pull requests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
