### PR TITLE
ci: build multi-arch images with native Go builder

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for workloadmanager
-FROM golang:1.26.4-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
 
 # Build arguments for multi-architecture support
 ARG TARGETOS=linux

--- a/docker/Dockerfile.picod
+++ b/docker/Dockerfile.picod
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.4 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
 
 # Build arguments for multi-architecture support
 ARG TARGETOS=linux

--- a/docker/Dockerfile.router
+++ b/docker/Dockerfile.router
@@ -1,5 +1,5 @@
 # Multi-stage build for agentcube-router
-FROM golang:1.26.4-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
 
 # Build arguments for multi-architecture support
 ARG TARGETOS=linux


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

This PR optimizes the multi-arch image build path by running the Go builder stages on `$BUILDPLATFORM` while keeping `TARGETOS` / `TARGETARCH` for cross-compilation.

On x64 GitHub-hosted runners, the previous Dockerfiles ran the `linux/arm64` Go builder stage under QEMU. In the release-image benchmark recorded in #419, the workloadmanager `linux/arm64` Go build was the dominant cost. This change keeps the produced images multi-arch, but avoids running the Go compiler through arm64 emulation.

Scope of this first PR:

- Change only the Go builder stage platform in `docker/Dockerfile`, `docker/Dockerfile.router`, and `docker/Dockerfile.picod`.
- Do not change release triggers, image tags, Helm chart metadata, matrix builds, or buildx cache behavior.
- Leave the Karmada-style prebuild pipeline, PicoD runtime-layer optimization, and matrix/cache improvements as follow-ups tracked by #419.

This PR does not conflict with #416 because #416 changes the release workflow metadata and Helm chart version handling, while this PR only changes Dockerfile builder stages. It is also separate from #264, which adjusts workloadmanager build entrypoints and Makefile flow.

**Which issue(s) this PR fixes**:
Fixes #419

**Special notes for your reviewer**:

- Scope: Dockerfile-only build performance optimization for multi-arch image builds.
- Changed files: `docker/Dockerfile`, `docker/Dockerfile.router`, `docker/Dockerfile.picod`.
- Validation:
  - `git diff --check upstream/main...HEAD`
  - `make build-all`
  - `docker buildx build --builder agentcube-day39 --platform linux/amd64,linux/arm64 -f docker/Dockerfile --target builder --progress=plain .`
  - `docker buildx build --builder agentcube-day39 --platform linux/amd64,linux/arm64 -f docker/Dockerfile.router --target builder --progress=plain .`
  - `docker buildx build --builder agentcube-day39 --platform linux/amd64,linux/arm64 -f docker/Dockerfile.picod --target builder --progress=plain .`
  - Fork push validation on `ranxi2001:ci/native-build-platform-images`: 9/9 workflows passed.
- AI assistance: Used Codex to inspect the build path, compare benchmark logs, and prepare this PR. I reviewed and validated the changes.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
