### PR TITLE
fix: migrate Code Interpreter MCP to SDK v2

### DIFF
--- a/integrations/code-interpreter-mcp/agentcube_code_interpreter_mcp/__main__.py
+++ b/integrations/code-interpreter-mcp/agentcube_code_interpreter_mcp/__main__.py
@@ -33,8 +33,17 @@ def main() -> None:
         help="Listen port for streamable-http (default: MCP_PORT or 8000)",
     )
     args = parser.parse_args()
-    mcp = create_mcp_server(host=args.host, port=args.port)
-    mcp.run(transport=args.transport)
+    mcp = create_mcp_server()
+    if args.transport == "streamable-http":
+        mcp.run(
+            transport="streamable-http",
+            host=args.host,
+            port=args.port,
+            stateless_http=True,
+            json_response=True,
+        )
+    else:
+        mcp.run(transport="stdio")
 
 
 if __name__ == "__main__":

--- a/integrations/code-interpreter-mcp/agentcube_code_interpreter_mcp/server.py
+++ b/integrations/code-interpreter-mcp/agentcube_code_interpreter_mcp/server.py
@@ -3,7 +3,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 
-"""FastMCP server backed by AgentCube CodeInterpreterClient."""
+"""MCP server backed by AgentCube CodeInterpreterClient."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from typing import Annotated, Any, Optional
 
 import requests
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from pydantic import Field
 
 # In-process cache of live CodeInterpreterClient instances for session_reuse.
@@ -166,22 +166,16 @@ def _call_with_session_recovery(
 
 def create_mcp_server(
     *,
-    host: str = "127.0.0.1",
-    port: int = 8000,
     instructions: str | None = None,
-) -> FastMCP:
+) -> MCPServer:
     instr = instructions or (
         "AgentCube sandbox. Multi-step: session_reuse=true, pass session_id from prior JSON; "
         "each run_code is a new process—only files persist. stop_session when done. "
         "If a session_id is expired, the server recreates the sandbox once (workspace files are lost)."
     )
-    app = FastMCP(
+    app = MCPServer(
         "agentcube-code-interpreter",
         instructions=instr,
-        host=host,
-        port=port,
-        stateless_http=True,
-        json_response=True,
     )
     CodeInterpreterClient = _import_client()
 

--- a/integrations/code-interpreter-mcp/pyproject.toml
+++ b/integrations/code-interpreter-mcp/pyproject.toml
@@ -15,8 +15,8 @@ readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
-    "mcp>=1.8.0",
-    "pydantic>=2.0.0",
+    "mcp>=2,<3",
+    "pydantic>=2.12.0",
     "requests>=2.28.0",
     "uvicorn>=0.30.0",
 ]

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -84,7 +84,7 @@ E2E_SKIP_SETUP=true ./test/e2e/run_e2e.sh
 |------|-------------|
 | `test_mcp_protocol_initialize_ping_list_tools` | MCP `initialize`, notification path, `ping`, `tools/list`; asserts tools `run_code`, `execute_command`, `write_file`, `list_files`, `stop_session` |
 | `test_mcp_execute_command` | `execute_command`: `echo` output |
-| `test_mcp_stateless_execution_nameerror` | Two `run_code` on same session (SDK case2); second expects `isError` + NameError-like text |
+| `test_mcp_stateless_execution_nameerror` | Two `run_code` on same session (SDK case2); second expects `is_error` + NameError-like text |
 | `test_mcp_write_list_run_code_file_workflow` | `write_file` → `list_files` → `run_code` read file; `session_reuse` + `stop_session` (light SDK case3 + reuse) |
 
 Minimal **`run_code`** smoke (SDK case1 style) lives in **`test_mcp_code_interpreter_stdio.py`** and **`test_mcp_code_interpreter_k8s.py`** to avoid duplicating the same check three times.

--- a/test/e2e/test_mcp_code_interpreter.py
+++ b/test/e2e/test_mcp_code_interpreter.py
@@ -78,16 +78,18 @@ async def _mcp_client_session(
     request_timeout: float = 120.0,
 ) -> AsyncIterator[tuple[Any, Any]]:
     """MCP Streamable HTTP client session; closes cleanly on exit."""
-    import httpx
+    import httpx2
     from mcp import ClientSession
     from mcp.client.streamable_http import streamable_http_client
 
     url = f"http://{host}:{port}/mcp"
-    async with httpx.AsyncClient(timeout=request_timeout) as http_client:
+    async with httpx2.AsyncClient(
+        timeout=request_timeout,
+        follow_redirects=True,
+    ) as http_client:
         async with streamable_http_client(url, http_client=http_client) as (
             read_stream,
             write_stream,
-            _,
         ):
             async with ClientSession(read_stream, write_stream) as session:
                 init_result = await session.initialize()
@@ -175,15 +177,18 @@ class TestMCPCodeInterpreterE2E(unittest.TestCase):
             print("[MCP E2E] MCP server subprocess stopped\n")
 
     def test_mcp_protocol_initialize_ping_list_tools(self):
-        """MCP: initialize, ping, tools/list; assert full tool surface and inputSchema."""
+        """MCP: initialize, ping, tools/list; assert full tool surface and input_schema."""
 
         async def body():
             async with _mcp_client_session(self.host, self.port) as (session, init_result):
-                self.assertIsNotNone(init_result.protocolVersion, "initialize must return protocolVersion")
-                print(f"[MCP E2E] initialize protocolVersion={init_result.protocolVersion!r}")
-                si = init_result.serverInfo
+                self.assertIsNotNone(
+                    init_result.protocol_version,
+                    "initialize must return protocol_version",
+                )
+                print(f"[MCP E2E] initialize protocol_version={init_result.protocol_version!r}")
+                si = init_result.server_info
                 if si is not None:
-                    print(f"[MCP E2E] serverInfo.name={getattr(si, 'name', None)!r}")
+                    print(f"[MCP E2E] server_info.name={getattr(si, 'name', None)!r}")
 
                 ping = await session.send_ping()
                 self.assertIsNotNone(ping)
@@ -201,15 +206,15 @@ class TestMCPCodeInterpreterE2E(unittest.TestCase):
                         (t.description or "").strip(),
                         f"tool {t.name!r} must have a non-empty description",
                     )
-                    schema = getattr(t, "inputSchema", None) or {}
+                    schema = t.input_schema or {}
                     self.assertEqual(
                         schema.get("type"),
                         "object",
-                        f"tool {t.name!r} inputSchema.type must be object",
+                        f"tool {t.name!r} input_schema.type must be object",
                     )
                     props = schema.get("properties")
                     if not isinstance(props, dict):
-                        self.fail(f"tool {t.name!r} inputSchema.properties must be dict, got {props!r}")
+                        self.fail(f"tool {t.name!r} input_schema.properties must be dict, got {props!r}")
                     print(f"[MCP E2E] tool {t.name!r} input properties: {list(props.keys())}")
 
         _run_async(body())
@@ -226,7 +231,7 @@ class TestMCPCodeInterpreterE2E(unittest.TestCase):
                         "session_reuse": False,
                     },
                 )
-                self.assertFalse(res.isError, _tool_result_text(res))
+                self.assertFalse(res.is_error, _tool_result_text(res))
                 data = json.loads(_tool_result_text(res))
                 self.assertIn("mcp-cmd-ok", data.get("output", ""), data)
                 print(f"[MCP E2E] execute_command ok: {data!r}")
@@ -234,7 +239,7 @@ class TestMCPCodeInterpreterE2E(unittest.TestCase):
         _run_async(body())
 
     def test_mcp_stateless_execution_nameerror(self):
-        """SDK case2 equivalent: two run_code calls on same session; second fails (isError)."""
+        """SDK case2 equivalent: two run_code calls on same session; second fails (is_error)."""
 
         async def body():
             async with _mcp_client_session(self.host, self.port) as (session, _):
@@ -246,7 +251,7 @@ class TestMCPCodeInterpreterE2E(unittest.TestCase):
                         "session_reuse": True,
                     },
                 )
-                self.assertFalse(r1.isError, _tool_result_text(r1))
+                self.assertFalse(r1.is_error, _tool_result_text(r1))
                 sid = json.loads(_tool_result_text(r1))["session_id"]
                 print(f"[MCP E2E] stateless step1 session_id={sid!r}")
 
@@ -259,7 +264,7 @@ class TestMCPCodeInterpreterE2E(unittest.TestCase):
                         "session_reuse": True,
                     },
                 )
-                self.assertTrue(r2.isError, "stateless print(x) must surface as MCP tool error")
+                self.assertTrue(r2.is_error, "stateless print(x) must surface as MCP tool error")
                 err_text = _tool_result_text(r2)
                 self.assertTrue(
                     "NameError" in err_text or "name 'x' is not defined" in err_text or "not defined" in err_text,
@@ -268,7 +273,7 @@ class TestMCPCodeInterpreterE2E(unittest.TestCase):
                 print(f"[MCP E2E] stateless step2 error as expected: {err_text[:200]!r}...")
 
                 r3 = await session.call_tool("stop_session", {"session_id": sid})
-                self.assertFalse(r3.isError, _tool_result_text(r3))
+                self.assertFalse(r3.is_error, _tool_result_text(r3))
 
         _run_async(body())
 
@@ -286,14 +291,14 @@ class TestMCPCodeInterpreterE2E(unittest.TestCase):
                         "session_reuse": True,
                     },
                 )
-                self.assertFalse(w.isError, _tool_result_text(w))
+                self.assertFalse(w.is_error, _tool_result_text(w))
                 sid = json.loads(_tool_result_text(w))["session_id"]
 
                 lst = await session.call_tool(
                     "list_files",
                     {"path": ".", "session_id": sid, "session_reuse": True},
                 )
-                self.assertFalse(lst.isError, _tool_result_text(lst))
+                self.assertFalse(lst.is_error, _tool_result_text(lst))
                 payload = json.loads(_tool_result_text(lst))
                 files = payload.get("entries") or []
                 names = []
@@ -315,13 +320,13 @@ class TestMCPCodeInterpreterE2E(unittest.TestCase):
                         "session_reuse": True,
                     },
                 )
-                self.assertFalse(r.isError, _tool_result_text(r))
+                self.assertFalse(r.is_error, _tool_result_text(r))
                 out = json.loads(_tool_result_text(r)).get("output", "")
                 self.assertIn(marker, out, out)
                 print(f"[MCP E2E] read marker via run_code ok: {out!r}")
 
                 st = await session.call_tool("stop_session", {"session_id": sid})
-                self.assertFalse(st.isError, _tool_result_text(st))
+                self.assertFalse(st.is_error, _tool_result_text(st))
                 d_stop = json.loads(_tool_result_text(st))
                 self.assertEqual(d_stop.get("status"), "stopped")
 
@@ -353,7 +358,7 @@ class TestMCPCodeInterpreterE2E(unittest.TestCase):
                             "session_reuse": True,
                         },
                     )
-                    self.assertFalse(u.isError, _tool_result_text(u))
+                    self.assertFalse(u.is_error, _tool_result_text(u))
                     sid = json.loads(_tool_result_text(u))["session_id"]
 
                     d = await session.call_tool(
@@ -365,7 +370,7 @@ class TestMCPCodeInterpreterE2E(unittest.TestCase):
                             "session_reuse": True,
                         },
                     )
-                    self.assertFalse(d.isError, _tool_result_text(d))
+                    self.assertFalse(d.is_error, _tool_result_text(d))
 
                     with open(out_path, "rb") as f:
                         self.assertEqual(f.read(), payload_bytes)
@@ -383,7 +388,7 @@ class TestMCPCodeInterpreterE2E(unittest.TestCase):
                             pass
                     if sid:
                         st = await session.call_tool("stop_session", {"session_id": sid})
-                        self.assertFalse(st.isError, _tool_result_text(st))
+                        self.assertFalse(st.is_error, _tool_result_text(st))
 
         _run_async(body())
 

--- a/test/e2e/test_mcp_code_interpreter_k8s.py
+++ b/test/e2e/test_mcp_code_interpreter_k8s.py
@@ -56,15 +56,17 @@ class TestMCPCodeInterpreterK8sDeploymentE2E(unittest.TestCase):
             raise unittest.SkipTest("MCP_K8S_MCP_URL not set (in-cluster MCP E2E not started)")
 
         async def body():
-            import httpx
+            import httpx2
             from mcp import ClientSession
             from mcp.client.streamable_http import streamable_http_client
 
-            async with httpx.AsyncClient(timeout=120.0) as http_client:
+            async with httpx2.AsyncClient(
+                timeout=120.0,
+                follow_redirects=True,
+            ) as http_client:
                 async with streamable_http_client(url, http_client=http_client) as (
                     read_stream,
                     write_stream,
-                    _,
                 ):
                     async with ClientSession(read_stream, write_stream) as session:
                         await session.initialize()
@@ -83,7 +85,7 @@ class TestMCPCodeInterpreterK8sDeploymentE2E(unittest.TestCase):
                                 "session_reuse": False,
                             },
                         )
-                        self.assertFalse(res.isError, _tool_result_text(res))
+                        self.assertFalse(res.is_error, _tool_result_text(res))
                         data = json.loads(_tool_result_text(res))
                         self.assertIn("5", (data.get("output") or ""), data)
                         print(f"[MCP K8s E2E] run_code via in-cluster pod ok output={data.get('output')!r}")

--- a/test/e2e/test_mcp_code_interpreter_stdio.py
+++ b/test/e2e/test_mcp_code_interpreter_stdio.py
@@ -80,8 +80,8 @@ class TestMCPCodeInterpreterStdioE2E(unittest.TestCase):
             async with stdio_client(params) as (read_stream, write_stream):
                 async with ClientSession(read_stream, write_stream) as session:
                     init = await session.initialize()
-                    self.assertIsNotNone(init.protocolVersion)
-                    print(f"[MCP stdio E2E] initialize ok protocolVersion={init.protocolVersion!r}")
+                    self.assertIsNotNone(init.protocol_version)
+                    print(f"[MCP stdio E2E] initialize ok protocol_version={init.protocol_version!r}")
 
                     tools = await session.list_tools()
                     names = {t.name for t in tools.tools}
@@ -97,7 +97,7 @@ class TestMCPCodeInterpreterStdioE2E(unittest.TestCase):
                             "session_reuse": False,
                         },
                     )
-                    self.assertFalse(res.isError, _tool_result_text(res))
+                    self.assertFalse(res.is_error, _tool_result_text(res))
                     data = json.loads(_tool_result_text(res))
                     self.assertIn("4", (data.get("output") or ""), data)
                     print(f"[MCP stdio E2E] run_code ok output={data.get('output')!r}")


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fresh installs resolve `mcp==2.0.0`, but the Code Interpreter MCP integration still uses the v1 SDK API and fails before the server can bind.

This migrates the integration within the official MCP Python SDK: it requires `mcp>=2,<3`, replaces `FastMCP` with `MCPServer`, moves Streamable HTTP settings to `run()`, and updates the E2E clients for `httpx2`, the two-value transport tuple, and snake_case protocol model fields.

**Which issue(s) this PR fixes**:
Fixes #447

**Special notes for your reviewer**:

- Compatibility: stdio and Streamable HTTP keep the existing CLI/environment behavior and tool surface.
- Validation: clean MCP 2.0 install, package build and dependency check, `ruff check .`, non-E2E Go tests, local HTTP/stdio protocol smokes, Docker HTTP protocol smoke, and fork push E2E validation.
- Codex assisted with migration analysis and drafting; I reviewed the diff and ran the validations above. Full local Kubernetes E2E was not run because this host has no Kind or kubeconfig; the fork push workflows provide that coverage.

**Does this PR introduce a user-facing change?**:

```release-note
The Code Interpreter MCP integration now supports MCP Python SDK v2.
```
