### PR TITLE
router: match longest entrypoint path prefix

### DIFF
--- a/pkg/router/handlers.go
+++ b/pkg/router/handlers.go
@@ -107,10 +107,16 @@ func (s *Server) handleGetSandboxError(c *gin.Context, err error) {
 
 func determineUpstreamURL(sandbox *types.SandboxInfo, path string) (*url.URL, error) {
 	// prefer matched entrypoint by path
+	var matched types.SandboxEntryPoint
+	found := false
 	for _, ep := range sandbox.EntryPoints {
-		if strings.HasPrefix(path, ep.Path) {
-			return buildURL(ep.Protocol, ep.Endpoint)
+		if entryPointPathMatches(path, ep.Path) && (!found || len(ep.Path) > len(matched.Path)) {
+			matched = ep
+			found = true
 		}
+	}
+	if found {
+		return buildURL(matched.Protocol, matched.Endpoint)
 	}
 	// fallback to first entrypoint
 	if len(sandbox.EntryPoints) == 0 {
@@ -118,6 +124,17 @@ func determineUpstreamURL(sandbox *types.SandboxInfo, path string) (*url.URL, er
 	}
 	ep := sandbox.EntryPoints[0]
 	return buildURL(ep.Protocol, ep.Endpoint)
+}
+
+func entryPointPathMatches(path, prefix string) bool {
+	if path != "" && !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	prefix = strings.TrimSuffix(prefix, "/")
+	if prefix == "" {
+		return true
+	}
+	return path == prefix || strings.HasPrefix(path, prefix+"/")
 }
 
 func buildURL(protocol, endpoint string) (*url.URL, error) {

--- a/pkg/router/handlers_test.go
+++ b/pkg/router/handlers_test.go
@@ -241,6 +241,63 @@ func TestHandleInvoke_NoEntryPoints(t *testing.T) {
 	}
 }
 
+func TestDetermineUpstreamURL_PathPrefix(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		entryPoints []types.SandboxEntryPoint
+		wantHost    string
+	}{
+		{
+			name: "longest prefix wins",
+			path: "/api/run",
+			entryPoints: []types.SandboxEntryPoint{
+				{Endpoint: "10.0.0.1:8080", Protocol: "HTTP", Path: "/"},
+				{Endpoint: "10.0.0.2:8080", Protocol: "HTTP", Path: "/api"},
+			},
+			wantHost: "10.0.0.2:8080",
+		},
+		{
+			name: "prefix must end on boundary",
+			path: "/api2/run",
+			entryPoints: []types.SandboxEntryPoint{
+				{Endpoint: "10.0.0.1:8080", Protocol: "HTTP", Path: "/api"},
+				{Endpoint: "10.0.0.2:8080", Protocol: "HTTP", Path: "/"},
+			},
+			wantHost: "10.0.0.2:8080",
+		},
+		{
+			name: "normalizes slashes",
+			path: "api/run",
+			entryPoints: []types.SandboxEntryPoint{
+				{Endpoint: "10.0.0.1:8080", Protocol: "HTTP", Path: "/api/"},
+			},
+			wantHost: "10.0.0.1:8080",
+		},
+		{
+			name: "falls back when no prefix matches",
+			path: "/api2/run",
+			entryPoints: []types.SandboxEntryPoint{
+				{Endpoint: "10.0.0.1:8080", Protocol: "HTTP", Path: "/api"},
+			},
+			wantHost: "10.0.0.1:8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sandbox := &types.SandboxInfo{EntryPoints: tt.entryPoints}
+			upstreamURL, err := determineUpstreamURL(sandbox, tt.path)
+			if err != nil {
+				t.Fatalf("determineUpstreamURL returned error: %v", err)
+			}
+			if upstreamURL.Host != tt.wantHost {
+				t.Fatalf("expected host %s, got %s", tt.wantHost, upstreamURL.Host)
+			}
+		})
+	}
+}
+
 func TestHandleAgentInvoke(t *testing.T) {
 	// Set required environment variables
 	setupEnv()


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Fixes router entrypoint selection when multiple `pathPrefix` values overlap.

The router was picking the first prefix match, so a runtime with `/` before `/api` could route `/api/foo` to the `/` entrypoint. It also treated `/api2` as matching `/api`.

This changes the selection to use the longest valid prefix match and keeps path boundaries sane.

**Which issue(s) this PR fixes**:
Fixes #388

**Special notes for your reviewer**:

Added focused tests for overlapping prefixes and `/api2` boundary behavior.

**Does this PR introduce a user-facing change?**:

```release-note
Router now selects the longest valid sandbox entrypoint path prefix when routing invocation requests.
