### PR TITLE
picod: fix path test on macOS

### DIFF
--- a/pkg/picod/files_test.go
+++ b/pkg/picod/files_test.go
@@ -115,6 +115,11 @@ func TestSanitizePath(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "picod-test-*")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
+	// macOS exposes /var through a /private/var symlink. sanitizePath returns
+	// the canonical path, so use the canonical workspace for the containment
+	// assertion as well.
+	resolvedTmpDir, err := filepath.EvalSymlinks(tmpDir)
+	assert.NoError(t, err)
 
 	server := &Server{
 		workspaceDir: tmpDir,
@@ -204,7 +209,7 @@ func TestSanitizePath(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				// Verify the result is within the workspace
-				relPath, relErr := filepath.Rel(tmpDir, result)
+				relPath, relErr := filepath.Rel(resolvedTmpDir, result)
 				assert.NoError(t, relErr)
 				assert.NotRegexp(t, `^\.\.`, relPath, "Path should not escape workspace")
 			}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes `TestSanitizePath` on macOS, where `/var` resolves to `/private/var`. The test now canonicalizes the temporary workspace before checking that sanitized paths remain inside it.

This only corrects the test assertion; production path sanitization is unchanged.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

This change was prepared with AI assistance and manually verified.

Environment:

```console
macOS 26.5.2
Darwin 25.5.0 arm64
go1.26.4 darwin/arm64
```

Before this change:

```console
$ go test ./pkg/picod -run '^TestSanitizePath$' -count=1
--- FAIL: TestSanitizePath
    --- FAIL: TestSanitizePath/valid_relative_path
        Expect "../../../../../../private/var/.../test.txt" to NOT match "^\\.\\."
    --- FAIL: TestSanitizePath/valid_nested_path
    --- FAIL: TestSanitizePath/path_traversal_in_middle
    --- FAIL: TestSanitizePath/absolute_path
    --- FAIL: TestSanitizePath/empty_path
    --- FAIL: TestSanitizePath/current_directory
    --- FAIL: TestSanitizePath/deep_nested_path
FAIL
```

After this change:

```console
$ go test ./pkg/picod -run '^TestSanitizePath$' -count=10
ok github.com/volcano-sh/agentcube/pkg/picod 0.687s

$ go test ./pkg/picod -count=1
ok github.com/volcano-sh/agentcube/pkg/picod 4.872s
```

The production implementation is unchanged.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
