### PR TITLE
workloadmanager: honor default code interpreter auth mode

### DIFF
--- a/pkg/workloadmanager/workload_builder.go
+++ b/pkg/workloadmanager/workload_builder.go
@@ -309,11 +309,11 @@ func buildSandboxByAgentRuntime(namespace string, name string, ownerID string, i
 }
 
 // buildCodeInterpreterEnvVars copies the template env vars and injects the
-// public key when authMode is picod.
+// public key unless authMode is none.
 func buildCodeInterpreterEnvVars(templateEnv []corev1.EnvVar, authMode runtimev1alpha1.AuthModeType) []corev1.EnvVar {
 	envVars := make([]corev1.EnvVar, len(templateEnv))
 	copy(envVars, templateEnv)
-	if authMode == runtimev1alpha1.AuthModePicoD {
+	if authMode != runtimev1alpha1.AuthModeNone {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "PICOD_AUTH_PUBLIC_KEY",
 			Value: GetCachedPublicKey(),
@@ -331,8 +331,8 @@ func buildSandboxByCodeInterpreter(namespace string, codeInterpreterName string,
 		return nil, nil, nil, fmt.Errorf("failed to get code interpreter %s/%s: %w", namespace, codeInterpreterName, err)
 	}
 
-	// Check public key available if authMode is picod
-	if codeInterpreterObj.Spec.AuthMode == runtimev1alpha1.AuthModePicoD && !IsPublicKeyCached() {
+	// Check public key available unless authMode is none
+	if codeInterpreterObj.Spec.AuthMode != runtimev1alpha1.AuthModeNone && !IsPublicKeyCached() {
 		return nil, nil, nil, api.ErrPublicKeyMissing
 	}
 

--- a/pkg/workloadmanager/workload_builder_test.go
+++ b/pkg/workloadmanager/workload_builder_test.go
@@ -332,6 +332,14 @@ func TestBuildCodeInterpreterEnvVars(t *testing.T) {
 				{Name: "PICOD_AUTH_PUBLIC_KEY", Value: "test-public-key"},
 			},
 		},
+		{
+			name:        "empty authMode injects public key",
+			templateEnv: nil,
+			authMode:    "",
+			expected: []corev1.EnvVar{
+				{Name: "PICOD_AUTH_PUBLIC_KEY", Value: "test-public-key"},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -566,6 +574,40 @@ func TestBuildSandboxByCodeInterpreter_PicodAuthFailsWithoutKey(t *testing.T) {
 	}
 
 	_, _, _, err = buildSandboxByCodeInterpreter(testNamespace, "ci-picod-no-key", "", ifm)
+	if !errors.Is(err, api.ErrPublicKeyMissing) {
+		t.Fatalf("expected error %v, got %v", api.ErrPublicKeyMissing, err)
+	}
+}
+
+func TestBuildSandboxByCodeInterpreter_DefaultAuthFailsWithoutKey(t *testing.T) {
+	codeInterpreter := &runtimev1alpha1.CodeInterpreter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ci-default-auth-no-key",
+			Namespace: testNamespace,
+		},
+		Spec: runtimev1alpha1.CodeInterpreterSpec{
+			Template: &runtimev1alpha1.CodeInterpreterSandboxTemplate{
+				Image: "my-ci-image:latest",
+			},
+		},
+	}
+
+	setCachedPublicKeyForTest(t, "")
+
+	fakeClient := cubefake.NewSimpleClientset(codeInterpreter)
+	factory := cubeinformers.NewSharedInformerFactory(fakeClient, 0)
+	codeInterpreterInformer := factory.Runtime().V1alpha1().CodeInterpreters()
+	err := codeInterpreterInformer.Informer().GetStore().Add(codeInterpreter)
+	assert.NoError(t, err)
+
+	ifm := &Informers{
+		CodeInterpreterLister:   codeInterpreterInformer.Lister(),
+		CodeInterpreterInformer: codeInterpreterInformer.Informer(),
+		informerFactory:         newFactory(),
+		cubeInformerFactory:     factory,
+	}
+
+	_, _, _, err = buildSandboxByCodeInterpreter(testNamespace, "ci-default-auth-no-key", "", ifm)
 	if !errors.Is(err, api.ErrPublicKeyMissing) {
 		t.Fatalf("expected error %v, got %v", api.ErrPublicKeyMissing, err)
 	}


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Keeps CodeInterpreter auth handling consistent between warm-pool and non-warm sandbox creation.

The non-warm path only treated explicit `picod` as PicoD auth. This makes the default/empty value behave the same way, matching the warm-pool path: anything except `none` gets the PicoD public key handling.

**Which issue(s) this PR fixes**:
Fixes #397

**Special notes for your reviewer**:

Added coverage for empty/default authMode in env injection and missing-key handling.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
