### PR TITLE
chore: update Go to 1.26.6

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for workloadmanager
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine AS builder
 
 # Build arguments for multi-architecture support
 ARG TARGETOS=linux

--- a/docker/Dockerfile.picod
+++ b/docker/Dockerfile.picod
@@ -1,5 +1,5 @@
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.26.5 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6 AS builder
 
 # Build arguments for multi-architecture support
 ARG TARGETOS=linux

--- a/docker/Dockerfile.router
+++ b/docker/Dockerfile.router
@@ -1,5 +1,5 @@
 # Multi-stage build for agentcube-router
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine AS builder
 
 # Build arguments for multi-architecture support
 ARG TARGETOS=linux

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/volcano-sh/agentcube
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/agiledragon/gomonkey/v2 v2.13.0


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates the Go version from 1.26.5 to 1.26.6 in `go.mod` and all Docker build images to keep the project’s Go toolchain consistent.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

Please verify that the Go 1.26.6 toolchain and corresponding Docker images are available in the build environment.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
