### PR TITLE
ci: run validation workflows on branch push

### DIFF
--- a/.github/workflows/codegen-check.yml
+++ b/.github/workflows/codegen-check.yml
@@ -1,6 +1,11 @@
 name: Codegen Check
 
 on:
+  push:
+    # Exclude branches created by Dependabot to avoid triggering current workflow
+    # for PRs initiated by Dependabot.
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
     branches:
       - main

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,6 +1,11 @@
 name: Codespell
 
 on:
+  push:
+    # Exclude branches created by Dependabot to avoid triggering current workflow
+    # for PRs initiated by Dependabot.
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
     branches:
       - main

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -1,6 +1,11 @@
 name: Copyright Check
 
 on:
+  push:
+    # Exclude branches created by Dependabot to avoid triggering current workflow
+    # for PRs initiated by Dependabot.
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
     branches:
       - main

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,11 @@
 name: Agentcube E2E Tests
 
 on:
+  push:
+    # Exclude branches created by Dependabot to avoid triggering current workflow
+    # for PRs initiated by Dependabot.
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
     branches:
       - main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,11 @@
 name: Lint
 
 on:
+  push:
+    # Exclude branches created by Dependabot to avoid triggering current workflow
+    # for PRs initiated by Dependabot.
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
     branches:
       - main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,11 @@
 name: Agentcube CI Workflow
 
 on:
+  push:
+    # Exclude branches created by Dependabot to avoid triggering current workflow
+    # for PRs initiated by Dependabot.
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
     branches:
       - main

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,6 +1,11 @@
 name: Python Lint
 
 on:
+  push:
+    # Exclude branches created by Dependabot to avoid triggering current workflow
+    # for PRs initiated by Dependabot.
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
     branches:
       - main

--- a/.github/workflows/python-sdk-tests.yml
+++ b/.github/workflows/python-sdk-tests.yml
@@ -1,6 +1,11 @@
 name: Python SDK Tests
 
 on:
+  push:
+    # Exclude branches created by Dependabot to avoid triggering current workflow
+    # for PRs initiated by Dependabot.
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
   merge_group:
 

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,6 +1,11 @@
 name: Test Coverage
 
 on:
+  push:
+    # Exclude branches created by Dependabot to avoid triggering current workflow
+    # for PRs initiated by Dependabot.
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
   merge_group: # enable merge queue
   workflow_call:


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

This enables branch push validation for the existing CI workflows, so contributors can see the same validation workflows on fork branch pushes before opening or updating a PR.

The change adds a `push` trigger to the existing validation workflows and excludes Dependabot branches, following the same contributor pre-check pattern used by Karmada. It does not change the existing `pull_request`, `merge_group`, or `workflow_call` triggers, and it does not change any workflow job commands.

Changed validation workflows:

- `.github/workflows/main.yml`
- `.github/workflows/e2e.yml`
- `.github/workflows/codegen-check.yml`
- `.github/workflows/codespell.yml`
- `.github/workflows/copyright-check.yml`
- `.github/workflows/lint.yml`
- `.github/workflows/python-lint.yml`
- `.github/workflows/python-sdk-tests.yml`
- `.github/workflows/test-coverage.yml`

Not changed:

- Release and publish workflows, because branch validation should not publish images, charts, Python packages, or plugins.
- `.github/workflows/workflows-approve.yml`, because it is a `pull_request_target` approval gate for PR workflow approval.
- DCO, because it is not a GitHub Actions workflow file.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

Scope:

- CI trigger-only change.
- No runtime code changes.
- No workflow job command changes.
- No release or publish workflow changes.

Validation:

- `git diff --check`
- Parsed the 9 changed workflow YAML files with PyYAML.
- Pushed `ranxi2001/agentcube:ci/enable-push-validation` at `bb2a6e5`; all 9 existing validation workflows were triggered by `push` and passed.

AI assistance:

- I used Codex to compare the Karmada trigger pattern, prepare the workflow trigger edits, validate the fork push runs, and draft this PR text. I reviewed the final diff and validation result.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
