### PR TITLE
ci: pin GitHub Actions Ubuntu runners

### DIFF
--- a/.github/workflows/build-push-release.yml
+++ b/.github/workflows/build-push-release.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/codegen-check.yml
+++ b/.github/workflows/codegen-check.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   codegen-check:
     name: Codegen Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   codespell:
     name: Check for spelling errors
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Filter paths

--- a/.github/workflows/dify-plugin-publish.yml
+++ b/.github/workflows/dify-plugin-publish.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/python-cli-publish.yml
+++ b/.github/workflows/python-cli-publish.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   publish-python-cli:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: pypi
     permissions:
       contents: read

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   python_lint:
     name: Python Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/python-sdk-publish.yml
+++ b/.github/workflows/python-sdk-publish.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   publish-python-sdk:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: pypi
     permissions:
       contents: read

--- a/.github/workflows/python-sdk-tests.yml
+++ b/.github/workflows/python-sdk-tests.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   python-sdk-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: sdk-python

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/workflows-approve.yml
+++ b/.github/workflows/workflows-approve.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   approve:
     name: Approve workflows based on contributor status
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
       pull-requests: read


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This pins GitHub Actions jobs that still use `ubuntu-latest` to `ubuntu-24.04`.

`ubuntu-latest` is a moving label and may point to a different Ubuntu image when GitHub migrates the hosted runner default. Pinning the runner image keeps CI behavior stable while preserving the current Ubuntu 24.04 environment used by `ubuntu-latest`.

**Which issue(s) this PR fixes**:
Refs #386

**Special notes for your reviewer**:

- Scope: only updates workflow runner labels from `ubuntu-latest` to `ubuntu-24.04`.
- Existing explicit labels are left unchanged, including `e2e.yml` on `ubuntu-22.04`.
- Tests:
  - `git diff --check HEAD~1..HEAD`
  - `rg -n 'runs-on:\s*ubuntu-latest' .github/workflows || true`
  - Python YAML parse for `.github/workflows/*.yml`
  - `go run github.com/rhysd/actionlint/cmd/actionlint@latest`
- AI assistance: Used Codex to inspect workflows, prepare the branch, and draft this PR. I reviewed and validated the changes.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```