### PR TITLE
docs: add proposal index and template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,9 @@ Using AI tools to help write your PR is acceptable, but as the author, you are r
 
 * Maintainers are listed in the top-level [`OWNERS`](./OWNERS) file and `OWNERS` files in subdirectories
 * Subsystem owners review and approve changes in their areas
-* Major design decisions go through design docs in `docs/design/`
+* Major design decisions go through proposals in `docs/proposals/`. Existing
+  historical design documents remain under `docs/design/` and are indexed from
+  `docs/proposals/README.md`.
 
 ##  Tooling
 

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -1,0 +1,106 @@
+# AgentCube Proposals
+
+This directory is the entry point for AgentCube design proposals.
+
+Proposal documents are used for major design decisions, new APIs, new
+controllers, user-facing behavior changes, and cross-component architecture
+changes that need review before implementation.
+
+This README intentionally does **not** maintain a full index of proposals stored
+under `docs/proposals/`. New proposals should be discoverable from the directory
+tree itself, so adding a new proposal does not require an additional README
+update. The table below only indexes legacy design documents that still live
+under `docs/design/`.
+
+## Proposal Layout
+
+New proposals should use a dedicated directory directly under `docs/proposals/`.
+Do not require area-based subdirectories at this stage.
+
+```text
+docs/proposals/
+  README.md
+  proposal-template.md
+  <proposal-name>/
+    README.md
+    images/
+```
+
+Use short, descriptive, lowercase directory names. Prefer hyphen-separated
+names, for example:
+
+- `docs/proposals/sandbox-pool-control-plane/README.md`
+- `docs/proposals/e2b-compatible-sdk-facade/README.md`
+
+Keep the proposal content in `README.md`. Store supporting images, manifests,
+benchmarks, or examples in the same proposal directory so links remain stable as
+the proposal grows.
+
+## Proposal Template
+
+Start new proposals from [proposal-template.md](proposal-template.md).
+
+The template keeps proposal metadata and review expectations consistent:
+
+- title
+- authors
+- reviewers
+- approvers
+- creation date
+- last updated date
+- status
+- tracking issue (optional)
+- summary
+- motivation
+- goals and non-goals
+- proposal
+- user stories (optional)
+- design details
+- risks and mitigations
+- test plan
+- alternatives
+- implementation plan (optional)
+
+## Legacy Design Documents
+
+AgentCube already has several design documents under `docs/design/`. They are
+listed here to make the historical proposal surface easier to discover. These
+legacy documents are not moved by this index, so existing links remain stable.
+
+| Proposal | Existing location | Area |
+| --- | --- | --- |
+| AgentCube Design Proposal | [docs/design/agentcube-proposal.md](../design/agentcube-proposal.md) | Overall architecture |
+| Sandbox Template for Agent and CodeInterpreter Runtimes | [docs/design/runtime-template-proposal.md](../design/runtime-template-proposal.md) | Runtime template API |
+| PicoD Design Document | [docs/design/picod-proposal.md](../design/picod-proposal.md) | Sandbox daemon API |
+| PicoD Plain Authentication Design | [docs/design/PicoD-Plain-Authentication-Design.md](../design/PicoD-Plain-Authentication-Design.md) | PicoD authentication |
+| Router Submodule Design Document | [docs/design/router-proposal.md](../design/router-proposal.md) | Router |
+| AgentCube Authentication and Authorization Design | [docs/design/auth-proposal.md](../design/auth-proposal.md) | AuthN/AuthZ |
+| Keycloak Integration Design | [docs/design/keycloak-proposal.md](../design/keycloak-proposal.md) | External identity provider |
+| AgentCube CLI Design | [docs/design/AgentRun-CLI-Design.md](../design/AgentRun-CLI-Design.md) | CLI |
+
+## Status Values
+
+Use one of these values in proposal front matter:
+
+| Status | Meaning |
+| --- | --- |
+| `draft` | The proposal is being written or discussed. |
+| `provisional` | The direction is accepted enough to guide implementation, but details may still change. |
+| `implemented` | The proposal has been implemented. |
+| `deferred` | The proposal is valid but not currently planned. |
+| `rejected` | The proposal was considered and rejected. |
+| `obsolete` | The proposal has been superseded by a newer design. |
+
+## Review Guidance
+
+Before implementing a major design change:
+
+1. Add or update a proposal.
+2. Link the related issue or PR if one exists.
+3. Keep implementation-specific details separate from the design summary.
+4. Include a test plan that covers the main risk areas.
+5. Keep rejected alternatives in the proposal so future contributors can
+   understand the tradeoffs.
+
+Do not use proposals as release notes or user guides. Once a proposal is
+implemented, update user-facing documentation under the appropriate docs area.

