### PR TITLE
chore: enable Dependabot Docker base image updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,15 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "00:00"
+      timezone: "UTC"
+    commit-message:
+      prefix: "chore(deps): "
+    ignore:
+      - dependency-name: "golang"


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

This PR adds a Docker ecosystem entry to `.github/dependabot.yml` for the `/docker` directory.

AgentCube already uses Dependabot for GitHub Actions updates. The v0.2.0 planning issue also calls out that Alpine runtime base images in `docker/Dockerfile` and `docker/Dockerfile.router` can become outdated over time, which increases security maintenance burden.

With this configuration, Dependabot can scan Dockerfiles under `/docker` and propose PRs when runtime Docker base image tags have newer versions. The primary motivation is Alpine base image maintenance for workloadmanager and router, and the configured directory scope also covers PicoD's Ubuntu runtime image in the same directory.

The `golang` Docker image is intentionally ignored. The Go builder image should stay aligned with the project's Go toolchain baseline in `go.mod` and CI, so Go toolchain upgrades should remain focused PRs rather than Docker-only Dependabot bumps.

**Which issue(s) this PR fixes**:

Refs #386

**Special notes for your reviewer**:

This is a configuration-only change. Dependabot's Docker updater discovers Dockerfiles by filename pattern under the configured directory, so `/docker` covers `Dockerfile`, `Dockerfile.router`, and `Dockerfile.picod`.

The Docker updater ignores `golang` because Go builder image updates need to stay coordinated with `go.mod` and GitHub Actions Go setup. This keeps Go toolchain baseline upgrades separate from runtime base image maintenance.

AI assistance was used to prepare the change rationale and validation notes. I reviewed and validated the changes.

Validation:

- `git diff --check upstream/main...HEAD`
- Parsed `.github/dependabot.yml` with PyYAML and verified the Docker `/docker` update entry is present and `golang` is ignored
- Audited Docker base images under `/docker`
- Fork-only validation: after enabling Dependabot version updates on the fork and temporarily scheduling the Docker updater, Dependabot opened [`alpine:3.19 -> 3.24`](https://github.com/ranxi2001/agentcube/pull/17) and [`ubuntu:24.04 -> 26.04`](https://github.com/ranxi2001/agentcube/pull/18) update PRs for `/docker`

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
