### PR TITLE
docs: align agent-sandbox version with go.mod

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,7 +28,7 @@ AgentCube relies on the [kubernetes-sigs/agent-sandbox](https://github.com/kuber
 
 ```bash
 # Install agent-sandbox CRDs and controller
-AGENT_SANDBOX_VERSION=v0.1.1
+AGENT_SANDBOX_VERSION=v0.4.6
 kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${AGENT_SANDBOX_VERSION}/manifest.yaml
 kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${AGENT_SANDBOX_VERSION}/extensions.yaml
 ```
@@ -241,7 +241,7 @@ To remove AgentCube from your cluster:
 ```bash
 helm uninstall agentcube -n agentcube
 kubectl delete namespace agentcube
-AGENT_SANDBOX_VERSION=v0.1.1
+AGENT_SANDBOX_VERSION=v0.4.6
 kubectl delete -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${AGENT_SANDBOX_VERSION}/extensions.yaml
 kubectl delete -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${AGENT_SANDBOX_VERSION}/manifest.yaml
 ```


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Updates the agent-sandbox version in `docs/getting-started.md` from v0.1.1 to v0.4.6 for both installation and cleanup.

AgentCube currently depends on agent-sandbox v0.4.6, while the getting-started guide still installed v0.1.1. This version mismatch could cause sandbox creation to time out, especially when using the warm pool example, even though the sandbox Pods were running.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

The version now matches the `sigs.k8s.io/agent-sandbox v0.4.6` dependency declared in `go.mod`.

**Does this PR introduce a user-facing change?**:

Yes.

```release-note
Updated the getting-started guide to install agent-sandbox v0.4.6, matching AgentCube's dependency and preventing sandbox creation timeouts caused by incompatible versions.