### PR TITLE
refactor(workloadmanager): swap unstructured lookups for typed informers and listers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # Copy source code
 COPY cmd/ cmd/
 COPY pkg/ pkg/
+COPY client-go/ client-go/
 
 # Build with dynamic architecture support and caching
 # Supports amd64, arm64, arm/v7, etc.

--- a/pkg/workloadmanager/informers.go
+++ b/pkg/workloadmanager/informers.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"time"
 
+	cubeinformers "github.com/volcano-sh/agentcube/client-go/informers/externalversions"
+	cubelisters "github.com/volcano-sh/agentcube/client-go/listers/runtime/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
@@ -50,18 +52,27 @@ var (
 )
 
 type Informers struct {
+	AgentRuntimeLister      cubelisters.AgentRuntimeLister
+	CodeInterpreterLister   cubelisters.CodeInterpreterLister
 	AgentRuntimeInformer    cache.SharedIndexInformer
 	CodeInterpreterInformer cache.SharedIndexInformer
 	PodInformer             cache.SharedIndexInformer
 	informerFactory         informers.SharedInformerFactory
+	cubeInformerFactory     cubeinformers.SharedInformerFactory
 }
 
 func NewInformers(k8sClient *K8sClient) *Informers {
+	agentRuntimeInformer := k8sClient.cubeInformerFactory.Runtime().V1alpha1().AgentRuntimes()
+	codeInterpreterInformer := k8sClient.cubeInformerFactory.Runtime().V1alpha1().CodeInterpreters()
+
 	return &Informers{
-		AgentRuntimeInformer:    k8sClient.dynamicInformer.ForResource(AgentRuntimeGVR).Informer(),
-		CodeInterpreterInformer: k8sClient.dynamicInformer.ForResource(CodeInterpreterGVR).Informer(),
+		AgentRuntimeLister:      agentRuntimeInformer.Lister(),
+		CodeInterpreterLister:   codeInterpreterInformer.Lister(),
+		AgentRuntimeInformer:    agentRuntimeInformer.Informer(),
+		CodeInterpreterInformer: codeInterpreterInformer.Informer(),
 		PodInformer:             k8sClient.podInformer,
 		informerFactory:         k8sClient.informerFactory,
+		cubeInformerFactory:     k8sClient.cubeInformerFactory,
 	}
 }
 
