### PR TITLE
Fix flaky router private key PEM test

### DIFF
--- a/pkg/router/jwt_test.go
+++ b/pkg/router/jwt_test.go
@@ -183,7 +183,7 @@ func TestGetPrivateKeyPEM(t *testing.T) {
 	privateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	assert.NoError(t, err)
 	assert.NotNil(t, privateKey)
-	assert.Equal(t, manager.privateKey, privateKey)
+	assert.True(t, manager.privateKey.Equal(privateKey))
 }
 
 func TestLoadPrivateKeyPEM(t *testing.T) {


### PR DESCRIPTION
Fixes a flaky router test seen in coverage:
https://github.com/volcano-sh/agentcube/actions/runs/26986069745/job/79635856049

The parsed RSA key is equivalent, but CRT internals can differ by leading zero bytes. Use rsa.PrivateKey.Equal for the assertion.