### PR TITLE
build: bump Go to v1.26.7

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for workloadmanager
-FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.7-alpine AS builder
 
 # Build arguments for multi-architecture support
 ARG TARGETOS=linux

--- a/docker/Dockerfile.picod
+++ b/docker/Dockerfile.picod
@@ -1,5 +1,5 @@
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.26.6 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.7 AS builder
 
 # Build arguments for multi-architecture support
 ARG TARGETOS=linux

--- a/docker/Dockerfile.router
+++ b/docker/Dockerfile.router
@@ -1,5 +1,5 @@
 # Multi-stage build for agentcube-router
-FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.7-alpine AS builder
 
 # Build arguments for multi-architecture support
 ARG TARGETOS=linux

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/volcano-sh/agentcube
 
-go 1.26.6
+go 1.26.7
 
 require (
 	github.com/agiledragon/gomonkey/v2 v2.13.0


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates the Go version from 1.26.6 to 1.26.7 in `go.mod` and all Docker build images to keep the project toolchain consistent and up to date.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

The Go version has been updated consistently across `go.mod` and the three Dockerfiles.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