--- a/docs/proposals/proposal-template.md
+++ b/docs/proposals/proposal-template.md
@@ -1,0 +1,99 @@
+---
+title: Your short, descriptive title
+authors:
+  - "@your-github-id"
+reviewers:
+  - TBD
+approvers:
+  - TBD
+creation-date: yyyy-mm-dd
+last-updated: yyyy-mm-dd
+status: draft
+tracking-issue: "" # Optional.
+---
+
+# Your short, descriptive title
+
+## Summary
+
+<!--
+Summarize the proposal in one or two paragraphs. Focus on the user-visible or
+architecture-level change, not the implementation history.
+-->
+
+## Motivation
+
+<!--
+Explain the problem, why it matters, and why it should be solved in AgentCube.
+Include the current limitations and the expected benefit.
+-->
+
+### Goals
+
+<!--
+List the specific outcomes this proposal is expected to achieve.
+-->
+
+- Goal 1
+- Goal 2
+
+### Non-Goals
+
+<!--
+List related topics that are intentionally out of scope.
+-->
+
+- Non-goal 1
+- Non-goal 2
+
+## Proposal
+
+<!--
+Describe the proposed design at a level that reviewers can evaluate before
+implementation. Include user workflows, control-plane behavior, APIs, resource
+ownership, and compatibility expectations when relevant.
+-->
+
+## User Stories (Optional)
+
+<!--
+Useful for user-facing APIs and lifecycle behavior.
+-->
+
+### Story 1
+
+### Story 2
+
+## Design Details
+
+<!--
+Add the detailed API shape, CRD fields, state machine, controller behavior,
+data flow, security model, upgrade behavior, and observability plan as needed.
+-->
+
+## Risks and Mitigations
+
+<!--
+Describe correctness, security, scalability, compatibility, and operational
+risks. Explain how they will be tested or mitigated.
+-->
+
+## Test Plan
+
+<!--
+List the validation strategy. Include unit, integration, e2e, migration, and
+failure-path coverage where appropriate.
+-->
+
+## Alternatives
+
+<!--
+Record other approaches that were considered and why they were not chosen.
+-->
+
+## Implementation Plan (Optional)
+
+<!--
+Use this section when the proposal is expected to be implemented in multiple
+pull requests or phases.
+-->


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This PR adds a dedicated `docs/proposals/` entry point for AgentCube design proposals.

AgentCube already has several design and proposal documents under `docs/design/`, but there is no proposal entry point or template that helps contributors discover the existing proposal surface or start a new proposal consistently.

This PR:

- adds `docs/proposals/README.md` with proposal layout guidance, status values, review guidance, and an index of existing legacy `docs/design/` documents;
- adds `docs/proposals/proposal-template.md`;
- updates `CONTRIBUTING.md` to point major design decisions to `docs/proposals/` while keeping existing historical design documents under `docs/design/`.

The proposal template follows the Karmada/Kubernetes enhancement proposal structure, but it is intentionally adapted for AgentCube's current stage. It does not introduce a proposal numbering process yet, and it adds lightweight metadata such as `status`, `last-updated`, and optional `tracking-issue`. `Test Plan` is kept as a top-level section because many AgentCube proposals involve CRDs, controllers, router behavior, runtime lifecycle, SDK behavior, cleanup semantics, and e2e validation.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

- Scope: docs-only proposal management.
- Existing `docs/design/` files are not moved, so current links remain stable.
- The README intentionally does not maintain a full index of future proposals under `docs/proposals/`; it only indexes legacy `docs/design/` documents.
- New proposals use a directory-based layout such as `docs/proposals/sandbox-pool-control-plane/README.md`, so images and supporting assets can be added later without changing the proposal path.
- Optional template fields and sections are explicitly marked: `tracking-issue`, `User Stories`, and `Implementation Plan`.
- Tests: `git diff --check upstream/main...HEAD`
- AI assistance: Used Codex to inspect existing docs structure, compare Karmada's proposal layout, and draft this PR. I reviewed and validated the changes.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```