@@ -77,8 +88,7 @@ func (ifm *Informers) RunAndWaitForCacheSync(ctx context.Context) error {
 
 func (ifm *Informers) run(stopCh <-chan struct{}) {
 	ifm.informerFactory.Start(stopCh)
-	go ifm.AgentRuntimeInformer.Run(stopCh)
-	go ifm.CodeInterpreterInformer.Run(stopCh)
+	ifm.cubeInformerFactory.Start(stopCh)
 }
 
 func (ifm *Informers) waitForCacheSync(ctx context.Context) error {

--- a/pkg/workloadmanager/informers_test.go
+++ b/pkg/workloadmanager/informers_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	cubefake "github.com/volcano-sh/agentcube/client-go/clientset/versioned/fake"
+	cubeinformers "github.com/volcano-sh/agentcube/client-go/informers/externalversions"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
@@ -64,6 +66,10 @@ func newFactory() informers.SharedInformerFactory {
 	return informers.NewSharedInformerFactory(fake.NewSimpleClientset(), 0)
 }
 
+func newCubeFactory() cubeinformers.SharedInformerFactory {
+	return cubeinformers.NewSharedInformerFactory(cubefake.NewSimpleClientset(), 0)
+}
+
 func TestRunAndWaitForCacheSync_ContextCancellation(t *testing.T) {
 	never := func() cache.SharedIndexInformer { return &neverSyncedInformer{} }
 	always := func() cache.SharedIndexInformer { return &alwaysSyncedInformer{} }
@@ -101,6 +107,7 @@ func TestRunAndWaitForCacheSync_ContextCancellation(t *testing.T) {
 				CodeInterpreterInformer: tc.codeInterpreter,
 				PodInformer:             tc.pod,
 				informerFactory:         newFactory(),
+				cubeInformerFactory:     newCubeFactory(),
 			}
 			err := runCanceled(t, ifm)
 			if !errors.Is(err, context.Canceled) {
@@ -116,6 +123,7 @@ func TestRunAndWaitForCacheSync_AllSynced(t *testing.T) {
 		CodeInterpreterInformer: &alwaysSyncedInformer{},
 		PodInformer:             &alwaysSyncedInformer{},
 		informerFactory:         newFactory(),
+		cubeInformerFactory:     newCubeFactory(),
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/pkg/workloadmanager/k8s_client.go
+++ b/pkg/workloadmanager/k8s_client.go
@@ -23,6 +23,8 @@ import (
 
 	"k8s.io/klog/v2"
 
+	cubeversioned "github.com/volcano-sh/agentcube/client-go/clientset/versioned"
+	cubeinformers "github.com/volcano-sh/agentcube/client-go/informers/externalversions"
 	runtimev1alpha1 "github.com/volcano-sh/agentcube/pkg/apis/runtime/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -62,15 +64,17 @@ var (
 
 // K8sClient encapsulates the Kubernetes client
 type K8sClient struct {
-	clientset       *kubernetes.Clientset
-	dynamicClient   dynamic.Interface
-	scheme          *runtime.Scheme
-	baseConfig      *rest.Config // Store base config for creating user clients
-	clientCache     *ClientCache // LRU cache for user clients
-	dynamicInformer dynamicinformer.DynamicSharedInformerFactory
-	informerFactory informers.SharedInformerFactory
-	podInformer     cache.SharedIndexInformer
-	podLister       listersv1.PodLister
+	clientset           *kubernetes.Clientset
+	cubeClientset       cubeversioned.Interface
+	dynamicClient       dynamic.Interface
+	scheme              *runtime.Scheme
+	baseConfig          *rest.Config // Store base config for creating user clients
+	clientCache         *ClientCache // LRU cache for user clients
+	dynamicInformer     dynamicinformer.DynamicSharedInformerFactory
+	informerFactory     informers.SharedInformerFactory
+	cubeInformerFactory cubeinformers.SharedInformerFactory
+	podInformer         cache.SharedIndexInformer
+	podLister           listersv1.PodLister
 }
 
 type sandboxEntry struct {
@@ -109,6 +113,12 @@ func NewK8sClient() (*K8sClient, error) {
 		return nil, fmt.Errorf("failed to create clientset: %w", err)
 	}
 
+	// Create typed versioned clientset for agentcube
+	cubeClientset, err := cubeversioned.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create typed versioned clientset: %w", err)
+	}
+
 	// Create dynamic client (for CRD operations)
 	dynamicClient, err := dynamic.NewForConfig(config)
 	if err != nil {
@@ -124,20 +134,25 @@ func NewK8sClient() (*K8sClient, error) {
 	// Create informer factory for core resources (Pods, etc.)
 	informerFactory := informers.NewSharedInformerFactory(clientset, 0)
 
+	// Create shared informer factory for typed objects
+	cubeInformerFactory := cubeinformers.NewSharedInformerFactory(cubeClientset, 0)
+
 	// Get pod informer and lister
 	podInformer := informerFactory.Core().V1().Pods().Informer()
 	podLister := informerFactory.Core().V1().Pods().Lister()
 
 	return &K8sClient{
-		clientset:       clientset,
-		dynamicClient:   dynamicClient,
-		scheme:          scheme,
-		baseConfig:      config,
-		clientCache:     NewClientCache(100), // Cache up to 100 clients
-		dynamicInformer: dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0),
-		informerFactory: informerFactory,
-		podInformer:     podInformer,
-		podLister:       podLister,
+		clientset:           clientset,
+		cubeClientset:       cubeClientset,
+		dynamicClient:       dynamicClient,
+		scheme:              scheme,
+		baseConfig:          config,
+		clientCache:         NewClientCache(100), // Cache up to 100 clients
+		dynamicInformer:     dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0),
+		informerFactory:     informerFactory,
+		cubeInformerFactory: cubeInformerFactory,
+		podInformer:         podInformer,
+		podLister:           podLister,
 	}, nil
 }
 

--- a/pkg/workloadmanager/workload_builder.go
+++ b/pkg/workloadmanager/workload_builder.go
@@ -45,11 +45,6 @@ const (
 	IdentitySecretName = "picod-router-identity" //nolint:gosec // This is a name reference, not a credential
 	// PublicKeyDataKey is the key in the Secret data map for the public key
 	PublicKeyDataKey = "public.pem"
-
-	// CodeInterpreterKind is the Kind of the CodeInterpreter custom resource.
-	CodeInterpreterKind = "CodeInterpreter"
-	// CodeInterpreterAPIVersion is the API version (Group/Version) of the CodeInterpreter custom resource.
-	CodeInterpreterAPIVersion = "runtime.agentcube.volcano.sh/v1alpha1"
 )
 
 // IdentitySecretNamespace is the namespace where the identity secret is stored
@@ -358,8 +353,8 @@ func buildSandboxByCodeInterpreter(namespace string, codeInterpreterName string,
 			sessionID:           sessionID,
 			idleTimeout:         idleTimeout,
 			ownerReference: &metav1.OwnerReference{
-				APIVersion: CodeInterpreterAPIVersion,
-				Kind:       CodeInterpreterKind,
+				APIVersion: runtimev1alpha1.CodeInterpreterGroupVersionKind.GroupVersion().String(),
+				Kind:       runtimev1alpha1.CodeInterpreterKind,
 				Name:       codeInterpreterObj.Name,
 				UID:        codeInterpreterObj.UID,
 			},

--- a/pkg/workloadmanager/workload_builder.go
+++ b/pkg/workloadmanager/workload_builder.go
@@ -29,9 +29,8 @@ import (
 	runtimev1alpha1 "github.com/volcano-sh/agentcube/pkg/apis/runtime/v1alpha1"
 	"github.com/volcano-sh/agentcube/pkg/common/types"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
@@ -46,6 +45,11 @@ const (
 	IdentitySecretName = "picod-router-identity" //nolint:gosec // This is a name reference, not a credential
 	// PublicKeyDataKey is the key in the Secret data map for the public key
 	PublicKeyDataKey = "public.pem"
+
+	// CodeInterpreterKind is the Kind of the CodeInterpreter custom resource.
+	CodeInterpreterKind = "CodeInterpreter"
+	// CodeInterpreterAPIVersion is the API version (Group/Version) of the CodeInterpreter custom resource.
+	CodeInterpreterAPIVersion = "runtime.agentcube.volcano.sh/v1alpha1"
 )
 
 // IdentitySecretNamespace is the namespace where the identity secret is stored
@@ -242,22 +246,12 @@ func buildSandboxClaimObject(params *buildSandboxClaimParams) *extensionsv1alpha
 }
 
 func buildSandboxByAgentRuntime(namespace string, name string, ifm *Informers) (*sandboxv1alpha1.Sandbox, *sandboxEntry, error) {
-	agentRuntimeKey := namespace + "/" + name
-	// TODO(hzxuzhonghu): make use of typed informer, so we don't need to do type conversion below
-	runtimeObj, exists, _ := ifm.AgentRuntimeInformer.GetStore().GetByKey(agentRuntimeKey)
-	if !exists {
-		return nil, nil, api.ErrAgentRuntimeNotFound
-	}
-
-	unstructuredObj, ok := runtimeObj.(*unstructured.Unstructured)
-	if !ok {
-		klog.Errorf("agent runtime %s type asserting unstructured.Unstructured failed", agentRuntimeKey)
-		return nil, nil, fmt.Errorf("agent runtime type asserting failed")
-	}
-
-	var agentRuntimeObj runtimev1alpha1.AgentRuntime
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.Object, &agentRuntimeObj); err != nil {
-		return nil, nil, fmt.Errorf("failed to convert unstructured to AgentRuntime: %w", err)
+	agentRuntimeObj, err := ifm.AgentRuntimeLister.AgentRuntimes(namespace).Get(name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil, api.ErrAgentRuntimeNotFound
+		}
+		return nil, nil, fmt.Errorf("failed to get agent runtime %s/%s: %w", namespace, name, err)
 	}
 
 	sessionID := uuid.New().String()
@@ -316,35 +310,14 @@ func buildCodeInterpreterEnvVars(templateEnv []corev1.EnvVar, authMode runtimev1
 	return envVars
 }
 
-func getCodeInterpreterFromInformer(namespace, name string, informer *Informers) (*runtimev1alpha1.CodeInterpreter, error) {
-	key := namespace + "/" + name
-	// TODO(hzxuzhonghu): make use of typed informer, so we don't need to do type conversion below
-	runtimeObj, exists, err := informer.CodeInterpreterInformer.GetStore().GetByKey(key)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get code interpreter %s from informer cache: %w", key, err)
-	}
-	if !exists {
-		return nil, api.ErrCodeInterpreterNotFound
-	}
-	unstructuredObj, ok := runtimeObj.(*unstructured.Unstructured)
-	if !ok {
-		klog.Errorf("code interpreter %s type asserting unstructured.Unstructured failed", key)
-		return nil, fmt.Errorf("code interpreter type asserting failed")
-	}
-
-	var codeInterpreterObj runtimev1alpha1.CodeInterpreter
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.Object, &codeInterpreterObj); err != nil {
-		return nil, fmt.Errorf("failed to convert unstructured to CodeInterpreter: %w", err)
-	}
-	return &codeInterpreterObj, nil
-}
-
 func buildSandboxByCodeInterpreter(namespace string, codeInterpreterName string, informer *Informers) (*sandboxv1alpha1.Sandbox, *extensionsv1alpha1.SandboxClaim, *sandboxEntry, error) {
-	codeInterpreterObjPtr, err := getCodeInterpreterFromInformer(namespace, codeInterpreterName, informer)
+	codeInterpreterObj, err := informer.CodeInterpreterLister.CodeInterpreters(namespace).Get(codeInterpreterName)
 	if err != nil {
-		return nil, nil, nil, err
+		if apierrors.IsNotFound(err) {
+			return nil, nil, nil, api.ErrCodeInterpreterNotFound
+		}
+		return nil, nil, nil, fmt.Errorf("failed to get code interpreter %s/%s: %w", namespace, codeInterpreterName, err)
 	}
-	codeInterpreterObj := *codeInterpreterObjPtr
 
 	// Check public key available if authMode is picod
 	if codeInterpreterObj.Spec.AuthMode == runtimev1alpha1.AuthModePicoD && !IsPublicKeyCached() {
@@ -385,8 +358,8 @@ func buildSandboxByCodeInterpreter(namespace string, codeInterpreterName string,
 			sessionID:           sessionID,
 			idleTimeout:         idleTimeout,
 			ownerReference: &metav1.OwnerReference{
-				APIVersion: codeInterpreterObj.APIVersion,
-				Kind:       codeInterpreterObj.Kind,
+				APIVersion: CodeInterpreterAPIVersion,
+				Kind:       CodeInterpreterKind,
 				Name:       codeInterpreterObj.Name,
 				UID:        codeInterpreterObj.UID,
 			},

--- a/pkg/workloadmanager/workload_builder_test.go
+++ b/pkg/workloadmanager/workload_builder_test.go
@@ -22,14 +22,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	cubefake "github.com/volcano-sh/agentcube/client-go/clientset/versioned/fake"
+	cubeinformers "github.com/volcano-sh/agentcube/client-go/informers/externalversions"
 	"github.com/volcano-sh/agentcube/pkg/api"
 	runtimev1alpha1 "github.com/volcano-sh/agentcube/pkg/apis/runtime/v1alpha1"
 	"github.com/volcano-sh/agentcube/pkg/common/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 )
 
@@ -219,34 +219,12 @@ func TestBuildSandboxClaimObject(t *testing.T) {
 	})
 }
 
-// fakeInformer wraps a cache.Store to satisfy cache.SharedIndexInformer (partially) for testing.
-type fakeInformer struct {
-	cache.SharedIndexInformer
-	store cache.Store
-}
-
 const (
 	testNamespace               = "default"
 	testAgentRuntimeName        = "test-runtime"
 	testCodeInterpreterWarmPool = "ci-with-wp"
 	testCodeInterpreterUID      = "ci-uid-123"
 )
-
-func (f *fakeInformer) GetStore() cache.Store {
-	return f.store
-}
-
-func toUnstructured(t *testing.T, obj interface{}, kind string) *unstructured.Unstructured {
-	t.Helper()
-	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
-	if err != nil {
-		t.Fatalf("failed to convert to unstructured: %v", err)
-	}
-	u := &unstructured.Unstructured{Object: data}
-	u.SetAPIVersion("runtime.agentcube.volcano.sh/v1alpha1")
-	u.SetKind(kind)
-	return u
-}
 
 // setCachedPublicKeyForTest directly mutates the package-level cachedPublicKey
 // behind a mutex. This is fine for serial test execution, but if tests ever run
@@ -263,14 +241,6 @@ func setCachedPublicKeyForTest(t *testing.T, value string) {
 		cachedPublicKey = previous
 		publicKeyCacheMutex.Unlock()
 	})
-}
-
-func addRuntimeObjectToStore(t *testing.T, store cache.Store, obj interface{}, kind string) {
-	t.Helper()
-	u := toUnstructured(t, obj, kind)
-	if err := store.Add(u); err != nil {
-		t.Fatalf("failed to add to store: %v", err)
-	}
 }
 
 func assertSandboxMetadata(t *testing.T, sandboxLabels map[string]string, sandboxName, namespace, namePrefix, workloadName, sessionID string) {
@@ -380,10 +350,15 @@ func TestBuildCodeInterpreterEnvVars(t *testing.T) {
 }
 
 func TestBuildSandboxByAgentRuntime_NotFound(t *testing.T) {
-	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
-	informer := &fakeInformer{store: store}
+	fakeClient := cubefake.NewSimpleClientset()
+	factory := cubeinformers.NewSharedInformerFactory(fakeClient, 0)
+	agentRuntimeInformer := factory.Runtime().V1alpha1().AgentRuntimes()
+
 	ifm := &Informers{
-		AgentRuntimeInformer: informer,
+		AgentRuntimeLister:   agentRuntimeInformer.Lister(),
+		AgentRuntimeInformer: agentRuntimeInformer.Informer(),
+		informerFactory:      newFactory(),
+		cubeInformerFactory:  factory,
 	}
 
 	_, _, err := buildSandboxByAgentRuntime(testNamespace, "missing", ifm)
@@ -394,10 +369,6 @@ func TestBuildSandboxByAgentRuntime_NotFound(t *testing.T) {
 
 func TestBuildSandboxByAgentRuntime_Success(t *testing.T) {
 	agentRuntime := &runtimev1alpha1.AgentRuntime{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "runtime.agentcube.volcano.sh/v1alpha1",
-			Kind:       "AgentRuntime",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testAgentRuntimeName,
 			Namespace: testNamespace,
@@ -419,12 +390,17 @@ func TestBuildSandboxByAgentRuntime_Success(t *testing.T) {
 		},
 	}
 
-	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
-	addRuntimeObjectToStore(t, store, agentRuntime, "AgentRuntime")
+	fakeClient := cubefake.NewSimpleClientset(agentRuntime)
+	factory := cubeinformers.NewSharedInformerFactory(fakeClient, 0)
+	agentRuntimeInformer := factory.Runtime().V1alpha1().AgentRuntimes()
+	err := agentRuntimeInformer.Informer().GetStore().Add(agentRuntime)
+	assert.NoError(t, err)
 
-	informer := &fakeInformer{store: store}
 	ifm := &Informers{
-		AgentRuntimeInformer: informer,
+		AgentRuntimeLister:   agentRuntimeInformer.Lister(),
+		AgentRuntimeInformer: agentRuntimeInformer.Informer(),
+		informerFactory:      newFactory(),
+		cubeInformerFactory:  factory,
 	}
 
 	sandbox, entry, err := buildSandboxByAgentRuntime(testNamespace, testAgentRuntimeName, ifm)
@@ -459,11 +435,99 @@ func TestBuildSandboxByAgentRuntime_Success(t *testing.T) {
 	}
 }
 
-func TestBuildSandboxByCodeInterpreter_NotFound(t *testing.T) {
-	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
-	informer := &fakeInformer{store: store}
+func TestBuildSandboxByAgentRuntime_DefaultTimeouts(t *testing.T) {
+	ar := &runtimev1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      testAgentRuntimeName,
+		},
+		Spec: runtimev1alpha1.AgentRuntimeSpec{
+			Template: &runtimev1alpha1.SandboxTemplate{
+				Labels: map[string]string{"foo": "bar"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx"},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := cubefake.NewSimpleClientset(ar)
+	factory := cubeinformers.NewSharedInformerFactory(fakeClient, 0)
+	agentRuntimeInformer := factory.Runtime().V1alpha1().AgentRuntimes()
+	err := agentRuntimeInformer.Informer().GetStore().Add(ar)
+	assert.NoError(t, err)
+
 	ifm := &Informers{
-		CodeInterpreterInformer: informer,
+		AgentRuntimeLister:   agentRuntimeInformer.Lister(),
+		AgentRuntimeInformer: agentRuntimeInformer.Informer(),
+		informerFactory:      newFactory(),
+		cubeInformerFactory:  factory,
+	}
+
+	sandbox, entry, err := buildSandboxByAgentRuntime(testNamespace, testAgentRuntimeName, ifm)
+	assert.NoError(t, err)
+	assert.NotNil(t, sandbox)
+	assert.NotNil(t, entry)
+
+	assert.Equal(t, types.SandboxKind, entry.Kind)
+	assert.Equal(t, DefaultSandboxIdleTimeout, entry.IdleTimeout)
+	assert.Equal(t, sandbox.Name, sandbox.Spec.PodTemplate.ObjectMeta.Labels[SandboxNameLabelKey])
+}
+
+func TestBuildSandboxByAgentRuntime_CustomTimeouts(t *testing.T) {
+	ar := &runtimev1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      testAgentRuntimeName,
+		},
+		Spec: runtimev1alpha1.AgentRuntimeSpec{
+			SessionTimeout:     &metav1.Duration{Duration: 30 * time.Minute},
+			MaxSessionDuration: &metav1.Duration{Duration: 4 * time.Hour},
+			Template: &runtimev1alpha1.SandboxTemplate{
+				Spec: corev1.PodSpec{
+					RuntimeClassName: ptr.To(""),
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx"},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := cubefake.NewSimpleClientset(ar)
+	factory := cubeinformers.NewSharedInformerFactory(fakeClient, 0)
+	agentRuntimeInformer := factory.Runtime().V1alpha1().AgentRuntimes()
+	err := agentRuntimeInformer.Informer().GetStore().Add(ar)
+	assert.NoError(t, err)
+
+	ifm := &Informers{
+		AgentRuntimeLister:   agentRuntimeInformer.Lister(),
+		AgentRuntimeInformer: agentRuntimeInformer.Informer(),
+		informerFactory:      newFactory(),
+		cubeInformerFactory:  factory,
+	}
+
+	sandbox, entry, err := buildSandboxByAgentRuntime(testNamespace, testAgentRuntimeName, ifm)
+	assert.NoError(t, err)
+	assert.NotNil(t, sandbox)
+	assert.NotNil(t, entry)
+
+	assert.Equal(t, 30*time.Minute, entry.IdleTimeout)
+	assert.Nil(t, sandbox.Spec.PodTemplate.Spec.RuntimeClassName)
+}
+
+func TestBuildSandboxByCodeInterpreter_NotFound(t *testing.T) {
+	fakeClient := cubefake.NewSimpleClientset()
+	factory := cubeinformers.NewSharedInformerFactory(fakeClient, 0)
+	codeInterpreterInformer := factory.Runtime().V1alpha1().CodeInterpreters()
+
+	ifm := &Informers{
+		CodeInterpreterLister:   codeInterpreterInformer.Lister(),
+		CodeInterpreterInformer: codeInterpreterInformer.Informer(),
+		informerFactory:         newFactory(),
+		cubeInformerFactory:     factory,
 	}
 
 	_, _, _, err := buildSandboxByCodeInterpreter(testNamespace, "missing", ifm)
@@ -474,10 +538,6 @@ func TestBuildSandboxByCodeInterpreter_NotFound(t *testing.T) {
 
 func TestBuildSandboxByCodeInterpreter_PicodAuthFailsWithoutKey(t *testing.T) {
 	codeInterpreter := &runtimev1alpha1.CodeInterpreter{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "runtime.agentcube.volcano.sh/v1alpha1",
-			Kind:       "CodeInterpreter",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ci-picod-no-key",
 			Namespace: testNamespace,
@@ -492,15 +552,20 @@ func TestBuildSandboxByCodeInterpreter_PicodAuthFailsWithoutKey(t *testing.T) {
 
 	setCachedPublicKeyForTest(t, "") // Empty key to trigger error
 
-	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
-	addRuntimeObjectToStore(t, store, codeInterpreter, "CodeInterpreter")
+	fakeClient := cubefake.NewSimpleClientset(codeInterpreter)
+	factory := cubeinformers.NewSharedInformerFactory(fakeClient, 0)
+	codeInterpreterInformer := factory.Runtime().V1alpha1().CodeInterpreters()
+	err := codeInterpreterInformer.Informer().GetStore().Add(codeInterpreter)
+	assert.NoError(t, err)
 
-	informer := &fakeInformer{store: store}
 	ifm := &Informers{
-		CodeInterpreterInformer: informer,
+		CodeInterpreterLister:   codeInterpreterInformer.Lister(),
+		CodeInterpreterInformer: codeInterpreterInformer.Informer(),
+		informerFactory:         newFactory(),
+		cubeInformerFactory:     factory,
 	}
 
-	_, _, _, err := buildSandboxByCodeInterpreter(testNamespace, "ci-picod-no-key", ifm)
+	_, _, _, err = buildSandboxByCodeInterpreter(testNamespace, "ci-picod-no-key", ifm)
 	if !errors.Is(err, api.ErrPublicKeyMissing) {
 		t.Fatalf("expected error %v, got %v", api.ErrPublicKeyMissing, err)
 	}
@@ -508,10 +573,6 @@ func TestBuildSandboxByCodeInterpreter_PicodAuthFailsWithoutKey(t *testing.T) {
 
 func TestBuildSandboxByCodeInterpreter_SuccessNoWarmPool(t *testing.T) {
 	codeInterpreter := &runtimev1alpha1.CodeInterpreter{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "runtime.agentcube.volcano.sh/v1alpha1",
-			Kind:       "CodeInterpreter",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ci-no-wp",
 			Namespace: testNamespace,
@@ -526,12 +587,17 @@ func TestBuildSandboxByCodeInterpreter_SuccessNoWarmPool(t *testing.T) {
 		},
 	}
 
-	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
-	addRuntimeObjectToStore(t, store, codeInterpreter, "CodeInterpreter")
+	fakeClient := cubefake.NewSimpleClientset(codeInterpreter)
+	factory := cubeinformers.NewSharedInformerFactory(fakeClient, 0)
+	codeInterpreterInformer := factory.Runtime().V1alpha1().CodeInterpreters()
+	err := codeInterpreterInformer.Informer().GetStore().Add(codeInterpreter)
+	assert.NoError(t, err)
 
-	informer := &fakeInformer{store: store}
 	ifm := &Informers{
-		CodeInterpreterInformer: informer,
+		CodeInterpreterLister:   codeInterpreterInformer.Lister(),
+		CodeInterpreterInformer: codeInterpreterInformer.Informer(),
+		informerFactory:         newFactory(),
+		cubeInformerFactory:     factory,
 	}
 
 	sandbox, claim, entry, err := buildSandboxByCodeInterpreter(testNamespace, "ci-no-wp", ifm)
@@ -563,10 +629,6 @@ func TestBuildSandboxByCodeInterpreter_SuccessNoWarmPool(t *testing.T) {
 
 func TestBuildSandboxByCodeInterpreter_SuccessWithWarmPool(t *testing.T) {
 	codeInterpreter := &runtimev1alpha1.CodeInterpreter{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "runtime.agentcube.volcano.sh/v1alpha1",
-			Kind:       "CodeInterpreter",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testCodeInterpreterWarmPool,
 			Namespace: testNamespace,
@@ -583,12 +645,17 @@ func TestBuildSandboxByCodeInterpreter_SuccessWithWarmPool(t *testing.T) {
 		},
 	}
 
-	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
-	addRuntimeObjectToStore(t, store, codeInterpreter, "CodeInterpreter")
+	fakeClient := cubefake.NewSimpleClientset(codeInterpreter)
+	factory := cubeinformers.NewSharedInformerFactory(fakeClient, 0)
+	codeInterpreterInformer := factory.Runtime().V1alpha1().CodeInterpreters()
+	err := codeInterpreterInformer.Informer().GetStore().Add(codeInterpreter)
+	assert.NoError(t, err)
 
-	informer := &fakeInformer{store: store}
 	ifm := &Informers{
-		CodeInterpreterInformer: informer,
+		CodeInterpreterLister:   codeInterpreterInformer.Lister(),
+		CodeInterpreterInformer: codeInterpreterInformer.Informer(),
+		informerFactory:         newFactory(),
+		cubeInformerFactory:     factory,
 	}
 
 	sandbox, claim, entry, err := buildSandboxByCodeInterpreter(testNamespace, testCodeInterpreterWarmPool, ifm)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

Swaps unstructured dynamic informer lookups in the workload manager for typed client-go listers and informers from the generated `client-go/` package. Builder functions now call `Lister.Get(name)` and receive typed objects directly — no more `unstructured.Unstructured` conversion or map casting.
Also fixes a latent bug where `OwnerReference` on CodeInterpreter sandbox claims read `APIVersion`/`Kind` from `TypeMeta`, which is empty in typed informer caches.
Resolves `TODO(hzxuzhonghu)` in `workload_builder.go`.

**Which issue(s) this PR fixes**:
Fixes #356 

**Special notes for your reviewer**:

- `Informers` struct gains `AgentRuntimeLister` and `CodeInterpreterLister` fields
- `K8sClient` now initializes a typed `cubeversioned.Interface` clientset and `cubeinformers.SharedInformerFactory`
- Tests migrated from `fakeInformer`/`toUnstructured` to `cubefake.NewSimpleClientset` + `cubeinformers.NewSharedInformerFactory`
- Dockerfile adds `client-go/` to `COPY` for compilation

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
