### PR TITLE
Run Codegen Check for all pull requests

### DIFF
--- a/.github/workflows/codegen-check.yml
+++ b/.github/workflows/codegen-check.yml
@@ -14,24 +14,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Filter paths
-        id: changes
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            codegen:
-              - 'pkg/apis/**'
-              - 'hack/**'
-              - '.github/workflows/**'
-              - 'Makefile'
-
       - name: Set up Go
-        if: steps.changes.outputs.codegen == 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Verify Generated Code
-        if: steps.changes.outputs.codegen == 'true'
         run: |
           make gen-check


### PR DESCRIPTION
This PR removes path-based filtering from the Codegen Check workflow so that make gen-check runs for every pull request.

Motivation
Previously, Codegen Check could be skipped when changes did not match the configured path filters. As a result, changes to files such as go.mod and go.sum could bypass the workflow, allowing code generation inconsistencies to remain undetected until a later pull request.

Running the workflow unconditionally ensures that generated code and dependency-related inconsistencies are detected immediately, improving CI reliability.

Changes
Removed path-based filtering from the Codegen Check workflow.
Configured make gen-check to run for every pull request targeting main and release-*.

Fixes #401 

