### PR TITLE
chart: enable workloadmanager auth

### DIFF
--- a/manifests/charts/base/templates/rbac-router.yaml
+++ b/manifests/charts/base/templates/rbac-router.yaml
@@ -27,3 +27,30 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ .Values.router.serviceAccountName | default "agentcube-router" }}
+{{- if .Values.workloadmanager.auth.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.router.serviceAccountName | default "agentcube-router" }}-workloadmanager
+rules:
+  - apiGroups: ["agents.x-k8s.io"]
+    resources: ["sandboxes"]
+    verbs: ["create", "delete"]
+  - apiGroups: ["extensions.agents.x-k8s.io"]
+    resources: ["sandboxclaims"]
+    verbs: ["create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.router.serviceAccountName | default "agentcube-router" }}-workloadmanager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-{{ .Values.router.serviceAccountName | default "agentcube-router" }}-workloadmanager
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.router.serviceAccountName | default "agentcube-router" }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/manifests/charts/base/templates/workloadmanager.yaml
+++ b/manifests/charts/base/templates/workloadmanager.yaml
@@ -79,6 +79,9 @@ spec:
           args:
             - --port={{ .Values.workloadmanager.service.port }}
             - --runtime-class-name=
+            {{- if .Values.workloadmanager.auth.enabled }}
+            - --enable-auth
+            {{- end }}
             {{- if .Values.spire.enabled }}
             - --tls-cert={{ .Values.spire.spiffeHelper.certDir }}/{{ .Values.spire.spiffeHelper.certFileName }}
             - --tls-key={{ .Values.spire.spiffeHelper.certDir }}/{{ .Values.spire.spiffeHelper.keyFileName }}

--- a/manifests/charts/base/values.yaml
+++ b/manifests/charts/base/values.yaml
@@ -49,6 +49,8 @@ router:
 # AgentCube Workload Manager
 workloadmanager:
   replicas: 1
+  auth:
+    enabled: true
   image:
     repository: ghcr.io/volcano-sh/workloadmanager
     pullPolicy: IfNotPresent


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Enables WorkloadManager auth in the base chart. The chart already has Router call WorkloadManager with its service account token, but WorkloadManager was not started with `--enable-auth`.

Also grants Router the minimal sandbox create/delete RBAC needed once WorkloadManager starts using the caller token.

**Which issue(s) this PR fixes**:
Fixes #432

**Special notes for your reviewer**:

Helm is not installed in my local env, so I could not run `helm template` or `helm lint`. I did run `git diff --cached --check` before committing.

**Does this PR introduce a user-facing change?**:
```release-note
Base chart now enables WorkloadManager auth by default.
```
