### PR TITLE
Bump Golang to v1.26.5

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for workloadmanager
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS builder
 
 # Build arguments for multi-architecture support
 ARG TARGETOS=linux

--- a/docker/Dockerfile.picod
+++ b/docker/Dockerfile.picod
@@ -1,5 +1,5 @@
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5 AS builder
 
 # Build arguments for multi-architecture support
 ARG TARGETOS=linux

--- a/docker/Dockerfile.router
+++ b/docker/Dockerfile.router
@@ -1,5 +1,5 @@
 # Multi-stage build for agentcube-router
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS builder
 
 # Build arguments for multi-architecture support
 ARG TARGETOS=linux

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/volcano-sh/agentcube
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/agiledragon/gomonkey/v2 v2.13.0


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Upgrades the project's Go version from 1.26.4 to 1.26.5.

This change updates the Go version declared in `go.mod` and synchronizes the Go builder images used by all Dockerfiles. GitHub Actions workflows read the version directly from `go.mod`, so no additional CI changes are required.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

The full test suite could not be completed locally because dependencies could not be downloaded from `proxy.golang.org`. The installed Go toolchain is Go 1.26.5, and all Go version references have been updated consistently.

**Does this PR introduce a user-facing change?**:

```release-note
NONE