### PR TITLE
examples: fix agent runtime and pcap configurations

### DIFF
--- a/example/agent-runtime/agent-runtime.yaml
+++ b/example/agent-runtime/agent-runtime.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   targetPort:
-    - pathPrefix: "/"
+    - pathPrefix: "/echo"
       port: 8080
       protocol: "HTTP"
   podTemplate:
@@ -16,7 +16,71 @@ spec:
     spec:
       containers:
         - name: simple
-          image: busybox
-          command: ["/bin/sh", "-c", "sleep 36000"]
+          image: python:3.11-slim
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /echo
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /echo
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          command: ["python3", "-c"]
+          args:
+            - |
+              import http.server
+              import json
+              import signal
+              import sys
+
+              class EchoHandler(http.server.BaseHTTPRequestHandler):
+                  def send_json(self, status, body):
+                      payload = json.dumps(body).encode("utf-8")
+                      self.send_response(status)
+                      self.send_header("Content-Type", "application/json")
+                      self.send_header("Content-Length", str(len(payload)))
+                      self.end_headers()
+                      self.wfile.write(payload)
+
+                  def do_GET(self):
+                      if self.path == "/echo":
+                          self.send_json(200, {"status": "healthy"})
+                      else:
+                          self.send_json(404, {"error": "not found"})
+
+                  def do_POST(self):
+                      if self.path != "/echo":
+                          self.send_json(404, {"error": "not found"})
+                          return
+                      try:
+                          length = int(self.headers.get("Content-Length", "0"))
+                          request = json.loads(self.rfile.read(length) or b"{}")
+                      except (ValueError, UnicodeDecodeError):
+                          self.send_json(400, {"error": "invalid JSON request body"})
+                          return
+                      if not isinstance(request, dict):
+                          self.send_json(400, {"error": "request body must be a JSON object"})
+                          return
+                      input_text = request.get("input", "")
+                      self.send_json(200, {"output": f"echo: {input_text}"})
+
+                  def log_message(self, format, *args):
+                      pass
+
+              signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+              http.server.ThreadingHTTPServer(("0.0.0.0", 8080), EchoHandler).serve_forever()
   sessionTimeout: "15m"
   maxSessionDuration: "8h"

--- a/example/pcap-analyzer/deployment.yaml
+++ b/example/pcap-analyzer/deployment.yaml
@@ -47,7 +47,7 @@ spec:
             - name: WORKLOAD_MANAGER_URL
               value: "http://workloadmanager.agentcube.svc.cluster.local:8080"
             - name: ROUTER_URL
-              value: "http://router.agentcube.svc.cluster.local:8080"
+              value: "http://agentcube-router.agentcube.svc.cluster.local:8080"
             - name: CODEINTERPRETER_NAME
               value: "my-interpreter"  # Name of CodeInterpreter CRD
             - name: SANDBOX_NAMESPACE

--- a/sdk-python/examples/README.md
+++ b/sdk-python/examples/README.md
@@ -2,14 +2,15 @@
 
 This directory contains examples of how to use the AgentCube Python SDK.
 
+Run all commands in this guide from the repository root.
+
 ## Prerequisites
 
 1.  **Install the SDK**:
     
-    You can install the SDK from the parent directory:
+    Install the SDK from the repository checkout:
     ```bash
-    cd ..
-    pip install .
+    pip install ./sdk-python
     ```
 
 2.  **AgentCube Environment**:
@@ -37,5 +38,35 @@ This directory contains examples of how to use the AgentCube Python SDK.
 
 To run it:
 ```bash
-python basic_usage.py
+python sdk-python/examples/basic_usage.py
+```
+
+### Agent Runtime Usage
+
+`agent_runtime_usage.py` creates a session for the runnable echo AgentRuntime,
+invokes it, closes the local client, and then reuses the same remote session with
+a second client. Calling `AgentRuntimeClient.close()` releases local HTTP
+resources; the remote session remains available until its configured timeout.
+
+Deploy the example runtime and forward the Router before running the script:
+
+```bash
+kubectl apply -f example/agent-runtime/agent-runtime.yaml
+kubectl port-forward -n agentcube svc/agentcube-router 8081:8080
+```
+
+In another terminal:
+
+```bash
+export ROUTER_URL="http://localhost:8081"
+python sdk-python/examples/agent_runtime_usage.py
+```
+
+The runtime name and namespace default to `simple-agentruntime` and `default`.
+Override them with `AGENT_RUNTIME_NAME` and `SANDBOX_NAMESPACE` if needed.
+The created session is removed automatically after its configured timeout. Remove
+the runtime definition when you are done:
+
+```bash
+kubectl delete -f example/agent-runtime/agent-runtime.yaml
 ```

--- a/sdk-python/examples/agent_runtime_usage.py
+++ b/sdk-python/examples/agent_runtime_usage.py
@@ -12,36 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 from agentcube import AgentRuntimeClient
 
-# first time: it will create a new pod
+
+agent_name = os.getenv("AGENT_RUNTIME_NAME", "simple-agentruntime")
+namespace = os.getenv("SANDBOX_NAMESPACE", "default")
+
+# Create a new AgentRuntime session.
 agent_client_v1 = AgentRuntimeClient(
-    agent_name="my-agent",
-    router_url="http://localhost:8081",
-    namespace="default",
+    agent_name=agent_name,
+    namespace=namespace,
     verbose=True,
 )
+session_id = agent_client_v1.session_id
 print(agent_client_v1.session_id)
 
 result_v1 = agent_client_v1.invoke(
-    payload={"prompt": "Hello World!"},
+    payload={"input": "Hello World!"},
+    path="echo",
 )
 print(result_v1)
+agent_client_v1.close()  # The remote session remains reusable.
 
-# second time: it will try to reuse the pod created before
+# Reuse the same AgentRuntime session with a new client.
 agent_client_v2 = AgentRuntimeClient(
-    agent_name="my-agent",
-    router_url="http://localhost:8081",
-    namespace="default",
-    session_id=agent_client_v1.session_id,
+    agent_name=agent_name,
+    namespace=namespace,
+    session_id=session_id,
     verbose=True,
 )
-# same with the first time
 print(agent_client_v2.session_id)
 
 result_v2 = agent_client_v2.invoke(
-    payload={"prompt": "Hello World!"},
+    payload={"input": "Hello again!"},
+    path="echo",
 )
 print(result_v2)
-
-
+agent_client_v2.close()


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Make the AgentRuntime SDK example runnable with the repository manifest by adding a minimal echo HTTP server and health probes. Document the deployment and invocation flow, and fix the PCAP analyzer's Router service address.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

This change was prepared with AI assistance and manually verified.

Tested with:
- `python -m pytest sdk-python/tests/test_agent_runtime.py -q`
- `ruff check sdk-python/examples/agent_runtime_usage.py`
- Kubernetes API server dry-runs for both changed manifests
- Direct health, echo POST, and 404 checks against the embedded HTTP server

**Does this PR introduce a user-facing change?**:

```release-note
Fix the AgentRuntime and PCAP analyzer examples so they use runnable and correctly addressed services.
```
