### PR TITLE
ci: use valid chart version for latest releases

### DIFF
--- a/.github/workflows/build-push-release.yml
+++ b/.github/workflows/build-push-release.yml
@@ -38,9 +38,14 @@ jobs:
         run: |
           echo "REPOSITORY_OWNER_LOWER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
           if [[ "${{ github.ref_type }}" == "tag" ]]; then
-            echo "TAG=${{ github.ref_name }}" >> "$GITHUB_ENV"
+            RELEASE_TAG="${{ github.ref_name }}"
+            echo "TAG=${RELEASE_TAG}" >> "$GITHUB_ENV"
+            echo "CHART_VERSION=${RELEASE_TAG}" >> "$GITHUB_ENV"
+            echo "APP_VERSION=${RELEASE_TAG}" >> "$GITHUB_ENV"
           else
             echo "TAG=latest" >> "$GITHUB_ENV"
+            echo "CHART_VERSION=0.0.0" >> "$GITHUB_ENV"
+            echo "APP_VERSION=latest" >> "$GITHUB_ENV"
           fi
 
       - name: Login to GitHub Container Registry
@@ -67,15 +72,15 @@ jobs:
           CHART_PATH: manifests/charts/base
           IMAGE_REGISTRY: ghcr.io/${{ env.REPOSITORY_OWNER_LOWER }}
         run: |
-          yq e -i '.version = env(TAG) | .appVersion = env(TAG)' "${CHART_PATH}/Chart.yaml"
+          yq e -i '.version = env(CHART_VERSION) | .appVersion = env(APP_VERSION)' "${CHART_PATH}/Chart.yaml"
           yq e -i '
             .router.image.repository = env(IMAGE_REGISTRY) + "/agentcube-router" |
             .router.image.tag = env(TAG) |
             .workloadmanager.image.repository = env(IMAGE_REGISTRY) + "/workloadmanager" |
             .workloadmanager.image.tag = env(TAG)
           ' "${CHART_PATH}/values.yaml"
-          helm package "${CHART_PATH}" --version "${TAG}" --app-version "${TAG}"
+          helm package "${CHART_PATH}" --version "${CHART_VERSION}" --app-version "${APP_VERSION}"
 
       - name: Push Helm chart
         run: |
-          helm push "agentcube-${TAG}.tgz" "oci://ghcr.io/${REPOSITORY_OWNER_LOWER}/charts"
+          helm push "agentcube-${CHART_VERSION}.tgz" "oci://ghcr.io/${REPOSITORY_OWNER_LOWER}/charts"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

This PR fixes the release workflow failure on `main` pushes while keeping latest image publishing enabled.

The release workflow uses `TAG=latest` for `main` branch pushes. That value is valid for Docker image tags, but the workflow also reused it as the Helm chart `version`. Helm chart versions must be valid SemVer values, so `helm package --version latest` fails with `chart.metadata.version "latest" is invalid`.

This PR separates Docker image tags from Helm chart metadata:

- On `main` pushes, Docker images still use `TAG=latest`, while the Helm chart uses `CHART_VERSION=0.0.0` and `APP_VERSION=latest`.
- On release tag pushes, Docker images, Helm chart `version`, Helm chart `appVersion`, the chart package filename, and the Helm OCI tag continue to use the existing Git tag value such as `v1.2.3`.

#### Which issue(s) this PR fixes

Fixes #417

#### Special notes for your reviewer

This intentionally keeps latest image publishing on `main` pushes and only fixes the invalid Helm chart version used for latest chart publishing.

Validation data:

- `main` push metadata: `TAG=latest`, `CHART_VERSION=0.0.0`, `APP_VERSION=latest`
- Fork `main` push validation run: https://github.com/ranxi2001/agentcube/actions/runs/28633043101
- Fork validation result: latest images were published, `agentcube-0.0.0.tgz` was packaged successfully, and `ghcr.io/ranxi2001/charts/agentcube:0.0.0` was pushed successfully.

AI assistance was used to inspect the workflow behavior, validate the fork run result, and prepare this PR text. I reviewed and validated the final change.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., usage docs, etc.

None.

#### What test reports have been run

- `git diff upstream/main --check`
- `actionlint -ignore 'too old to run on GitHub Actions' .github/workflows/build-push-release.yml`
- `helm lint manifests/charts/base`
- Helm package simulation for `main` push: `agentcube-0.0.0.tgz`
- Helm package simulation for release tag `v1.2.3`: `agentcube-v1.2.3.tgz`
- Helm package simulation for prerelease tag `v1.2.3-alpha`: `agentcube-v1.2.3-alpha.tgz`
- Fork `main` push validation run: https://github.com/ranxi2001/agentcube/actions/runs/28633043101
