### PR TITLE
chore: update Go toolchain to 1.26.4

### DIFF
--- a/.github/workflows/build-push-release.yml
+++ b/.github/workflows/build-push-release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24.4"
+          go-version-file: go.mod
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/codegen-check.yml
+++ b/.github/workflows/codegen-check.yml
@@ -29,7 +29,7 @@ jobs:
         if: steps.changes.outputs.codegen == 'true'
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.4"
+          go-version-file: go.mod
 
       - name: Verify Generated Code
         if: steps.changes.outputs.codegen == 'true'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
 
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
         if: steps.changes.outputs.lint == 'true'
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version-file: go.mod
 
       - name: Run golangci-lint
         if: steps.changes.outputs.lint == 'true'

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -42,7 +42,7 @@ jobs:
         if: steps.changes.outputs.coverage == 'true'
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version-file: go.mod
 
       - name: Run tests with coverage
         if: steps.changes.outputs.coverage == 'true'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for workloadmanager
-FROM golang:1.24.9-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 # Build arguments for multi-architecture support
 ARG TARGETOS=linux

--- a/docker/Dockerfile.picod
+++ b/docker/Dockerfile.picod
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24.4 AS builder
+FROM golang:1.26.4 AS builder
 
 # Build arguments for multi-architecture support
 ARG TARGETOS=linux

--- a/docker/Dockerfile.router
+++ b/docker/Dockerfile.router
@@ -1,5 +1,5 @@
 # Multi-stage build for agentcube-router
-FROM golang:1.24.9-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 # Build arguments for multi-architecture support
 ARG TARGETOS=linux

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/volcano-sh/agentcube
 
-go 1.24.4
-
-toolchain go1.24.9
+go 1.26.4
 
 require (
 	github.com/agiledragon/gomonkey/v2 v2.13.0


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR updates AgentCube's Go toolchain baseline to Go 1.26.4.

It also reduces future Go version drift in GitHub Actions by making Go setup read from `go.mod` via `go-version-file: go.mod`, instead of hard-coding separate Go versions in individual workflows.

Docker builder images are updated to the same Go patch version because Dockerfiles cannot read `go.mod` automatically.

**Which issue(s) this PR fixes**:
Refs #386

**Special notes for your reviewer**:

Scope:
- Update `go.mod` to `go 1.26.4`.
- Remove the redundant old `toolchain go1.24.9` line after running `go mod tidy` with the target Go version.
- Update Go-related GitHub Actions to use `go-version-file: go.mod`.
- Update workload manager, router, and picod Docker builder images to Go 1.26.4.

Validation:
- Fork validation PR: https://github.com/ranxi2001/agentcube/pull/3
- Fork CI passed: `Check for spelling errors`, `Codegen Check`, `Python Lint`, two `build` checks, `coverage`, `e2e-test`, `golangci-lint`, and `python-sdk-tests`.

Local validation:
- `go list ./... | grep -v '^github.com/volcano-sh/agentcube/test/e2e$' | xargs go test -count=1`
- `go test -race -v -coverprofile=coverage.out -coverpkg=./pkg/... ./pkg/...`
- `make build-all`
- `make lint`
- `make gen-check`
- `docker build -f docker/Dockerfile -t agentcube-go1264-workloadmanager:test .`
- `docker build -f docker/Dockerfile.router -t agentcube-go1264-router:test .`
- `docker build -f docker/Dockerfile.picod -t agentcube-go1264-picod:test .`
- `git diff --check`

AI assistance:
- Used Codex to inspect the existing toolchain drift, prepare the focused branch, and run validation. I reviewed and validated the changes.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
