### PR TITLE
build: add developer convenience targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,14 @@ help: ## Display this help.
 gen-crd: controller-gen ## Generate CRD manifests
 	$(CONTROLLER_GEN) crd paths="./pkg/apis/runtime/v1alpha1/..." output:crd:artifacts:config=manifests/charts/base/crds
 
+.PHONY: install-crds
+install-crds: gen-crd ## Install CRDs into the current Kubernetes cluster
+	kubectl apply -f manifests/charts/base/crds
+
+.PHONY: uninstall-crds
+uninstall-crds: ## Remove CRDs from the current Kubernetes cluster
+	kubectl delete -f manifests/charts/base/crds --ignore-not-found
+
 .PHONY: generate
 generate: controller-gen gen-crd ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./pkg/apis/..."
@@ -124,10 +132,26 @@ test:
 	@echo "Running tests..."
 	go test -v ./...
 
+.PHONY: test-coverage
+test-coverage: ## Run pkg tests with race detector and coverage
+	go test -race -v -coverprofile=coverage.out -coverpkg=./pkg/... ./pkg/...
+	go tool cover -func=coverage.out
+
 # Format code
+.PHONY: fmt
 fmt: ## Format code
 	@echo "Formatting code..."
 	go fmt ./...
+
+.PHONY: fmt-check
+fmt-check: ## Check Go formatting
+	@echo "Checking Go formatting..."
+	@unformatted="$$(gofmt -l .)"; \
+	if [ -n "$$unformatted" ]; then \
+		echo "Go files need formatting:"; \
+		echo "$$unformatted"; \
+		exit 1; \
+	fi
 
 .PHONY: vet
 vet: ## Run go vet against code.
@@ -137,6 +161,14 @@ vet: ## Run go vet against code.
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint
 	$(GOLANGCI_LINT) run ./...
+
+.PHONY: verify
+verify: ## Run local verification before submitting PR
+	$(MAKE) gen-check
+	$(MAKE) fmt-check
+	$(MAKE) vet
+	$(MAKE) lint
+	$(MAKE) test
 
 # Generate copyright headers
 .PHONY: gen-copyright
@@ -254,6 +286,16 @@ docker-push-picod: docker-build-picod
 	@echo "Tagging and pushing Picod Docker image to $(IMAGE_REGISTRY)/$(PICOD_IMAGE)..."
 	docker tag $(PICOD_IMAGE) $(IMAGE_REGISTRY)/$(PICOD_IMAGE)
 	docker push $(IMAGE_REGISTRY)/$(PICOD_IMAGE)
+
+##@ Helm
+
+.PHONY: helm-template
+helm-template: ## Render Helm chart locally
+	helm template agentcube manifests/charts/base
+
+.PHONY: helm-lint
+helm-lint: ## Lint Helm chart
+	helm lint manifests/charts/base
 
 
 ##@ Dependencies

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ toolchain go1.24.9
 require (
 	github.com/agiledragon/gomonkey/v2 v2.13.0
 	github.com/alicebob/miniredis/v2 v2.35.0
-	github.com/gin-contrib/gzip v1.0.1
 	github.com/fsnotify/fsnotify v1.9.0
+	github.com/gin-contrib/gzip v1.0.1
 	github.com/gin-gonic/gin v1.10.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
## What this PR does
- Adds a local `verify` target for common pre-submit checks.
- Adds `test-coverage` to mirror the GitHub coverage command.
- Adds `install-crds` and `uninstall-crds` for local CRD validation workflows.
- Adds `helm-template` and `helm-lint` for chart validation.
- Includes the `go mod tidy` ordering change required by `make gen-check`.

## Verification
- `make help`
- `make -n install-crds uninstall-crds helm-template helm-lint verify test-coverage`
- `make helm-template`
- `make helm-lint`
- `GOCACHE=/private/tmp/agentcube-go-cache make gen-check`

Note: `make test-coverage` runs locally, but on macOS this repository currently fails in `pkg/picod/TestSanitizePath` because temporary paths normalize between `/var` and `/private/var`. The PR target matches the existing Ubuntu CI coverage command.