### PR TITLE
chore(deps): add dependabot configuration for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "00:00"
+      timezone: "UTC"
+    commit-message:
+      prefix: "chore(deps): "
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Fixes #392 
### Description
As requested, adding a standalone Dependabot configuration to automatically track and update pinned SHAs for our GitHub Actions workflows. This ensures our actions stay up-to-date and secure without manual overhead.

### Key Changes
* Created `.github/dependabot.yml` targeting the `github-actions` ecosystem.
* Set the update schedule to `weekly`.
* Configured semantic commit prefixes (`chore(deps): `).
